### PR TITLE
Improve run lookup performance

### DIFF
--- a/app/graphql/mutations/base_covid_run_mutation.rb
+++ b/app/graphql/mutations/base_covid_run_mutation.rb
@@ -6,7 +6,9 @@ module Mutations
     protected
 
     def send_messages(run:)
-      Messages.publish(run, Pipelines.ont.message)
+      resolved_run = Ont::Run.includes(flowcells: { library: { requests: { tags: :tag_set } } })
+                             .find_by(id: run.id)
+      Messages.publish(resolved_run, Pipelines.ont.message)
     end
   end
 end

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -181,7 +181,7 @@ default: &default
           value: request.sample_name
           populate_on_row_type: :sample
   ont:
-    message: &ont_covid_message
+    message:
       lims: *lims
       key: oseq_flowcell_run
       fields:


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* Very significantly improve the performance of lookups of the run.  Turns thousands of database requests for message preparation into only 7 requests.
  * The run by ID
  * The associated flowcells for the run
  * The associated libraries for the flowcells
  * The associated requests for the libraries
  * The associated tag_taggables for the requests
  * The associated tags for the tag_taggables
  * The associated tag set for the tags