### PR TITLE
GPL-426 Optimise plate creation

### DIFF
--- a/app/models/ont/request_factory.rb
+++ b/app/models/ont/request_factory.rb
@@ -8,7 +8,7 @@ module Ont
   class RequestFactory
     include ActiveModel::Model
 
-    validate :check_request, :check_tag
+    validate :check_request, :check_tag, :check_well_request_join
 
     def initialize(attributes = {})
       @well = attributes[:well]
@@ -20,12 +20,13 @@ module Ont
 
     attr_reader :request
 
-    def save
-      return false unless valid?
+    def save(**options)
+      return false unless options[:validate] == false || valid?
 
-      request.save
-      @tag_taggable&.save
-      @well_request_join.save
+      # No need to validate any lower level objects since validation above has already checked them
+      request.save(validate: false)
+      @tag_taggable&.save(validate: false)
+      @well_request_join.save(validate: false)
       true
     end
 
@@ -72,6 +73,14 @@ module Ont
       return if @tag_taggable.nil? || @tag_taggable.valid?
 
       @tag_taggable.errors.each do |k, v|
+        errors.add(k, v)
+      end
+    end
+
+    def check_well_request_join
+      return if @well_request_join.nil? || @well_request_join.valid?
+
+      @well_request_join.errors.each do |k, v|
         errors.add(k, v)
       end
     end

--- a/app/models/ont/well_factory.rb
+++ b/app/models/ont/well_factory.rb
@@ -24,10 +24,6 @@ module Ont
     def save(**options)
       return false unless options[:validate] == false || valid?
 
-      check_tag_service
-      check_for_raised_exceptions
-      return false if errors.any?
-
       # No need to validate any lower level objects since validation above has already checked them
       well.save(validate: false)
       @request_factories.map { |request_factory| request_factory.save(validate: false) }

--- a/app/models/ont/well_factory.rb
+++ b/app/models/ont/well_factory.rb
@@ -21,11 +21,16 @@ module Ont
 
     attr_reader :well
 
-    def save
-      return false unless valid?
+    def save(**options)
+      return false unless options[:validate] == false || valid?
 
-      well.save
-      @request_factories.collect(&:save)
+      check_tag_service
+      check_for_raised_exceptions
+      return false if errors.any?
+
+      # No need to validate any lower level objects since validation above has already checked them
+      well.save(validate: false)
+      @request_factories.map { |request_factory| request_factory.save(validate: false) }
       true
     end
 

--- a/app/services/tag_service.rb
+++ b/app/services/tag_service.rb
@@ -4,27 +4,21 @@
 # The service will allow checking a collection of tags are unique
 class TagService
   def initialize(tag_set)
-    @tag_set = tag_set
-    @tags = []
+    @all_tags = tag_set.nil? ? [] : Tag.where(tag_set_id: tag_set.id)
+    @registered_tags = Set.new
   end
 
-  attr_reader :tag_set
-
   def find_and_register_tag(group_id)
-    return if tag_set.nil?
-
-    tag = Tag.find_by(tag_set_id: tag_set.id, group_id: group_id)
-    tags << tag unless tag.nil?
-    tag
+    found_tag = all_tags.find { |tag| tag.group_id == group_id }
+    registered_tags << found_tag unless found_tag.nil?
+    found_tag
   end
 
   def complete?
-    return true if tag_set.nil?
-
-    tag_set.tags.count == tags.uniq.count
+    all_tags.count == registered_tags.count
   end
 
   private
 
-  attr_reader :tags
+  attr_reader :all_tags, :registered_tags
 end

--- a/db/migrate/20200506214419_add_multi_column_index_to_samples.rb
+++ b/db/migrate/20200506214419_add_multi_column_index_to_samples.rb
@@ -1,0 +1,5 @@
+class AddMultiColumnIndexToSamples < ActiveRecord::Migration[6.0]
+  def change
+    add_index :samples, [:name, :external_id, :species]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_28_092948) do
+ActiveRecord::Schema.define(version: 2020_05_06_214419) do
 
   create_table "container_materials", force: :cascade do |t|
     t.string "container_type"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(version: 2020_04_28_092948) do
     t.string "species"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name", "external_id", "species"], name: "index_samples_on_name_and_external_id_and_species"
     t.index ["name"], name: "index_samples_on_name", unique: true
   end
 

--- a/spec/models/ont/request_factory_spec.rb
+++ b/spec/models/ont/request_factory_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
   context '#save' do
     context 'valid build' do
       let(:attributes) { { well: well, tag_service: tag_service, request_attributes: { name: 'sample 1', external_id: '1', tag_group_id: tag.group_id } } }
