### PR TITLE
Added BUG fix for issue #376 pipelines config uat misssing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,3 +75,6 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: false
+
+Rails/UniqueValidationWithoutIndex:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,6 +75,3 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: false
-
-Rails/UniqueValidationWithoutIndex:
-  Enabled: false

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -188,7 +188,7 @@ development:
 test:
   <<: *default
 
-staging:
+uat:
   <<: *default
 
 production:


### PR DESCRIPTION
BUG - couldnt create pacbio run
This was because after creation, a message is send to the mlwh
Which gets the message config from the pipelines.yml
Recently with rails 6 upgrade, the way of loading the config had changed
to have the uat << default pipelines.yml load the config

Also has to disable rubocop check UniqueValidationWithoutIndex
which is current failing a different depfu update **UPDATE** not needed on travis

