### PR TITLE
Added the ability to add a request to pacbio library with no tags.

### DIFF
--- a/app/messages/messages/message.rb
+++ b/app/messages/messages/message.rb
@@ -66,8 +66,9 @@ module Messages
       end
     end
 
+    # we need to do this via try as certain fields may be nil
     def evaluate_method_chain(object, chain)
-      chain.inject(object, :send)
+      chain.inject(object) { |o, meth| o.try(:send, meth) }
     end
   end
 end

--- a/app/models/pacbio/library_factory.rb
+++ b/app/models/pacbio/library_factory.rb
@@ -9,7 +9,7 @@ module Pacbio
   class LibraryFactory
     include ActiveModel::Model
 
-    validate :check_libraries
+    validate :check_libraries, :check_tags
 
     def initialize(attributes = [])
       build_libraries(attributes)
@@ -60,6 +60,16 @@ module Pacbio
 
         library.errors.each do |k, v|
           errors.add(k, v)
+        end
+      end
+    end
+
+    def check_tags
+      libraries.each do |library|
+        next if library.request_libraries.length < 2
+
+        if library.request_libraries.any? { |rl| rl.tag_id.nil? }
+          errors.add('tag', 'must be present')
         end
       end
     end

--- a/app/models/pacbio/request_library.rb
+++ b/app/models/pacbio/request_library.rb
@@ -14,10 +14,10 @@ module Pacbio
     belongs_to :library, class_name: 'Pacbio::Library', foreign_key: :pacbio_library_id,
                          inverse_of: :request_libraries
     # TODO: make this taggable
-    belongs_to :tag, class_name: '::Tag', foreign_key: :tag_id, inverse_of: false
+    belongs_to :tag, class_name: '::Tag', foreign_key: :tag_id, inverse_of: false, optional: true
 
     delegate :sample_name, to: :request
-    delegate :oligo, :group_id, :set_name, :id, to: :tag, prefix: :tag
+    delegate :oligo, :group_id, :set_name, :id, to: :tag, prefix: :tag, allow_nil: true
 
     validates :tag, uniqueness: { scope: :library,
                                   message: 'need to be unique within a library' }

--- a/app/models/pacbio/well_library_factory.rb
+++ b/app/models/pacbio/well_library_factory.rb
@@ -35,8 +35,10 @@ module Pacbio
       end
     end
 
+    # don't need to worry about nils
     def check_tags
-      all_tags = well.tags + libraries.collect(&:request_libraries).flatten.collect(&:tag_id)
+      all_tags = (well.tags +
+        libraries.collect(&:request_libraries).flatten.collect(&:tag_id)).compact
       return if all_tags.length == all_tags.uniq.length
 
       errors.add(:tags, 'are not unique within the libraries')

--- a/spec/factories/pacbio/request_library.rb
+++ b/spec/factories/pacbio/request_library.rb
@@ -2,6 +2,9 @@ FactoryBot.define do
   factory :pacbio_request_library, class: Pacbio::RequestLibrary do
     request   { create(:pacbio_request) }
     library   { create(:pacbio_library) }
-    tag       { create(:tag) }
+
+    factory :pacbio_request_library_with_tag do
+      tag {create(:tag)}
+    end
   end
 end

--- a/spec/models/pacbio/library_factory_spec.rb
+++ b/spec/models/pacbio/library_factory_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Pacbio::LibraryFactory, type: :model, pacbio: true do
       expect(factory.errors.full_messages).to_not be_empty
     end
 
-    it 'produces an error if any of the associated requests are invalid' do
+    xit 'produces an error if any of the associated requests are invalid' do
       library_attributes << attributes_for(:pacbio_library).merge(requests: [{id: requests.first.id, type: 'requests'}])
       factory = Pacbio::LibraryFactory.new(library_attributes)
       expect(factory).to_not be_valid

--- a/spec/models/pacbio/library_factory_spec.rb
+++ b/spec/models/pacbio/library_factory_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Pacbio::LibraryFactory, type: :model, pacbio: true do
       expect(factory.errors.full_messages).to_not be_empty
     end
 
-    xit 'produces an error if any of the associated requests are invalid' do
-      library_attributes << attributes_for(:pacbio_library).merge(requests: [{id: requests.first.id, type: 'requests'}])
+    it 'produces an error if there is more than one request and they dont have tags' do
+      library_attributes << attributes_for(:pacbio_library).merge(requests: [{id: requests.first.id, type: 'requests'}, {id: requests.last.id, type: 'requests'}])
       factory = Pacbio::LibraryFactory.new(library_attributes)
       expect(factory).to_not be_valid
       expect(factory.errors.full_messages).to_not be_empty

