### PR TITLE
Gpl 387 run factory

### DIFF
--- a/app/models/ont/flowcell.rb
+++ b/app/models/ont/flowcell.rb
@@ -8,6 +8,9 @@ module Ont
     belongs_to :run, foreign_key: :ont_run_id, inverse_of: :flowcells, dependent: :destroy
     belongs_to :library, foreign_key: :ont_library_id, inverse_of: :flowcell
 
-    validates :position, presence: true
+    validates :position,
+              presence: true,
+              uniqueness: { scope: :ont_run_id,
+                            message: 'position should only appear once within run' }
   end
 end

--- a/app/models/ont/run_factory.rb
+++ b/app/models/ont/run_factory.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Ont namespace
+module Ont
+  # RunFactory
+  # The factory will create runs from a list of libraries
+  class RunFactory
+    include ActiveModel::Model
+
+    validate :check_run, :check_flowcells
+
+    def initialize(library_names = [])
+      @flowcells = []
+      build_run(library_names)
+    end
+
+    attr_reader :run
+
+    def save(**options)
+      return false unless options[:validate] == false || valid?
+
+      @run.save(validate: false)
+      @flowcells.each { |flowcell| flowcell.save(validate: false) }
+      true
+    end
+
+    private
+
+    attr_reader :flowcells
+
+    def build_run(library_names)
+      constants_accessor = Pipelines::ConstantsAccessor.new(Pipelines.ont.covid)
+      @run = Ont::Run.new(instrument_name: constants_accessor.instrument_name)
+      library_names.each_with_index do |library_name, idx|
+        library = Ont::Library.find_by(name: library_name)
+        @flowcells << Ont::Flowcell.new(position: idx + 1, run: run, library: library)
+      end
+    end
+
+    def check_run
+      errors.add('run', 'was not created') if @run.nil?
+
+      return if @run.valid?
+
+      @run.errors.each do |k, v|
+        errors.add(k, v)
+      end
+    end
+
+    def check_flowcells
+      @flowcells.each do |flowcell|
+        next if flowcell.valid?
+
+        flowcell.errors.each do |k, v|
+          errors.add(k, v)
+        end
+      end
+    end
+  end
+end

--- a/app/models/ont/run_factory.rb
+++ b/app/models/ont/run_factory.rb
@@ -32,6 +32,7 @@ module Ont
       constants_accessor = Pipelines::ConstantsAccessor.new(Pipelines.ont.covid)
       @run = Ont::Run.new(instrument_name: constants_accessor.instrument_name)
       library_names.each_with_index do |library_name, idx|
+        # the flowcell requires a library, so if a library does not exist the flowcell, and therefore factory, will be invalid
         library = Ont::Library.find_by(name: library_name)
         @flowcells << Ont::Flowcell.new(position: idx + 1, run: run, library: library)
       end

--- a/app/models/ont/run_factory.rb
+++ b/app/models/ont/run_factory.rb
@@ -32,7 +32,8 @@ module Ont
       constants_accessor = Pipelines::ConstantsAccessor.new(Pipelines.ont.covid)
       @run = Ont::Run.new(instrument_name: constants_accessor.instrument_name)
       library_names.each_with_index do |library_name, idx|
-        # the flowcell requires a library, so if a library does not exist the flowcell, and therefore factory, will be invalid
+        # the flowcell requires a library, so if a library does not exist
+        # the flowcell, and therefore factory, will be invalid
         library = Ont::Library.find_by(name: library_name)
         @flowcells << Ont::Flowcell.new(position: idx + 1, run: run, library: library)
       end

--- a/app/models/ont/run_factory.rb
+++ b/app/models/ont/run_factory.rb
@@ -9,9 +9,9 @@ module Ont
 
     validate :check_run, :check_flowcells
 
-    def initialize(library_names = [])
+    def initialize(attributes = [])
       @flowcells = []
-      build_run(library_names)
+      build_run(attributes)
     end
 
     attr_reader :run
@@ -28,14 +28,14 @@ module Ont
 
     attr_reader :flowcells
 
-    def build_run(library_names)
+    def build_run(attributes)
       constants_accessor = Pipelines::ConstantsAccessor.new(Pipelines.ont.covid)
       @run = Ont::Run.new(instrument_name: constants_accessor.instrument_name)
-      library_names.each_with_index do |library_name, idx|
+      attributes.each do |flowcell_spec|
         # the flowcell requires a library, so if a library does not exist
         # the flowcell, and therefore factory, will be invalid
-        library = Ont::Library.find_by(name: library_name)
-        @flowcells << Ont::Flowcell.new(position: idx + 1, run: run, library: library)
+        library = Ont::Library.find_by(name: flowcell_spec[:library_name])
+        @flowcells << Ont::Flowcell.new(position: flowcell_spec[:position], run: run, library: library)
       end
     end
 

