### PR TITLE
Library name uniqueness

### DIFF
--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -9,6 +9,8 @@ module Ont
                         inverse_of: :library, dependent: :nullify
 
     validates :name, :pool, :pool_size, presence: true
+    validates :name, uniqueness: { case_sensitive: false,
+                                   message: 'must be unique: a pool already exists for this plate' }
 
     def self.library_name(plate_barcode, pool)
       return nil if plate_barcode.nil? || pool.nil?

--- a/spec/factories/ont/libraries.rb
+++ b/spec/factories/ont/libraries.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :ont_library, class: 'Ont::Library' do
-    name { "PLATE-1-123456-2" }
-    pool { 2 }
+    sequence(:pool) { |n| n }
+    name { "PLATE-1-123456-#{pool}" }
     pool_size { 24 }
     
     factory :ont_library_in_tube do

--- a/spec/models/ont/library_spec.rb
+++ b/spec/models/ont/library_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Ont::Library, type: :model do
     expect(library).to_not be_valid
   end
 
+  it 'name must be unique' do
+    library = create(:ont_library)
+    new_library = build(:ont_library, name: library.name)
+    expect(new_library).to_not be_valid
+    expect(new_library.errors.full_messages).to contain_exactly('Name must be unique: a pool already exists for this plate')
+  end
+
   context 'library name' do
     it 'returns nil with nil plate_barcode' do
       name = Ont::Library.library_name(nil, 2)

--- a/spec/requests/v2/ont/libraries_spec.rb
+++ b/spec/requests/v2/ont/libraries_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe 'GraphQL', type: :request do
     end
 
     it 'returns single library when one exists' do
-      create(:ont_library)
+      library = create(:ont_library)
       allow_any_instance_of(Ont::Library).to receive(:tube_barcode).and_return('test tube barcode')
       post v2_path, params: { query: '{ ontLibraries { name plateBarcode pool poolSize tubeBarcode } }' }
       expect(response).to have_http_status(:success)
       json = ActiveSupport::JSON.decode(response.body)
       expect(json['data']['ontLibraries']).to contain_exactly(
-        { 'name' => 'PLATE-1-123456-2', 'plateBarcode' => 'PLATE-1-123456', 'pool' => 2,
+        { 'name' => library.name, 'plateBarcode' => library.plate_barcode, 'pool' => library.pool,
           'poolSize' => 24, 'tubeBarcode' => 'test tube barcode'})
     end
 
@@ -51,7 +51,7 @@ RSpec.describe 'GraphQL', type: :request do
     end
 
     it 'creates tubes with libraries with provided parameters' do
-      libraries = create(:ont_library_in_tube)
+      library = create(:ont_library_in_tube)
 
       allow_any_instance_of(Ont::LibraryFactory).to receive(:save).and_return(true)
       allow_any_instance_of(Ont::LibraryFactory).to receive(:tube).and_return(Tube.first)
@@ -65,7 +65,7 @@ RSpec.describe 'GraphQL', type: :request do
 
       expect(tubes_json[0]['barcode']).to be_present
       expect(tubes_json[0]['materials']).to contain_exactly(
-        { 'name' => 'PLATE-1-123456-2', 'pool' => 2, 'poolSize' => 24 }
+        { 'name' => library.name, 'pool' => library.pool, 'poolSize' => 24 }
       )
 
       expect(mutation_json['errors']).to be_empty


### PR DESCRIPTION
Changes proposed in this pull request:

* Add a uniqueness to library names
* With the current implementation ensures that only one library can exist from the pooling of a single plate
