### PR TITLE
Changes necessary for updating warehouse

### DIFF
--- a/app/controllers/v1/samples_controller.rb
+++ b/app/controllers/v1/samples_controller.rb
@@ -18,7 +18,7 @@ module V1
 
     def params_names
       params.require(:data).require(:attributes)[:samples].map do |param|
-        param.permit(:external_id, :name, :species).to_h
+        param.permit(:external_id, :external_study_id, :name, :species).to_h
       end
     end
   end

--- a/app/models/chip.rb
+++ b/app/models/chip.rb
@@ -6,7 +6,7 @@ class Chip < ApplicationRecord
   has_many :flowcells, dependent: :nullify
 
   validates :barcode, presence: true
-  validates_length_of :barcode, minimum: 16
+  validates :barcode, length: { minimum: 16 }
 
   after_create :create_flowcells
   before_save :update_serial_number
@@ -18,6 +18,6 @@ class Chip < ApplicationRecord
   end
 
   def update_serial_number
-    self.serial_number = self.barcode[0..15]
+    self.serial_number = barcode[0..15]
   end
 end

--- a/app/models/chip.rb
+++ b/app/models/chip.rb
@@ -5,9 +5,19 @@ class Chip < ApplicationRecord
   belongs_to :run, optional: true
   has_many :flowcells, dependent: :nullify
 
+  validates :barcode, presence: true
+  validates_length_of :barcode, minimum: 16
+
   after_create :create_flowcells
+  before_save :update_serial_number
+
+  private
 
   def create_flowcells
     Flowcell.create([{ position: 1, chip: self }, { position: 2, chip: self }])
+  end
+
+  def update_serial_number
+    self.serial_number = self.barcode[0..15]
   end
 end

--- a/app/models/run_factory.rb
+++ b/app/models/run_factory.rb
@@ -4,8 +4,9 @@
 class RunFactory
   include ActiveModel::Model
 
+  #TODO: the barcode will need to be removed once the ui is refactored to build a new run with validation
   def initialize(attributes = [])
-    attributes.each { |run| runs << Run.new(run.merge!(chip: Chip.new)) }
+    attributes.each { |run| runs << Run.new(run.merge!(chip: Chip.new(barcode: 'FLEVEAOLPTOWPNWU20319131581014320190911XXXXXXXXXXXXX'))) }
   end
 
   def runs

--- a/app/models/run_factory.rb
+++ b/app/models/run_factory.rb
@@ -4,9 +4,14 @@
 class RunFactory
   include ActiveModel::Model
 
-  #TODO: the barcode will need to be removed once the ui is refactored to build a new run with validation
+  # TODO: the barcode will need to be removed once
+  # the ui is refactored to build a new run with validation
   def initialize(attributes = [])
-    attributes.each { |run| runs << Run.new(run.merge!(chip: Chip.new(barcode: 'FLEVEAOLPTOWPNWU20319131581014320190911XXXXXXXXXXXXX'))) }
+    attributes.each do |run|
+      runs << Run.new(run.merge!(chip: Chip.new(
+        barcode: 'FLEVEAOLPTOWPNWU20319131581014320190911XXXXXXXXXXXXX'
+      )))
+    end
   end
 
   def runs

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -5,7 +5,7 @@ class Sample < ApplicationRecord
   include Material
 
   attr_readonly :name
-  validates :name, :external_id, :species, presence: true
+  validates :name, :external_id, :external_study_id, :species, presence: true
   validates :name, uniqueness: true
   has_many :libraries, dependent: :nullify
 

--- a/db/migrate/20181112145617_create_samples.rb
+++ b/db/migrate/20181112145617_create_samples.rb
@@ -6,6 +6,7 @@ class CreateSamples < ActiveRecord::Migration[5.2]
       t.string :name
       t.datetime :deactivated_at
       t.integer :external_id
+      t.integer :external_study_id
       t.string :species
       t.timestamps
     end

--- a/db/migrate/20190212110741_create_chips.rb
+++ b/db/migrate/20190212110741_create_chips.rb
@@ -2,6 +2,7 @@ class CreateChips < ActiveRecord::Migration[5.2]
   def change
     create_table :chips do |t|
       t.string :barcode
+      t.string :serial_number
       t.belongs_to :run, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema.define(version: 2019_02_12_111752) do
 
   create_table "chips", force: :cascade do |t|
     t.string "barcode"
+    t.string "serial_number"
     t.integer "run_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -61,6 +62,7 @@ ActiveRecord::Schema.define(version: 2019_02_12_111752) do
     t.string "name"
     t.datetime "deactivated_at"
     t.integer "external_id"
+    t.integer "external_study_id"
     t.string "species"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/create_dummy_runs.rake
+++ b/lib/tasks/create_dummy_runs.rake
@@ -3,9 +3,9 @@
 namespace :dummy_runs do
   task create: :environment do |_t|
     (1..5).each do |i|
-      sample = Sample.create(name: "Sample#{i}", external_id: i, species: "Species#{i}", tube: Tube.create)
+      sample = Sample.create(name: "Sample#{i}", external_id: i, external_study_id: i, species: "Species#{i}", tube: Tube.create)
       library = Library.create(sample: sample, enzyme_id: i, tube: Tube.create)