--- a/app/models/ont/run_factory.rb
+++ b/app/models/ont/run_factory.rb
@@ -35,7 +35,9 @@ module Ont
         # the flowcell requires a library, so if a library does not exist
         # the flowcell, and therefore factory, will be invalid
         library = Ont::Library.find_by(name: flowcell_spec[:library_name])
-        @flowcells << Ont::Flowcell.new(position: flowcell_spec[:position], run: run, library: library)
+        @flowcells << Ont::Flowcell.new(position: flowcell_spec[:position],
+                                        run: run, library:
+        library)
       end
     end
 

--- a/app/pipelines/pipelines/constants_accessor.rb
+++ b/app/pipelines/pipelines/constants_accessor.rb
@@ -14,5 +14,9 @@ module Pipelines
     def species
       @constants_base.species
     end
+
+    def instrument_name
+      @constants_base.instrument_name
+    end
   end
 end

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -184,6 +184,7 @@ default: &default
     covid:
       external_study_id: "example id"
       species: "example species"
+      instrument_name: 'GridIon'
 
 
 development:

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -184,7 +184,7 @@ default: &default
     covid:
       external_study_id: "example id"
       species: "example species"
-      instrument_name: "GridIon"
+      instrument_name: "GridION"
 
 
 development:

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -184,7 +184,7 @@ default: &default
     covid:
       external_study_id: "example id"
       species: "example species"
-      instrument_name: 'GridIon'
+      instrument_name: "GridIon"
 
 
 development:

--- a/spec/models/ont/flowcell_spec.rb
+++ b/spec/models/ont/flowcell_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe Ont::Flowcell, type: :model, ont: true do
     flowcell = build(:ont_flowcell, library: nil)
     expect(flowcell).to_not be_valid
   end
+
+  it 'must have a unique position' do
+    flowcell = create(:ont_flowcell)
+    new_flowcell = build(:ont_flowcell, position: flowcell.position, run:flowcell.run)
+    expect(new_flowcell).to_not be_valid
+  end
 end

--- a/spec/models/ont/library_factory_spec.rb
+++ b/spec/models/ont/library_factory_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Ont::PlateFactory, type: :model, ont: true do
+RSpec.describe Ont::LibraryFactory, type: :model, ont: true do
   let!(:plate) { create(:plate_with_wells, row_count: 3, column_count: 3) }
 
   context '#initialise' do

