### PR TITLE
Config request tag set name

### DIFF
--- a/app/models/ont/request_factory.rb
+++ b/app/models/ont/request_factory.rb
@@ -36,7 +36,8 @@ module Ont
     attr_reader :tag_taggable, :well, :well_request_join
 
     def build_request(request_attributes)
-      tag_set_id = TagSet.find_by(name: 'OntWell96Samples')
+      constants_accessor = Pipelines::ConstantsAccessor.new(Pipelines.ont.covid)
+      tag_set_id = TagSet.find_by(name: constants_accessor.pcr_tag_set_name)
       tag = ::Tag.find_by(tag_set_id: tag_set_id, oligo: request_attributes[:tag_oligo])
       @ont_request = Ont::Request.new(external_id: request_attributes[:external_id],
                                       name: request_attributes[:name])

--- a/app/models/ont/request_factory.rb
+++ b/app/models/ont/request_factory.rb
@@ -42,7 +42,11 @@ module Ont
       @ont_request = Ont::Request.new(external_id: request_attributes[:external_id],
                                       name: request_attributes[:name])
       @tag_taggable = ::TagTaggable.new(taggable: ont_request, tag: tag)
-      @well_request_join = ::ContainerMaterial.new(container: well, material: ont_request)
+      add_to_well(ont_request)
+    end
+
+    def add_to_well(material)
+      @well_request_join = ::ContainerMaterial.new(container: well, material: material)
     end
 
     def check_ont_request

--- a/app/pipelines/pipelines/constants_accessor.rb
+++ b/app/pipelines/pipelines/constants_accessor.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Pipelines
+  # An accessor for constant values in the pipeline for configuration options
+  class ConstantsAccessor
+    def initialize(base)
+      @constants_base = base
+    end
+
+    def external_study_id
+      @constants_base.external_study_id
+    end
+
+    def species
+      @constants_base.species
+    end
+  end
+end

--- a/app/pipelines/pipelines/constants_accessor.rb
+++ b/app/pipelines/pipelines/constants_accessor.rb
@@ -7,12 +7,8 @@ module Pipelines
       @constants_base = base
     end
 
-    def external_study_id
-      @constants_base.external_study_id
-    end
-
-    def species
-      @constants_base.species
+    def pcr_tag_set_name
+      @constants_base.pcr_tag_set_name
     end
   end
 end

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -180,6 +180,9 @@ default: &default
           type: :model
           value: request.sample_name
           populate_on_row_type: :sample
+  ont:
+    covid:
+      pcr_tag_set_name: "OntWell96Samples"
 
 
 development:

--- a/spec/models/ont/request_factory_spec.rb
+++ b/spec/models/ont/request_factory_spec.rb
@@ -2,7 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Ont::RequestFactory, type: :model, ont: true do
   let(:well) { create(:well) }
-  let(:tag_set) { create(:tag_set_with_tags, name: 'OntWell96Samples') }
+  let(:tag_set_name) { 'OntWell96Samples' }
+  let(:tag_set) { create(:tag_set_with_tags, name: tag_set_name) }
+
+  before do
+    allow_any_instance_of(Pipelines::ConstantsAccessor).to receive(:pcr_tag_set_name).and_return(tag_set_name)
+  end
 
   context '#initialise' do
     it 'is not valid if given no well' do

--- a/spec/pipelines/constants_accessor_spec.rb
+++ b/spec/pipelines/constants_accessor_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Pipelines::ConstantsAccessor, type: :model do
+  context 'when base constants are defined' do
+    let(:constants_accessor) {
+      Pipelines::ConstantsAccessor.new(
+        Class.new do
+          def external_study_id
+            'test study id'
+          end
+
+          def species
+            'test species'
+          end
+        end.new
+      )
+    }
+
+    it 'will return the external study id' do
+      expect(constants_accessor.external_study_id).to eq('test study id')
+    end
+
+    it 'will return the species' do
+      expect(constants_accessor.species).to eq('test species')
+    end
+  end
+end

--- a/spec/pipelines/constants_accessor_spec.rb
+++ b/spec/pipelines/constants_accessor_spec.rb
@@ -5,23 +5,15 @@ RSpec.describe Pipelines::ConstantsAccessor, type: :model do
     let(:constants_accessor) {
       Pipelines::ConstantsAccessor.new(
         Class.new do
-          def external_study_id
-            'test study id'
-          end
-
-          def species
-            'test species'
+          def pcr_tag_set_name
+            'test tag set name'
           end
         end.new
       )
     }
 
-    it 'will return the external study id' do
-      expect(constants_accessor.external_study_id).to eq('test study id')
-    end
-
-    it 'will return the species' do
-      expect(constants_accessor.species).to eq('test species')
+    it 'will return the pcr tag set name' do
+      expect(constants_accessor.pcr_tag_set_name).to eq('test tag set name')
     end
   end
 end


### PR DESCRIPTION
Changes proposed in this pull request:

* Re-add the constants accessor
* Allow getting the Covid sample pcr_tag_set_name from the constants