-      chip = Chip.create
+      chip = Chip.create(barcode: 'FLEVEAOLPTOWPNWU20319131581014320190911XXXXXXXXXXXXX')
       chip.flowcells.first.library = library
       chip.flowcells.last.library = library
       chip.save

--- a/spec/factories/chips.rb
+++ b/spec/factories/chips.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :chip do
     run
-    sequence(:barcode) { |n| "TRAC-#{n}" }
+    sequence(:barcode) { |n| "FLEVEAOLPTOWPNWU20319131581014320190911XXXXXXXXXXXXX-#{n}" }
   end
 end

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :sample do
     sequence(:name) { |n| "Sample#{n}" }
     sequence(:external_id, &:to_s)
+    sequence(:external_study_id, &:to_s)
     species { 'human' }
   end
 end

--- a/spec/models/chip_spec.rb
+++ b/spec/models/chip_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 
 RSpec.describe Chip, type: :model do
 
+  let(:barcode) { 'FLEVEAOLPTOWPNWU20319131581014320190911XXXXXXXXXXXXX' }
+  let(:serial_number) { 'FLEVEAOLPTOWPNWU' }
+
   context 'after create' do
     it '#create_flowcells' do
       chip = create(:chip)
@@ -30,15 +33,23 @@ RSpec.describe Chip, type: :model do
   end
 
   context 'barcode' do
-    it 'can have a barcode' do
-      expect(create(:chip, barcode: "TRAC-123")).to be_valid
-      expect(create(:chip, barcode: nil)).to be_valid
+    it 'must have a barcode' do
+      expect(build(:chip, barcode: barcode)).to be_valid
+      expect(build(:chip, barcode: nil)).to_not be_valid
     end
 
-    it 'can be updated with a barcode' do
-      chip = create(:chip)
-      chip.update(barcode: "TRAC-123")
-      expect(chip.barcode).to eq "TRAC-123"
+    it 'must have a barcode of 16 characters or more' do
+      expect(build(:chip, barcode: serial_number)).to be_valid
+      expect(build(:chip, barcode: 'smashit')).to_not be_valid
+    end
+
+    context 'serial number' do
+
+      it 'will be updated when the barcode is updated' do
+        chip = create(:chip, barcode: 'FLEVEAOLPTOWPNWU20319131581014320190911XXXXXXXXXXXXX')
+        expect(chip.serial_number).to eq 'FLEVEAOLPTOWPNWU'
+      end
+
     end
   end
 

--- a/spec/models/sample_factory_spec.rb
+++ b/spec/models/sample_factory_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe SampleFactory, type: :model do
       expect(factory).to_not be_valid
       expect(factory.errors.full_messages[0]).to eq("Name can\'t be blank")
       expect(factory.errors.full_messages[1]).to eq("External can\'t be blank")
-      expect(factory.errors.full_messages[2]).to eq("Species can\'t be blank")
-      expect(factory.errors.full_messages.length).to eq(3)
+      expect(factory.errors.full_messages[2]).to eq("External study can\'t be blank")
+      expect(factory.errors.full_messages[3]).to eq("Species can\'t be blank")
+      expect(factory.errors.full_messages.length).to eq(4)
     end
   end
 

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Sample, type: :model do
     it 'should be active' do
       expect(create(:sample)).to be_active
     end
+
+    describe 'external_study_id' do
+
+      it 'must have an external study id' do
+        expect(build(:sample, external_study_id: nil)).not_to be_valid
+      end
+
+    end
   end
 
   context 'on update' do

--- a/spec/requests/v1/chips_spec.rb
+++ b/spec/requests/v1/chips_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'ChipsController', type: :request do
 
   context '#update' do
     let(:chip) { create(:chip) }
+    let(:barcode) { 'FLEVEAOLPTOWPNWU20319131581014320190911XXXXXXXXXXXXX-2' }
+
 
     context 'on success' do
       let(:body) do
@@ -12,7 +14,7 @@ RSpec.describe 'ChipsController', type: :request do
             type: "chips",
             id: chip.id,
             attributes: {
-              "barcode":"TRAC123"
+              barcode: barcode
             }
           }
         }.to_json
@@ -26,7 +28,7 @@ RSpec.describe 'ChipsController', type: :request do
       it 'updates a chip' do
         patch v1_chip_path(chip), params: body, headers: json_api_headers
         chip.reload
-        expect(chip.barcode).to eq "TRAC123"
+        expect(chip.barcode).to eq barcode
       end
     end
 
@@ -37,7 +39,7 @@ RSpec.describe 'ChipsController', type: :request do
             type: "chips",
             id: chip.id,
             attributes: {
-              "barcode":"TRAC123"
+              barcode: barcode
             }
           }
         }.to_json


### PR DESCRIPTION
Added serial number to chip updated from barcode. 
Made chip barcode mandatory of at least length 16. 
Added study id to sample and made it required.
Added an arbitary chip barcode in run factory until we have had a chance to sort out the new run creation.
The above changes are necessary otherwise it will affect the integrity of the warehouse data.
TODO: Update traction-ui to pull study uuid and sample uuid.