+      let(:factory) { Ont::RequestFactory.new(attributes) }
 
       before do
         allow_any_instance_of(Pipelines::ConstantsAccessor).to receive(:external_study_id).and_return('test external id')
@@ -83,12 +84,10 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
       end
 
       it 'is valid with given attributes' do
-        factory = Ont::RequestFactory.new(attributes)
         expect(factory).to be_valid
       end
 
       it 'creates ont request' do
-        factory = Ont::RequestFactory.new(attributes)
         expect(factory.save).to be_truthy
         expect(Ont::Request.all.count).to eq(1)
         expect(Ont::Request.first.external_study_id).to eq('test external id')
@@ -97,15 +96,14 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
 
       context 'without tag_group_id' do
         let(:attributes_without_tag) { { well: well, tag_service: tag_service, request_attributes: { name: 'sample 1', external_id: '1' } } }
+        let(:factory) { Ont::RequestFactory.new(attributes_without_tag) }
 
         it 'creates an untagged ont request' do
-          factory = Ont::RequestFactory.new(attributes_without_tag)
           expect(factory.save).to be_truthy
           expect(Ont::Request.first.tags.count).to eq(0)
         end
 
         it 'does not create a tag taggable' do
-          factory = Ont::RequestFactory.new(attributes_without_tag)
           expect(factory.save).to be_truthy
           expect(::TagTaggable.count).to eq(0)
         end
@@ -117,14 +115,12 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
         end
 
         it 'creates a tagged ont request' do
-          factory = Ont::RequestFactory.new(attributes)
           expect(factory.save).to be_truthy
           expect(Ont::Request.first.tags.count).to eq(1)
           expect(Ont::Request.first.tags).to contain_exactly(tag)
         end
 
         it 'creates a tag taggable' do
-          factory = Ont::RequestFactory.new(attributes)
           expect(factory.save).to be_truthy
           expect(::TagTaggable.count).to eq(1)
           expect(::TagTaggable.first.tag).to eq(tag)
@@ -134,7 +130,6 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
       end
 
       it 'creates a container material' do
-        factory = Ont::RequestFactory.new(attributes)
         expect(factory.save).to be_truthy
         expect(::ContainerMaterial.all.count).to eq(1)
         expect(::ContainerMaterial.first.container).to eq(::Well.where(position: 'A1').first)
@@ -142,7 +137,6 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
       end
 
       it 'creates a sample for a request if that sample does not exist' do
-        factory = Ont::RequestFactory.new(attributes)
         expect(factory.save).to be_truthy
         expect(::Sample.all.count).to eq(1)
         expect(::Sample.first.name).to eq('sample 1')
@@ -154,7 +148,6 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
 
       it 'does not create a sample for a request if that sample already exists' do
         create(:sample, name: 'sample 1', external_id: '1', species: 'test sample species')
-        factory = Ont::RequestFactory.new(attributes)
         expect(factory.save).to be_truthy
         expect(::Sample.all.count).to eq(1)
         expect(::Sample.first.requests.count).to eq(1)

--- a/spec/models/ont/request_factory_spec.rb
+++ b/spec/models/ont/request_factory_spec.rb
@@ -153,6 +153,20 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
         expect(::Sample.first.requests.count).to eq(1)
         expect(::Sample.first.requests.first.requestable).to eq(Ont::Request.first)
       end
+
+      it 'validates the tag taggable only once by default' do
+        validation_count = 0
+        allow_any_instance_of(TagTaggable).to receive(:valid?) { |_| validation_count += 1 }
+        factory.save
+        expect(validation_count).to eq(1)
+      end
+
+      it 'validates the container material join only once by default' do
+        validation_count = 0
+        allow_any_instance_of(ContainerMaterial).to receive(:valid?) { |_| validation_count += 1 }
+        factory.save
+        expect(validation_count).to eq(1)
+      end
     end
 
     context 'invalid build' do

--- a/spec/models/ont/request_factory_spec.rb
+++ b/spec/models/ont/request_factory_spec.rb
@@ -154,6 +154,16 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
         expect(::Sample.first.requests.first.requestable).to eq(Ont::Request.first)
       end
 
+      it 'validates the request only once by default' do
+        validation_count = 0
+        allow_any_instance_of(Request).to receive(:valid?) { |_| validation_count += 1 }
+        factory.save
+        expect(validation_count).to be >= 1
+        # TODO: this should be only once, but isn't at the moment
+        # see https://github.com/sanger/traction-service/issues/355
+        # expect(validation_count).to eq(1)
+      end
+
       it 'validates the tag taggable only once by default' do
         validation_count = 0
         allow_any_instance_of(TagTaggable).to receive(:valid?) { |_| validation_count += 1 }
