### PR TITLE
Modify ont rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To create pacbio dummy runs: `bundle exec rails pacbio_runs:create`
 
 To create saphyr dummy runs: `bundle exec rails saphyr_runs:create`
 
-To create ont dummy runs: `bundle exec rails ont_runs:create`
+To create ont dummy data: `bundle exec rails ont_data:create`
 
 ## Database drop
 

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -182,7 +182,7 @@ default: &default
           populate_on_row_type: :sample
   ont:
     covid:
-      pcr_tag_set_name: "OntWell96Samples"
+      pcr_tag_set_name: "ONT_EXP-PBC096"
       message:
         lims: *lims
         key: oseq_flowcell

--- a/lib/tasks/ont_data.rake
+++ b/lib/tasks/ont_data.rake
@@ -75,7 +75,7 @@ def create_number_of_plates(count, plate_no)
   variables = OntPlates::Variables.new
   constants_accessor = Pipelines::ConstantsAccessor.new(Pipelines.ont.covid)
 
-  plate_no.upto(plate_no+count-1).collect do |i|
+  plate_no.upto(plate_no + count - 1).collect do |i|
     create_plate(i, variables, constants_accessor)
   end
 end


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* modify rake task for creating ont runs so that you can create plates and libraries to make it easier to test with the ui
* added a count so you can specify the number of plates and runs you would like to create
* modified so that you can rerun it without getting any errors. It will take the last plate and set the barcode based on that.
* rubocopped so split up the task a bit.