--- a/spec/models/ont/run_factory_spec.rb
+++ b/spec/models/ont/run_factory_spec.rb
@@ -1,0 +1,178 @@
+require 'rails_helper'
+
+RSpec.describe Ont::RunFactory, type: :model, ont: true do
+  let!(:instrument_name) { 'test instrument name' }
+
+  before do
+    allow_any_instance_of(Pipelines::ConstantsAccessor).to receive(:instrument_name).and_return(instrument_name)
+  end
+
+  context '#initialise' do
+    it 'is invalid if run is invalid' do
+      errors = ActiveModel::Errors.new(Ont::Run.new)
+      errors.add('run', message: 'This is a test error')
+      allow_any_instance_of(Ont::Run).to receive(:valid?).and_return(false)
+      allow_any_instance_of(Ont::Run).to receive(:errors).and_return(errors)
+      factory = Ont::RunFactory.new([])
+      expect(factory).to_not be_valid
+    end
+
+    it 'is invalid if any flowcell is invalid' do
+      errors = ActiveModel::Errors.new(Ont::Flowcell.new)
+      errors.add('run', message: 'This is a test error')
+      allow_any_instance_of(Ont::Flowcell).to receive(:valid?).and_return(false)
+      allow_any_instance_of(Ont::Flowcell).to receive(:errors).and_return(errors)
+      factory = Ont::RunFactory.new(['PLATE-2-1234-2'])
+      expect(factory).to_not be_valid
+    end
+  end
+
+  context '#save' do
+    context 'valid build' do
+      context 'with no library names' do
+        it 'creates a run' do
+          factory = Ont::RunFactory.new([])
+          factory.save
+          expect(Ont::Run.count).to eq(1)
+          expect(Ont::Run.first.instrument_name).to eq(instrument_name)
+        end
+
+        it 'creates no flowcells' do
+          factory = Ont::RunFactory.new([])
+          factory.save
+          expect(Ont::Flowcell.count).to eq(0)
+        end
+
+        context 'validates' do
+          let!(:run) { create(:ont_run) }
+          let!(:flowcell) { create(:ont_flowcell) }
+
+          it 'the run exactly once' do
+            allow(Ont::Run).to receive(:new).and_return(run)
+            expect(run).to receive(:valid?).exactly(1)
+            factory = Ont::RunFactory.new([])
+            factory.save
+          end
+
+          it 'no flowcells' do
+            allow(Ont::Flowcell).to receive(:new).and_return(flowcell)
+            expect(flowcell).to receive(:valid?).exactly(0)
+            factory = Ont::RunFactory.new([])
+            factory.save
+          end
+        end
+
+        context 'without validation' do
+          let!(:run) { create(:ont_run) }
+          let!(:flowcell) { create(:ont_flowcell) }
+
+          it 'does not validate created run' do
+            allow(Ont::Run).to receive(:new).and_return(run)
+            expect(run).to_not receive(:valid?)
+            factory = Ont::RunFactory.new([])
+            factory.save(validate: false)
+          end
+
+          it 'does not validate any flowcells' do
+            allow(Ont::Flowcell).to receive(:new).and_return(flowcell)
+            expect(flowcell).to_not receive(:valid?)
+            factory = Ont::RunFactory.new([])
+            factory.save(validate: false)
+          end
+        end
+      end
+      
+      context 'with library names' do
+        let!(:libraries) { create_list(:ont_library, 3).each_with_index do |library, idx|
+          library.update(name: "library number #{idx + 1}")
+        end }
+        let!(:library_names) { libraries.collect(&:name) }
+
+        it 'creates a run' do
+          factory = Ont::RunFactory.new(library_names)
+          factory.save
+          expect(Ont::Run.count).to eq(1)
+          expect(Ont::Run.first.instrument_name).to eq(instrument_name)
+        end
+
+        it 'creates expected flowcells' do
+          factory = Ont::RunFactory.new(library_names)
+          factory.save
+          expect(Ont::Flowcell.count).to eq(3)
+          expect(Ont::Flowcell.all.map { |flowcell| flowcell.run }).to all( eq(Ont::Run.first) )
+
+          expect(Ont::Flowcell.first.position).to eq(1)
+          expect(Ont::Flowcell.first.library).to eq(Ont::Library.find_by(name: library_names.first))
+          expect(Ont::Flowcell.second.position).to eq(2)
+          expect(Ont::Flowcell.second.library).to eq(Ont::Library.find_by(name: library_names.second))
+          expect(Ont::Flowcell.third.position).to eq(3)
+          expect(Ont::Flowcell.third.library).to eq(Ont::Library.find_by(name: library_names.third))
+        end
+
+        context 'validates' do
+          let!(:run) { create(:ont_run) }
+          let!(:flowcell) { create(:ont_flowcell) }
+
+          it 'the run exactly once' do
+            allow(Ont::Run).to receive(:new).and_return(run)
+            expect(run).to receive(:valid?).exactly(1)
+            factory = Ont::RunFactory.new(library_names)
+            factory.save
+          end
+
+          it 'each flowcell exactly once' do
+            allow(Ont::Flowcell).to receive(:new).and_return(flowcell)
+            expect(flowcell).to receive(:valid?).exactly(3)
+            factory = Ont::RunFactory.new(library_names)
+            factory.save
+          end
+        end
+
+        context 'without validation' do
+          let!(:run) { create(:ont_run) }
+          let!(:flowcell) { create(:ont_flowcell) }
+
+          it 'does not validate created run' do
+            allow(Ont::Run).to receive(:new).and_return(run)
+            expect(run).to_not receive(:valid?)
+            factory = Ont::RunFactory.new(library_names)
+            factory.save(validate: false)
+          end
+
+          it 'does not validate any flowcells' do
+            allow(Ont::Flowcell).to receive(:new).and_return(flowcell)
+            expect(flowcell).to_not receive(:valid?)
+            factory = Ont::RunFactory.new(library_names)
+            factory.save(validate: false)
+          end
+        end
+      end
+    end
+
+    context 'invalid build' do
+      before do
+        errors = ActiveModel::Errors.new(Ont::Run.new)
+        errors.add('run', message: 'This is a test error')
+        allow_any_instance_of(Ont::Run).to receive(:valid?).and_return(false)
+        allow_any_instance_of(Ont::Run).to receive(:errors).and_return(errors)
+      end
+
+      it 'returns false on save' do
+        factory = Ont::RunFactory.new([])
+        expect(factory.save).to be_falsey
+      end
+
+      it 'does not create any runs' do
+        factory = Ont::RunFactory.new([])
+        factory.save
+        expect(Ont::Run.count).to eq(0)
+      end
+  
+      it 'does not create any flowcells' do
+        factory = Ont::RunFactory.new([])
+        factory.save
+        expect(Ont::Flowcell.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/pipelines/constants_accessor_spec.rb
+++ b/spec/pipelines/constants_accessor_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Pipelines::ConstantsAccessor, type: :model do
           def species
             'test species'
           end
+
+          def instrument_name
+            'test instrument name'
+          end
         end.new
       )
     }
@@ -22,6 +26,10 @@ RSpec.describe Pipelines::ConstantsAccessor, type: :model do
 
     it 'will return the species' do
       expect(constants_accessor.species).to eq('test species')
+    end
+
+    it 'will return the instrument name' do
+      expect(constants_accessor.instrument_name).to eq('test instrument name')
     end
   end
 end


### PR DESCRIPTION
Changes proposed in this pull request:

* Add the run factory
* Ensure it only validates it's created entities once, and validation can be skipped altogether