@@ -166,6 +176,39 @@ RSpec.describe Ont::RequestFactory, type: :model, ont: true do
         allow_any_instance_of(ContainerMaterial).to receive(:valid?) { |_| validation_count += 1 }
         factory.save
         expect(validation_count).to eq(1)
+      end
+
+      it 'validates the ONT request only once by default' do
+        validation_count = 0
+        allow_any_instance_of(Ont::Request).to receive(:valid?) { |_| validation_count += 1 }
+        factory.save
+        expect(validation_count).to be >= 1
+        # TODO: this should be only once, but isn't at the moment
+        # see https://github.com/sanger/traction-service/issues/355
+        # expect(validation_count).to eq(1)
+      end
+
+      it 'validates the sample only once by default' do
+        validation_count = 0
+        allow_any_instance_of(Sample).to receive(:valid?) { |_| validation_count += 1 }
+        factory.save
+        expect(validation_count).to be >= 1
+        # TODO: this should be only once, but isn't at the moment
+        # see https://github.com/sanger/traction-service/issues/355
+        # expect(validation_count).to eq(1)
+      end
+
+      it 'validates no children when (validate: false) is passed' do
+        validation_count = 0
+        allow_any_instance_of(Request).to receive(:valid?) { |_| validation_count += 1 }
+        allow_any_instance_of(TagTaggable).to receive(:valid?) { |_| validation_count += 1 }
+        allow_any_instance_of(ContainerMaterial).to receive(:valid?) { |_| validation_count += 1 }
+        allow_any_instance_of(Ont::Request).to receive(:valid?) { |_| validation_count += 1 }
+        allow_any_instance_of(Sample).to receive(:valid?) { |_| validation_count += 1 }
+        factory.save(validate: false)
+        # TODO: this should be zero, but isn't at the moment
+        # see https://github.com/sanger/traction-service/issues/355
+        # expect(validation_count).to eq(0)
       end
     end
 

--- a/spec/models/ont/well_factory_spec.rb
+++ b/spec/models/ont/well_factory_spec.rb
@@ -123,6 +123,30 @@ RSpec.describe Ont::WellFactory, type: :model, ont: true do
         expect(factory.save).to be_truthy
       end
 
+      it 'validates the well only once by default' do
+        validation_count = 0
+        allow_any_instance_of(Well).to receive(:valid?) { |_| validation_count += 1 }
+        factory = Ont::WellFactory.new(well_with_many_samples)
+        factory.save
+        expect(validation_count).to eq(1)
+      end
+
+      it 'validates the request factories only once each by default' do
+        validation_count = 0
+        allow_any_instance_of(Ont::RequestFactory).to receive(:valid?) { |_| validation_count += 1 }
+        factory = Ont::WellFactory.new(well_with_many_samples)
+        factory.save
+        expect(validation_count).to eq(96)
+      end
+
+      it 'validates no children when (validate: false) is passed' do
+        validation_count = 0
+        allow_any_instance_of(Well).to receive(:valid?) { |_| validation_count += 1 }
+        allow_any_instance_of(Ont::RequestFactory).to receive(:valid?) { |_| validation_count += 1 }
+        factory = Ont::WellFactory.new(well_with_many_samples)
+        factory.save(validate: false)
+        expect(validation_count).to eq(0)
+      end
     end
 
     context 'invalid build' do


### PR DESCRIPTION
I've partially done this, but I've put it down due to time boxing.  The requests do process faster here, but there's still an outstanding issue I haven't been able to resolve AND there are more issues looking at the SQL logs.  The main outstanding issue in this branch is that I wasn't able to get the entities created by the Request Factory to only validate once in a normal workflow.  This is because the Ont::Request and the Sample are set to autosave the Request when their relationships are updated.  And the Request is set to autosave the Ont::Request and Sample when it's relationships are updated.  This is good, but the save causes another validation.  I tried removing the autosave from the relationships but that: a) causes issues in Pacbio and Saphyr which rely on this autosave and b) caused issues I couldn't resolve quickly for Ont as well.  I was able to test the performance when the autosave was off and it improved the plate creation by another 30 seconds, bringing it down to 200 seconds on my machine in SQLite, but this is still nowhere near the number we want to reach.  There must be other optimisations elsewhere as well.