--- a/spec/models/pacbio/library_spec.rb
+++ b/spec/models/pacbio/library_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Pacbio::Library, type: :model, pacbio: true do
       expect(sample_names.length).to eq(5)
       expect(sample_names.any?(&:blank?)).to be_falsey
     end
+
   end
 
   context 'library' do

--- a/spec/models/pacbio/request_library_spec.rb
+++ b/spec/models/pacbio/request_library_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Pacbio::RequestLibrary, type: :model, pacbio: true do
     expect(build(:pacbio_request_library, library: nil)).to_not be_valid
   end
 
-  it 'must have a tag' do
-    expect(build(:pacbio_request_library, tag: nil)).to_not be_valid
+  it 'can have a tag' do
+    expect(build(:pacbio_request_library, tag: create(:tag)).tag).to be_present
   end
 
   it 'can have a sample name' do
@@ -19,7 +19,7 @@ RSpec.describe Pacbio::RequestLibrary, type: :model, pacbio: true do
   end
 
   it 'can have some tag attributes' do
-    request_library = create(:pacbio_request_library)
+    request_library = create(:pacbio_request_library, tag: create(:tag))
     expect(request_library.tag_oligo).to be_present
     expect(request_library.tag_group_id).to be_present
     expect(request_library.tag_set_name).to be_present

--- a/spec/models/pacbio/well_library_factory_spec.rb
+++ b/spec/models/pacbio/well_library_factory_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Pacbio::WellLibraryFactory, type: :model, pacbio: true do
       expect(factory).to_not be_valid
       expect(factory.errors.full_messages).to_not be_empty
     end
+
+    it 'produces an error if there are multiples requests in any of the libraries and they do not have tags'
   end
 
   context '#save' do

--- a/spec/models/pacbio/well_library_factory_spec.rb
+++ b/spec/models/pacbio/well_library_factory_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 RSpec.describe Pacbio::WellLibraryFactory, type: :model, pacbio: true do
 
   let(:well)                    { create(:pacbio_well) }
-  let(:request_library_1)       { create(:pacbio_request_library)}
-  let(:request_library_2)       { create(:pacbio_request_library)}
-  let(:request_library_3)       { create(:pacbio_request_library)}
-  let(:request_library_4)       { create(:pacbio_request_library)}
-  let(:request_library_5)       { create(:pacbio_request_library)}
+  let(:request_library_1)       { create(:pacbio_request_library_with_tag) }
+  let(:request_library_2)       { create(:pacbio_request_library_with_tag) }
+  let(:request_library_3)       { create(:pacbio_request_library_with_tag) }
+  let(:request_library_4)       { create(:pacbio_request_library_with_tag) }
+  let(:request_library_5)       { create(:pacbio_request_library_with_tag) }
   let(:request_library_invalid) { create(:pacbio_request_library, tag: request_library_5.tag)}
   let(:library_ids)             { [
                                     {

--- a/spec/pipelines/pacbio/message_spec.rb
+++ b/spec/pipelines/pacbio/message_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'PacBio', type: :model, pacbio: true do
 
       context 'samples' do
 
-        let(:request_libraries)   { create_list(:pacbio_request_library, 5) }
+        let(:request_libraries)   { create_list(:pacbio_request_library, 5, tag: create(:tag)) }
 
         before(:each) do
           plate_well.libraries << request_libraries.collect(&:library)
@@ -103,19 +103,19 @@ RSpec.describe 'PacBio', type: :model, pacbio: true do
             expect(message_sample[:study_uuid]).to eq(request_library.request.external_study_id)
           end
 
-          it 'must have a tag sequence' do
+          it 'can have a tag sequence' do
             expect(message_sample[:tag_sequence]).to eq(request_library.tag.oligo)
           end
 
-          it 'must have a tag group id' do
+          it 'can have a tag group id' do
             expect(message_sample[:tag_set_id_lims]).to eq(request_library.tag.group_id)
           end
 
-          it 'must have a tag identifier' do
+          it 'can have a tag identifier' do
             expect(message_sample[:tag_identifier]).to eq(request_library.tag.id)
           end
 
-          it 'must have a tag set name' do
+          it 'can have a tag set name' do
             expect(message_sample[:tag_set_name]).to eq(request_library.tag.set_name)
           end
 

--- a/spec/requests/v1/pacbio/wells/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/wells/libraries_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe 'Well::LibrariesController', type: :request, pacbio: true do
 
   let(:well)                  { create(:pacbio_well) }
-  let(:request_libraries)     { create_list(:pacbio_request_library, 5)}
+  let(:request_libraries)     { create_list(:pacbio_request_library_with_tag, 5)}
   let(:dodgy_request_library) { create(:pacbio_request_library, tag: request_libraries.first.tag) }
 
   context '#create' do


### PR DESCRIPTION
Because we are not doing multiplexing at the moment I have not added checks to ensure that all of the requests in a library have tags if there is more than one request.