### PR TITLE
Gpl 445 performance improvements

### DIFF
--- a/app/graphql/mutations/base_covid_run_mutation.rb
+++ b/app/graphql/mutations/base_covid_run_mutation.rb
@@ -5,8 +5,8 @@ module Mutations
   class BaseCovidRunMutation < BaseMutation
     protected
 
-    def send_messages(run:)
-      Messages.publish(Ont::Run.resolved_query.find_by(id: run.id), Pipelines.ont.message)
+    def send_messages(resolved_run:)
+      Messages.publish(resolved_run, Pipelines.ont.message)
     end
   end
 end

--- a/app/graphql/mutations/base_covid_run_mutation.rb
+++ b/app/graphql/mutations/base_covid_run_mutation.rb
@@ -6,7 +6,7 @@ module Mutations
     protected
 
     def send_messages(run:)
-      Messages.publish(run.resolved_run, Pipelines.ont.message)
+      Messages.publish(Ont::Run.resolved_query.find_by(id: run.id), Pipelines.ont.message)
     end
   end
 end

--- a/app/graphql/mutations/base_covid_run_mutation.rb
+++ b/app/graphql/mutations/base_covid_run_mutation.rb
@@ -6,9 +6,7 @@ module Mutations
     protected
 
     def send_messages(run:)
-      resolved_run = Ont::Run.includes(flowcells: { library: { requests: { tags: :tag_set } } })
-                             .find_by(id: run.id)
-      Messages.publish(resolved_run, Pipelines.ont.message)
+      Messages.publish(run.resolved_run, Pipelines.ont.message)
     end
   end
 end

--- a/app/graphql/mutations/create_covid_libraries_mutation.rb
+++ b/app/graphql/mutations/create_covid_libraries_mutation.rb
@@ -16,7 +16,8 @@ module Mutations
       factory = Ont::LibraryFactory.new(arguments.to_h)
 
       if factory.save
-        { tubes: [factory.tube], errors: [] }
+        resolved_tube = Tube.resolved_query.find_by(id: factory.tube.id)
+        { tubes: [resolved_tube], errors: [] }
       else
         { tubes: nil, errors: factory.errors.full_messages }
       end

--- a/app/graphql/mutations/create_covid_run_mutation.rb
+++ b/app/graphql/mutations/create_covid_run_mutation.rb
@@ -15,8 +15,9 @@ module Mutations
       factory = Ont::RunFactory.new(flowcells.to_a)
 
       if factory.save
-        send_messages(run: factory.run)
-        { run: factory.run, errors: [] }
+        resolved_run = Ont::Run.resolved_query.find_by(id: factory.run.id)
+        send_messages(resolved_run: resolved_run)
+        { run: resolved_run, errors: [] }
       else
         { run: nil, errors: factory.errors.full_messages }
       end

--- a/app/graphql/mutations/create_plate_with_covid_samples_mutation.rb
+++ b/app/graphql/mutations/create_plate_with_covid_samples_mutation.rb
@@ -16,7 +16,8 @@ module Mutations
       factory = Ont::PlateFactory.new(arguments.to_h)
 
       if factory.save
-        { plate: factory.plate, errors: [] }
+        resolved_plate = Plate.resolved_query.find_by(id: factory.plate.id)
+        { plate: resolved_plate, errors: [] }
       else
         { plate: nil, errors: factory.errors.full_messages }
       end

--- a/app/graphql/mutations/update_covid_run_mutation.rb
+++ b/app/graphql/mutations/update_covid_run_mutation.rb
@@ -21,13 +21,11 @@ module Mutations
       errors = update_run_flowcells(run, properties.flowcells)
       run_was_updated ||= errors.nil?
 
-      if errors&.any?
-        { run: nil, errors: errors }
-      else
-        resolved_run = Ont::Run.resolved_query.find_by(id: run.id)
-        send_messages(resolved_run: resolved_run) if run_was_updated
-        { run: resolved_run, errors: [] }
-      end
+      return { run: nil, errors: errors } if errors&.any?
+
+      resolved_run = Ont::Run.resolved_query.find_by(id: run.id)
+      send_messages(resolved_run: resolved_run) if run_was_updated
+      { run: resolved_run, errors: [] }
     end
 
     private

--- a/app/graphql/mutations/update_covid_run_mutation.rb
+++ b/app/graphql/mutations/update_covid_run_mutation.rb
@@ -24,8 +24,9 @@ module Mutations
       if errors&.any?
         { run: nil, errors: errors }
       else
-        send_messages(run: run) if run_was_updated
-        { run: run, errors: [] }
+        resolved_run = Ont::Run.resolved_query.find_by(id: run.id)
+        send_messages(resolved_run: resolved_run) if run_was_updated
+        { run: resolved_run, errors: [] }
       end
     end
 

--- a/app/graphql/types/query_types.rb
+++ b/app/graphql/types/query_types.rb
@@ -32,7 +32,7 @@ module Types
     field :plates, [Types::Outputs::PlateType], 'Find all Plates.', null: false
 
     def plates
-      Plate.all
+      Plate.all_resolved_plates
     end
 
     # Ont::Libraries

--- a/app/graphql/types/query_types.rb
+++ b/app/graphql/types/query_types.rb
@@ -12,7 +12,7 @@ module Types
     def well(id:)
       return nil unless Well.exists?(id)
 
-      Well.find(id)
+      Well.resolved_well(id: id)
     end
 
     field :wells, [Types::Outputs::WellType], 'Find all Wells.', null: false do
@@ -21,9 +21,9 @@ module Types
 
     def wells(plate_id: nil)
       if plate_id.nil?
-        Well.all
+        Well.all_resolved_wells
       else
-        Well.where(plate_id: plate_id)
+        Well.includes(Well.includes_args).where(plate_id: plate_id)
       end
     end
 

--- a/app/graphql/types/query_types.rb
+++ b/app/graphql/types/query_types.rb
@@ -46,7 +46,7 @@ module Types
 
     def ont_libraries(unassigned_to_flowcells: false)
       if unassigned_to_flowcells
-        Ont::Library.includes(Ont::Library.includes_hash)
+        Ont::Library.includes(Ont::Library.includes_args)
                     .left_outer_joins(:flowcell).where(ont_flowcells: { id: nil })
       else
         Ont::Library.all_resolved_libraries

--- a/app/graphql/types/query_types.rb
+++ b/app/graphql/types/query_types.rb
@@ -46,7 +46,8 @@ module Types
 
     def ont_libraries(unassigned_to_flowcells: false)
       if unassigned_to_flowcells
-        Ont::Library.includes(Ont::Library.includes_hash).left_outer_joins(:flowcell).where(ont_flowcells: { id: nil })
+        Ont::Library.includes(Ont::Library.includes_hash)
+                    .left_outer_joins(:flowcell).where(ont_flowcells: { id: nil })
       else
         Ont::Library.all_resolved_libraries
       end

--- a/app/graphql/types/query_types.rb
+++ b/app/graphql/types/query_types.rb
@@ -10,9 +10,7 @@ module Types
     end
 
     def well(id:)
-      return nil unless Well.exists?(id)
-
-      Well.resolved_well(id: id)
+      Well.resolved_query.find_by(id: id)
     end
 
     field :wells, [Types::Outputs::WellType], 'Find all Wells.', null: false do
@@ -21,9 +19,9 @@ module Types
 
     def wells(plate_id: nil)
       if plate_id.nil?
-        Well.all_resolved_wells
+        Well.resolved_query.all
       else
-        Well.includes(Well.includes_args).where(plate_id: plate_id)
+        Well.resolved_query.where(plate_id: plate_id)
       end
     end
 
@@ -32,7 +30,7 @@ module Types
     field :plates, [Types::Outputs::PlateType], 'Find all Plates.', null: false
 
     def plates
-      Plate.all_resolved_plates
+      Plate.resolved_query.all
     end
 
     # Ont::Libraries
@@ -46,10 +44,9 @@ module Types
 
     def ont_libraries(unassigned_to_flowcells: false)
       if unassigned_to_flowcells
-        Ont::Library.includes(Ont::Library.includes_args)
-                    .left_outer_joins(:flowcell).where(ont_flowcells: { id: nil })
+        Ont::Library.resolved_query.left_outer_joins(:flowcell).where(ont_flowcells: { id: nil })
       else
-        Ont::Library.all_resolved_libraries
+        Ont::Library.resolved_query.all
       end
     end
 
@@ -62,13 +59,13 @@ module Types
     def ont_run(id:)
       return nil unless Ont::Run.exists?(id)
 
-      Ont::Run.resolved_run(id: id)
+      Ont::Run.resolved_query.find_by(id: id)
     end
 
     field :ont_runs, [Types::Outputs::Ont::RunType], 'Find all Ont Runs.', null: false
 
     def ont_runs
-      Ont::Run.all_resolved_runs
+      Ont::Run.resolved_query.all
     end
   end
 end

--- a/app/graphql/types/query_types.rb
+++ b/app/graphql/types/query_types.rb
@@ -46,9 +46,9 @@ module Types
 
     def ont_libraries(unassigned_to_flowcells: false)
       if unassigned_to_flowcells
-        Ont::Library.left_outer_joins(:flowcell).where(ont_flowcells: { id: nil })
+        Ont::Library.includes(Ont::Library.includes_hash).left_outer_joins(:flowcell).where(ont_flowcells: { id: nil })
       else
-        Ont::Library.all
+        Ont::Library.all_resolved_libraries
       end
     end
 

--- a/app/graphql/types/query_types.rb
+++ b/app/graphql/types/query_types.rb
@@ -61,13 +61,13 @@ module Types
     def ont_run(id:)
       return nil unless Ont::Run.exists?(id)
 
-      Ont::Run.find(id)
+      Ont::Run.resolved_run(id: id)
     end
 
     field :ont_runs, [Types::Outputs::Ont::RunType], 'Find all Ont Runs.', null: false
 
     def ont_runs
-      Ont::Run.all
+      Ont::Run.all_resolved_runs
     end
   end
 end

--- a/app/models/container_material.rb
+++ b/app/models/container_material.rb
@@ -9,12 +9,10 @@ class ContainerMaterial < ApplicationRecord
   belongs_to :material, polymorphic: true
 
   def self.includes_args(except = nil)
-    if except == :container
-      [:material]
-    elsif except == :material
-      [:container]
-    else
-      %i[container material]
-    end
+    args = []
+    args << :material unless except == :material
+    args << :container unless except == :container
+
+    args
   end
 end

--- a/app/models/container_material.rb
+++ b/app/models/container_material.rb
@@ -14,7 +14,7 @@ class ContainerMaterial < ApplicationRecord
     elsif except == :material
       [:container]
     else
-      [:container, :material]
+      %i[container material]
     end
   end
 end

--- a/app/models/container_material.rb
+++ b/app/models/container_material.rb
@@ -7,4 +7,14 @@
 class ContainerMaterial < ApplicationRecord
   belongs_to :container, polymorphic: true
   belongs_to :material, polymorphic: true
+
+  def self.includes_args(except = nil)
+    if except == :container
+      [:material]
+    elsif except == :material
+      [:container]
+    else
+      [:container, :material]
+    end
+  end
 end

--- a/app/models/ont/flowcell.rb
+++ b/app/models/ont/flowcell.rb
@@ -13,5 +13,9 @@ module Ont
               presence: true,
               uniqueness: { scope: :ont_run_id,
                             message: 'should only appear once within run' }
+
+    def self.includes_hash
+      { library: { requests: { tags: :tag_set } } }
+    end
   end
 end

--- a/app/models/ont/flowcell.rb
+++ b/app/models/ont/flowcell.rb
@@ -14,13 +14,13 @@ module Ont
               uniqueness: { scope: :ont_run_id,
                             message: 'should only appear once within run' }
 
-    def self.includes_args(*except_keys)
-      if except_keys.include?(:run)
-        [ library: Ont::Library.includes_args(:flowcell) ]
-      elsif except_keys.include?(:library)
-        [ run: Ont::Run.includes_args(:flowcells) ]
+    def self.includes_args(except: except)
+      if except == :run
+        [ library: Ont::Library.includes_args(except: :flowcell) ]
+      elsif except == :library
+        [ run: Ont::Run.includes_args(except: :flowcells) ]
       else
-        [ library: Ont::Library.includes_args(:flowcell), run: Ont::Run.includes_args(:flowcells) ]
+        [ library: Ont::Library.includes_args(except: :flowcell), run: Ont::Run.includes_args(except: :flowcells) ]
       end
     end
   end

--- a/app/models/ont/flowcell.rb
+++ b/app/models/ont/flowcell.rb
@@ -14,8 +14,15 @@ module Ont
               uniqueness: { scope: :ont_run_id,
                             message: 'should only appear once within run' }
 
-    def self.includes_hash
-      { library: { requests: { tags: :tag_set } } }
+    def self.includes_hash(*except_keys)
+      if except_keys.include?(:run)
+        { library: Ont::Library.includes_hash(:flowcell) }
+      elsif except_keys.include?(:library)
+        { run: Ont::Run.includes_hash(:flowcells) }
+      else
+        { library: Ont::Library.includes_hash(:flowcell),
+          run: Ont::Run.includes_hash(:flowcells) }
+      end
     end
   end
 end

--- a/app/models/ont/flowcell.rb
+++ b/app/models/ont/flowcell.rb
@@ -14,13 +14,13 @@ module Ont
               uniqueness: { scope: :ont_run_id,
                             message: 'should only appear once within run' }
 
-    def self.includes_args(except: except)
+    def self.includes_args(except = nil)
       if except == :run
-        [ library: Ont::Library.includes_args(except: :flowcell) ]
+        [ library: Ont::Library.includes_args(:flowcell) ]
       elsif except == :library
-        [ run: Ont::Run.includes_args(except: :flowcells) ]
+        [ run: Ont::Run.includes_args(:flowcells) ]
       else
-        [ library: Ont::Library.includes_args(except: :flowcell), run: Ont::Run.includes_args(except: :flowcells) ]
+        [ library: Ont::Library.includes_args(:flowcell), run: Ont::Run.includes_args(:flowcells) ]
       end
     end
   end

--- a/app/models/ont/flowcell.rb
+++ b/app/models/ont/flowcell.rb
@@ -14,14 +14,13 @@ module Ont
               uniqueness: { scope: :ont_run_id,
                             message: 'should only appear once within run' }
 
-    def self.includes_hash(*except_keys)
+    def self.includes_args(*except_keys)
       if except_keys.include?(:run)
-        { library: Ont::Library.includes_hash(:flowcell) }
+        [ library: Ont::Library.includes_args(:flowcell) ]
       elsif except_keys.include?(:library)
-        { run: Ont::Run.includes_hash(:flowcells) }
+        [ run: Ont::Run.includes_args(:flowcells) ]
       else
-        { library: Ont::Library.includes_hash(:flowcell),
-          run: Ont::Run.includes_hash(:flowcells) }
+        [ library: Ont::Library.includes_args(:flowcell), run: Ont::Run.includes_args(:flowcells) ]
       end
     end
   end

--- a/app/models/ont/flowcell.rb
+++ b/app/models/ont/flowcell.rb
@@ -16,11 +16,11 @@ module Ont
 
     def self.includes_args(except = nil)
       if except == :run
-        [ library: Ont::Library.includes_args(:flowcell) ]
+        [library: Ont::Library.includes_args(:flowcell)]
       elsif except == :library
-        [ run: Ont::Run.includes_args(:flowcells) ]
+        [run: Ont::Run.includes_args(:flowcells)]
       else
-        [ library: Ont::Library.includes_args(:flowcell), run: Ont::Run.includes_args(:flowcells) ]
+        [library: Ont::Library.includes_args(:flowcell), run: Ont::Run.includes_args(:flowcells)]
       end
     end
   end

--- a/app/models/ont/flowcell.rb
+++ b/app/models/ont/flowcell.rb
@@ -15,13 +15,11 @@ module Ont
                             message: 'should only appear once within run' }
 
     def self.includes_args(except = nil)
-      if except == :run
-        [library: Ont::Library.includes_args(:flowcell)]
-      elsif except == :library
-        [run: Ont::Run.includes_args(:flowcells)]
-      else
-        [library: Ont::Library.includes_args(:flowcell), run: Ont::Run.includes_args(:flowcells)]
-      end
+      args = []
+      args << { library: Ont::Library.includes_args(:flowcell) } unless except == :library
+      args << { run: Ont::Run.includes_args(:flowcells) } unless except == :run
+
+      args
     end
   end
 end

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -29,10 +29,6 @@ module Ont
       container_material.container.barcode
     end
 
-    def resolved_library
-      self.class.resolved_query.find(id)
-    end
-
     def self.includes_args(except = nil)
       args = []
       args << { flowcell: Ont::Flowcell.includes_args(:library) } unless except == :flowcell

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -34,22 +34,11 @@ module Ont
     end
 
     def self.includes_args(except = nil)
-      if except == :requests
-        [flowcell: Ont::Flowcell.includes_args(:library)]
-      elsif except == :flowcell
-        [requests: Ont::Request.includes_args(:library)]
-      else
-        [flowcell: Ont::Flowcell.includes_args(:library),
-         requests: Ont::Request.includes_args(:library)]
-      end
-    end
+      args = []
+      args << { flowcell: Ont::Flowcell.includes_args(:library) } unless except == :flowcell
+      args << { requests: Ont::Request.includes_args(:library) } unless except == :requests
 
-    def self.resolved_library(id:)
-      resolved_query.find(id)
-    end
-
-    def self.all_resolved_libraries
-      resolved_query.all
+      args
     end
 
     def self.resolved_query

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -33,13 +33,13 @@ module Ont
       self.class.resolved_query.find(id)
     end
 
-    def self.includes_args(*except_keys)
-      if except_keys.include?(:requests)
-        [ flowcell: Ont::Flowcell.includes_args(:library) ]
-      elsif except_keys.include?(:flowcell)
+    def self.includes_args(except: except)
+      if except == :requests
+        [ flowcell: Ont::Flowcell.includes_args(except: :library) ]
+      elsif except == :flowcell
         [ requests: { tags: :tag_set } ]
       else
-        [ flowcell: Ont::Flowcell.includes_args(:library), requests: { tags: :tag_set } ]
+        [ flowcell: Ont::Flowcell.includes_args(except: :library), requests: { tags: :tag_set } ]
       end
     end
 

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -33,13 +33,13 @@ module Ont
       self.class.resolved_query.find(id)
     end
 
-    def self.includes_args(except: except)
+    def self.includes_args(except = nil)
       if except == :requests
-        [ flowcell: Ont::Flowcell.includes_args(except: :library) ]
+        [ flowcell: Ont::Flowcell.includes_args(:library) ]
       elsif except == :flowcell
-        [ requests: Ont::Request.includes_args(except: :library) ]
+        [ requests: Ont::Request.includes_args(:library) ]
       else
-        [ flowcell: Ont::Flowcell.includes_args(except: :library), requests: Ont::Request.includes_args(except: :library) ]
+        [ flowcell: Ont::Flowcell.includes_args(:library), requests: Ont::Request.includes_args(:library) ]
       end
     end
 

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -35,11 +35,12 @@ module Ont
 
     def self.includes_args(except = nil)
       if except == :requests
-        [ flowcell: Ont::Flowcell.includes_args(:library) ]
+        [flowcell: Ont::Flowcell.includes_args(:library)]
       elsif except == :flowcell
-        [ requests: Ont::Request.includes_args(:library) ]
+        [requests: Ont::Request.includes_args(:library)]
       else
-        [ flowcell: Ont::Flowcell.includes_args(:library), requests: Ont::Request.includes_args(:library) ]
+        [flowcell: Ont::Flowcell.includes_args(:library),
+         requests: Ont::Request.includes_args(:library)]
       end
     end
 

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -37,9 +37,9 @@ module Ont
       if except == :requests
         [ flowcell: Ont::Flowcell.includes_args(except: :library) ]
       elsif except == :flowcell
-        [ requests: { tags: :tag_set } ]
+        [ requests: Ont::Request.includes_args(except: :library) ]
       else
-        [ flowcell: Ont::Flowcell.includes_args(except: :library), requests: { tags: :tag_set } ]
+        [ flowcell: Ont::Flowcell.includes_args(except: :library), requests: Ont::Request.includes_args(except: :library) ]
       end
     end
 

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -52,8 +52,6 @@ module Ont
       resolved_query.all
     end
 
-    private
-
     def self.resolved_query
       Ont::Library.includes(includes_hash)
     end

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -28,5 +28,34 @@ module Ont
 
       container_material.container.barcode
     end
+
+    def resolved_library
+      self.class.resolved_query.find(id)
+    end
+
+    def self.includes_hash(*except_keys)
+      if except_keys.include?(:requests)
+        { flowcell: Ont::Flowcell.includes_hash(:library) }
+      elsif except_keys.include?(:flowcell)
+        { requests: { tags: :tag_set } }
+      else
+        { flowcell: Ont::Flowcell.includes_hash(:library),
+          requests: { tags: :tag_set } }
+      end
+    end
+
+    def self.resolved_library(id:)
+      resolved_query.find(id)
+    end
+
+    def self.all_resolved_libraries
+      resolved_query.all
+    end
+
+    private
+
+    def self.resolved_query
+      Ont::Library.includes(includes_hash)
+    end
   end
 end

--- a/app/models/ont/library.rb
+++ b/app/models/ont/library.rb
@@ -33,14 +33,13 @@ module Ont
       self.class.resolved_query.find(id)
     end
 
-    def self.includes_hash(*except_keys)
+    def self.includes_args(*except_keys)
       if except_keys.include?(:requests)
-        { flowcell: Ont::Flowcell.includes_hash(:library) }
+        [ flowcell: Ont::Flowcell.includes_args(:library) ]
       elsif except_keys.include?(:flowcell)
-        { requests: { tags: :tag_set } }
+        [ requests: { tags: :tag_set } ]
       else
-        { flowcell: Ont::Flowcell.includes_hash(:library),
-          requests: { tags: :tag_set } }
+        [ flowcell: Ont::Flowcell.includes_args(:library), requests: { tags: :tag_set } ]
       end
     end
 
@@ -53,7 +52,7 @@ module Ont
     end
 
     def self.resolved_query
-      Ont::Library.includes(includes_hash)
+      Ont::Library.includes(*includes_args)
     end
   end
 end

--- a/app/models/ont/request.rb
+++ b/app/models/ont/request.rb
@@ -10,15 +10,15 @@ module Ont
                          dependent: :destroy, optional: true
     validates :name, :external_id, presence: true
 
-    def self.includes_args(except: except)
+    def self.includes_args(except = nil)
       if except == :container_material
-        [ library: Ont::Library.includes_args(except: :requests), tags: :tag_set ]
+        [ library: Ont::Library.includes_args(:requests), tags: :tag_set ]
       elsif except == :library
         [ container_material: :container, tags: :tag_set ]
       elsif except == :tags
-        [ container_material: :container, library: Ont::Library.includes_args(except: :requests) ]
+        [ container_material: :container, library: Ont::Library.includes_args(:requests) ]
       else
-        [ container_material: :container, library: Ont::Library.includes_args(except: :requests), tags: :tag_set ]
+        [ container_material: :container, library: Ont::Library.includes_args(:requests), tags: :tag_set ]
       end
     end
   end

--- a/app/models/ont/request.rb
+++ b/app/models/ont/request.rb
@@ -9,5 +9,17 @@ module Ont
     belongs_to :library, foreign_key: :ont_library_id, inverse_of: :requests,
                          dependent: :destroy, optional: true
     validates :name, :external_id, presence: true
+
+    def self.includes_args(except: except)
+      if except == :container_material
+        [ library: Ont::Library.includes_args(except: :requests), tags: :tag_set ]
+      elsif except == :library
+        [ container_material: :container, tags: :tag_set ]
+      elsif except == :tags
+        [ container_material: :container, library: Ont::Library.includes_args(except: :requests) ]
+      else
+        [ container_material: :container, library: Ont::Library.includes_args(except: :requests), tags: :tag_set ]
+      end
+    end
   end
 end

--- a/app/models/ont/request.rb
+++ b/app/models/ont/request.rb
@@ -11,18 +11,15 @@ module Ont
     validates :name, :external_id, presence: true
 
     def self.includes_args(except = nil)
-      if except == :container_material
-        [library: Ont::Library.includes_args(:requests), tags: Tag.includes_args]
-      elsif except == :library
-        [container_material: ContainerMaterial.includes_args(:material), tags: Tag.includes_args]
-      elsif except == :tags
-        [container_material: ContainerMaterial.includes_args(:material),
-         library: Ont::Library.includes_args(:requests)]
-      else
-        [container_material: ContainerMaterial.includes_args(:material),
-         library: Ont::Library.includes_args(:requests),
-         tags: Tag.includes_args]
+      args = []
+      args << { tags: Tag.includes_args } unless except == :tags
+      args << { library: Ont::Library.includes_args(:requests) } unless except == :library
+
+      unless except == :container_material
+        args << { container_material: ContainerMaterial.includes_args(:material) }
       end
+
+      args
     end
   end
 end

--- a/app/models/ont/request.rb
+++ b/app/models/ont/request.rb
@@ -12,13 +12,15 @@ module Ont
 
     def self.includes_args(except = nil)
       if except == :container_material
-        [ library: Ont::Library.includes_args(:requests), tags: :tag_set ]
+        [library: Ont::Library.includes_args(:requests), tags: :tag_set]
       elsif except == :library
-        [ container_material: :container, tags: :tag_set ]
+        [container_material: :container, tags: :tag_set]
       elsif except == :tags
-        [ container_material: :container, library: Ont::Library.includes_args(:requests) ]
+        [container_material: :container, library: Ont::Library.includes_args(:requests)]
       else
-        [ container_material: :container, library: Ont::Library.includes_args(:requests), tags: :tag_set ]
+        [container_material: :container,
+         library: Ont::Library.includes_args(:requests),
+         tags: :tag_set]
       end
     end
   end

--- a/app/models/ont/request.rb
+++ b/app/models/ont/request.rb
@@ -16,7 +16,8 @@ module Ont
       elsif except == :library
         [container_material: ContainerMaterial.includes_args(:material), tags: Tag.includes_args]
       elsif except == :tags
-        [container_material: ContainerMaterial.includes_args(:material), library: Ont::Library.includes_args(:requests)]
+        [container_material: ContainerMaterial.includes_args(:material),
+         library: Ont::Library.includes_args(:requests)]
       else
         [container_material: ContainerMaterial.includes_args(:material),
          library: Ont::Library.includes_args(:requests),

--- a/app/models/ont/request.rb
+++ b/app/models/ont/request.rb
@@ -14,11 +14,11 @@ module Ont
       if except == :container_material
         [library: Ont::Library.includes_args(:requests), tags: :tag_set]
       elsif except == :library
-        [container_material: :container, tags: :tag_set]
+        [container_material: ContainerMaterial.includes_args(:material), tags: :tag_set]
       elsif except == :tags
-        [container_material: :container, library: Ont::Library.includes_args(:requests)]
+        [container_material: ContainerMaterial.includes_args(:material), library: Ont::Library.includes_args(:requests)]
       else
-        [container_material: :container,
+        [container_material: ContainerMaterial.includes_args(:material),
          library: Ont::Library.includes_args(:requests),
          tags: :tag_set]
       end

--- a/app/models/ont/request.rb
+++ b/app/models/ont/request.rb
@@ -12,15 +12,15 @@ module Ont
 
     def self.includes_args(except = nil)
       if except == :container_material
-        [library: Ont::Library.includes_args(:requests), tags: :tag_set]
+        [library: Ont::Library.includes_args(:requests), tags: Tag.includes_args]
       elsif except == :library
-        [container_material: ContainerMaterial.includes_args(:material), tags: :tag_set]
+        [container_material: ContainerMaterial.includes_args(:material), tags: Tag.includes_args]
       elsif except == :tags
         [container_material: ContainerMaterial.includes_args(:material), library: Ont::Library.includes_args(:requests)]
       else
         [container_material: ContainerMaterial.includes_args(:material),
          library: Ont::Library.includes_args(:requests),
-         tags: :tag_set]
+         tags: Tag.includes_args]
       end
     end
   end

--- a/app/models/ont/run.rb
+++ b/app/models/ont/run.rb
@@ -22,5 +22,23 @@ module Ont
     def experiment_name
       "ONTRUN-#{id}"
     end
+
+    def resolved_run
+      self.class.resolved_query.find(id)
+    end
+
+    def self.resolved_run(id:)
+      resolved_query.find(id)
+    end
+
+    def self.all_resolved_runs
+      resolved_query.all
+    end
+
+    private
+
+    def self.resolved_query
+      Ont::Run.includes(flowcells: { library: { requests: { tags: :tag_set } } })
+    end
   end
 end

--- a/app/models/ont/run.rb
+++ b/app/models/ont/run.rb
@@ -38,7 +38,7 @@ module Ont
     private
 
     def self.resolved_query
-      Ont::Run.includes(flowcells: { library: { requests: { tags: :tag_set } } })
+      Ont::Run.includes(flowcells: Ont::Flowcell.includes_hash)
     end
   end
 end

--- a/app/models/ont/run.rb
+++ b/app/models/ont/run.rb
@@ -27,10 +27,10 @@ module Ont
       self.class.resolved_query.find(id)
     end
 
-    def self.includes_args(*except_keys)
-      return [] if except_keys.include?(:flowcells)
+    def self.includes_args(except: except)
+      return [] if except == :flowcells
 
-      [ flowcells: Ont::Flowcell.includes_args(:run) ]
+      [flowcells: Ont::Flowcell.includes_args(except: :run)]
     end
 
     def self.resolved_run(id:)

--- a/app/models/ont/run.rb
+++ b/app/models/ont/run.rb
@@ -41,8 +41,6 @@ module Ont
       resolved_query.all
     end
 
-    private
-
     def self.resolved_query
       Ont::Run.includes(includes_hash)
     end

--- a/app/models/ont/run.rb
+++ b/app/models/ont/run.rb
@@ -23,22 +23,11 @@ module Ont
       "ONTRUN-#{id}"
     end
 
-    def resolved_run
-      self.class.resolved_query.find(id)
-    end
-
     def self.includes_args(except = nil)
-      return [] if except == :flowcells
+      args = []
+      args << { flowcells: Ont::Flowcell.includes_args(:run) } unless except == :flowcells
 
-      [flowcells: Ont::Flowcell.includes_args(:run)]
-    end
-
-    def self.resolved_run(id:)
-      resolved_query.find(id)
-    end
-
-    def self.all_resolved_runs
-      resolved_query.all
+      args
     end
 
     def self.resolved_query

--- a/app/models/ont/run.rb
+++ b/app/models/ont/run.rb
@@ -27,10 +27,10 @@ module Ont
       self.class.resolved_query.find(id)
     end
 
-    def self.includes_args(except: except)
+    def self.includes_args(except = nil)
       return [] if except == :flowcells
 
-      [flowcells: Ont::Flowcell.includes_args(except: :run)]
+      [flowcells: Ont::Flowcell.includes_args(:run)]
     end
 
     def self.resolved_run(id:)

--- a/app/models/ont/run.rb
+++ b/app/models/ont/run.rb
@@ -27,6 +27,12 @@ module Ont
       self.class.resolved_query.find(id)
     end
 
+    def self.includes_hash(*except_keys)
+      return {} if except_keys.include?(:flowcells)
+
+      { flowcells: Ont::Flowcell.includes_hash(:run) }
+    end
+
     def self.resolved_run(id:)
       resolved_query.find(id)
     end
@@ -38,7 +44,7 @@ module Ont
     private
 
     def self.resolved_query
-      Ont::Run.includes(flowcells: Ont::Flowcell.includes_hash)
+      Ont::Run.includes(includes_hash)
     end
   end
 end

--- a/app/models/ont/run.rb
+++ b/app/models/ont/run.rb
@@ -27,10 +27,10 @@ module Ont
       self.class.resolved_query.find(id)
     end
 
-    def self.includes_hash(*except_keys)
-      return {} if except_keys.include?(:flowcells)
+    def self.includes_args(*except_keys)
+      return [] if except_keys.include?(:flowcells)
 
-      { flowcells: Ont::Flowcell.includes_hash(:run) }
+      [ flowcells: Ont::Flowcell.includes_args(:run) ]
     end
 
     def self.resolved_run(id:)
@@ -42,7 +42,7 @@ module Ont
     end
 
     def self.resolved_query
-      Ont::Run.includes(includes_hash)
+      Ont::Run.includes(*includes_args)
     end
   end
 end

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -26,7 +26,7 @@ class Plate < ApplicationRecord
     self.class.resolved_query.find(id)
   end
 
-  def self.includes_args(except: except)
+  def self.includes_args(except = nil)
     return [] if except == :wells
 
     [wells: { container_materials: :material }]

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -22,10 +22,6 @@ class Plate < ApplicationRecord
     wells.sort { |a, b| a.row == b.row ? a.column <=> b.column : a.row <=> b.row }
   end
 
-  def resolved_plate
-    self.class.resolved_query.find(id)
-  end
-
   def self.includes_args(except = nil)
     args = []
     args << { wells: Well.includes_args(:plate) } unless except == :wells

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -29,7 +29,7 @@ class Plate < ApplicationRecord
   def self.includes_args(except = nil)
     return [] if except == :wells
 
-    [wells: { container_materials: :material }]
+    [wells: Well.includes_args(:plate)]
   end
 
   def self.resolved_plate(id:)

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -21,4 +21,26 @@ class Plate < ApplicationRecord
   def wells_by_row_then_column
     wells.sort { |a, b| a.row == b.row ? a.column <=> b.column : a.row <=> b.row }
   end
+
+  def resolved_plate
+    self.class.resolved_query.find(id)
+  end
+
+  def self.includes_args(except: except)
+    return [] if except == :wells
+
+    [wells: { container_materials: :material }]
+  end
+
+  def self.resolved_plate(id:)
+    resolved_query.find(id)
+  end
+
+  def self.all_resolved_plates
+    resolved_query.all
+  end
+
+  def self.resolved_query
+    Plate.includes(*includes_args)
+  end
 end

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -27,17 +27,10 @@ class Plate < ApplicationRecord
   end
 
   def self.includes_args(except = nil)
-    return [] if except == :wells
+    args = []
+    args << { wells: Well.includes_args(:plate) } unless except == :wells
 
-    [wells: Well.includes_args(:plate)]
-  end
-
-  def self.resolved_plate(id:)
-    resolved_query.find(id)
-  end
-
-  def self.all_resolved_plates
-    resolved_query.all
+    args
   end
 
   def self.resolved_query

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -18,6 +18,6 @@ class Tag < ApplicationRecord
                                      case_sensitive: false }
 
   def self.includes_args
-    [:tag_set]
+    :tag_set
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,4 +16,8 @@ class Tag < ApplicationRecord
   validates :group_id, uniqueness: { scope: :tag_set_id,
                                      message: 'group id should only appear once within set',
                                      case_sensitive: false }
+
+  def self.includes_args
+    [:tag_set]
+  end
 end

--- a/app/models/tube.rb
+++ b/app/models/tube.rb
@@ -12,4 +12,17 @@ class Tube < ApplicationRecord
             'container_materials.material_type LIKE ?', "#{pipeline.capitalize}::%"
           )
         }
+
+  def self.includes_args(except = nil)
+    args = []
+    unless except == :container_materials
+      args << { container_materials: ContainerMaterial.includes_args(:container) }
+    end
+
+    args
+  end
+
+  def self.resolved_query
+    Tube.includes(*includes_args)
+  end
 end

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -22,7 +22,7 @@ class Well < ApplicationRecord
 
   def self.includes_args(except = nil)
     if except == :plate
-      [container_materials: :material]
+      [container_materials: ContainerMaterial.includes_args(:container)]
     elsif except == :container_materials
       [plate: Plate.includes_args(:wells)]
     else

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -21,21 +21,14 @@ class Well < ApplicationRecord
   end
 
   def self.includes_args(except = nil)
-    if except == :plate
-      [container_materials: ContainerMaterial.includes_args(:container)]
-    elsif except == :container_materials
-      [plate: Plate.includes_args(:wells)]
-    else
-      [container_materials: :material, plate: Plate.includes_args(:wells)]
+    args = []
+    args << { plate: Plate.includes_args(:wells) } unless except == :plate
+
+    unless except == :container_materials
+      args << { container_materials: ContainerMaterial.includes_args(:container) }
     end
-  end
 
-  def self.resolved_well(id:)
-    resolved_query.find(id)
-  end
-
-  def self.all_resolved_wells
-    resolved_query.all
+    args
   end
 
   def self.resolved_query

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -15,4 +15,30 @@ class Well < ApplicationRecord
   def column
     position[1..-1].to_i
   end
+
+  def resolved_well
+    self.class.resolved_query.find(id)
+  end
+
+  def self.includes_args(except = nil)
+    if except == :plate
+      [container_materials: :material]
+    elsif except == :container_materials
+      [plate: Plate.includes_args(:wells)]
+    else
+      [container_materials: :material, plate: Plate.includes_args(:wells)]
+    end
+  end
+
+  def self.resolved_well(id:)
+    resolved_query.find(id)
+  end
+
+  def self.all_resolved_wells
+    resolved_query.all
+  end
+
+  def self.resolved_query
+    Well.includes(*includes_args)
+  end
 end

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -16,10 +16,6 @@ class Well < ApplicationRecord
     position[1..-1].to_i
   end
 
-  def resolved_well
-    self.class.resolved_query.find(id)
-  end
-
   def self.includes_args(except = nil)
     args = []
     args << { plate: Plate.includes_args(:wells) } unless except == :plate

--- a/spec/models/container_material_spec.rb
+++ b/spec/models/container_material_spec.rb
@@ -8,4 +8,18 @@ RSpec.describe ContainerMaterial, type: :model do
   it 'is not valid without a material' do
     expect(build(:container_material, material: nil)).to_not be_valid
   end
+
+  context 'resolve' do
+    it 'returns expected includes_args' do
+      expect(ContainerMaterial.includes_args).to eq([:container, :material])
+    end
+
+    it 'removes container from includes_args' do
+      expect(ContainerMaterial.includes_args(:container)).to eq([:material])
+    end
+
+    it 'removes run from includes_args' do
+      expect(ContainerMaterial.includes_args(:material)).to eq([:container])
+    end
+  end
 end

--- a/spec/models/container_material_spec.rb
+++ b/spec/models/container_material_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ContainerMaterial, type: :model do
@@ -11,15 +13,15 @@ RSpec.describe ContainerMaterial, type: :model do
 
   context 'resolve' do
     it 'returns expected includes_args' do
-      expect(ContainerMaterial.includes_args).to eq([:container, :material])
+      expect(ContainerMaterial.includes_args).to contain_exactly(:container, :material)
     end
 
     it 'removes container from includes_args' do
-      expect(ContainerMaterial.includes_args(:container)).to eq([:material])
+      expect(ContainerMaterial.includes_args(:container)).to_not include(:container)
     end
 
     it 'removes run from includes_args' do
-      expect(ContainerMaterial.includes_args(:material)).to eq([:container])
+      expect(ContainerMaterial.includes_args(:material)).to_not include(:material)
     end
   end
 end

--- a/spec/models/ont/flowcell_spec.rb
+++ b/spec/models/ont/flowcell_spec.rb
@@ -49,17 +49,17 @@ RSpec.describe Ont::Flowcell, type: :model, ont: true do
   context 'resolve' do
     it 'returns expected includes_args' do
       expect(Ont::Flowcell.includes_args).to eq([
-        library: Ont::Library.includes_args(except: :flowcell),
-        run: Ont::Run.includes_args(except: :flowcells)
+        library: Ont::Library.includes_args(:flowcell),
+        run: Ont::Run.includes_args(:flowcells)
       ])
     end
 
     it 'removes run from includes_args' do
-      expect(Ont::Flowcell.includes_args(except: :run)).to eq([library: Ont::Library.includes_args(except: :flowcell)])
+      expect(Ont::Flowcell.includes_args(:run)).to eq([library: Ont::Library.includes_args(:flowcell)])
     end
 
     it 'removes library from includes_args' do
-      expect(Ont::Flowcell.includes_args(except: :library)).to eq([run: Ont::Run.includes_args(except: :flowcells)])
+      expect(Ont::Flowcell.includes_args(:library)).to eq([run: Ont::Run.includes_args(:flowcells)])
     end
   end
 end

--- a/spec/models/ont/flowcell_spec.rb
+++ b/spec/models/ont/flowcell_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe Ont::Flowcell, type: :model, ont: true do
       expect(run.flowcells.count).to be(initial_flowcell_count - 1)
     end
   end
+
+  context 'resolve' do
+    it 'returns expected includes_hash' do
+      expect(Ont::Flowcell.includes_hash).to eq({ library: { requests: { tags: :tag_set } } })
+    end
+  end
 end

--- a/spec/models/ont/flowcell_spec.rb
+++ b/spec/models/ont/flowcell_spec.rb
@@ -49,17 +49,17 @@ RSpec.describe Ont::Flowcell, type: :model, ont: true do
   context 'resolve' do
     it 'returns expected includes_args' do
       expect(Ont::Flowcell.includes_args).to eq([
-        library: Ont::Library.includes_args(:flowcell),
-        run: Ont::Run.includes_args(:flowcells)
+        library: Ont::Library.includes_args(except: :flowcell),
+        run: Ont::Run.includes_args(except: :flowcells)
       ])
     end
 
     it 'removes run from includes_args' do
-      expect(Ont::Flowcell.includes_args(:run)).to eq([library: Ont::Library.includes_args(:flowcell)])
+      expect(Ont::Flowcell.includes_args(except: :run)).to eq([library: Ont::Library.includes_args(except: :flowcell)])
     end
 
     it 'removes library from includes_args' do
-      expect(Ont::Flowcell.includes_args(:library)).to eq([run: Ont::Run.includes_args(:flowcells)])
+      expect(Ont::Flowcell.includes_args(except: :library)).to eq([run: Ont::Run.includes_args(except: :flowcells)])
     end
   end
 end

--- a/spec/models/ont/flowcell_spec.rb
+++ b/spec/models/ont/flowcell_spec.rb
@@ -47,19 +47,19 @@ RSpec.describe Ont::Flowcell, type: :model, ont: true do
   end
 
   context 'resolve' do
-    it 'returns expected includes_hash' do
-      expect(Ont::Flowcell.includes_hash).to eq({
-        library: Ont::Library.includes_hash(:flowcell),
-        run: Ont::Run.includes_hash(:flowcells)
-      })
+    it 'returns expected includes_args' do
+      expect(Ont::Flowcell.includes_args).to eq([
+        library: Ont::Library.includes_args(:flowcell),
+        run: Ont::Run.includes_args(:flowcells)
+      ])
     end
 
-    it 'removes run from includes_hash' do
-      expect(Ont::Flowcell.includes_hash(:run)).to eq({ library: Ont::Library.includes_hash(:flowcell) })
+    it 'removes run from includes_args' do
+      expect(Ont::Flowcell.includes_args(:run)).to eq([library: Ont::Library.includes_args(:flowcell)])
     end
 
-    it 'removes library from includes_hash' do
-      expect(Ont::Flowcell.includes_hash(:library)).to eq({ run: Ont::Run.includes_hash(:flowcells) })
+    it 'removes library from includes_args' do
+      expect(Ont::Flowcell.includes_args(:library)).to eq([run: Ont::Run.includes_args(:flowcells)])
     end
   end
 end

--- a/spec/models/ont/flowcell_spec.rb
+++ b/spec/models/ont/flowcell_spec.rb
@@ -48,7 +48,18 @@ RSpec.describe Ont::Flowcell, type: :model, ont: true do
 
   context 'resolve' do
     it 'returns expected includes_hash' do
-      expect(Ont::Flowcell.includes_hash).to eq({ library: { requests: { tags: :tag_set } } })
+      expect(Ont::Flowcell.includes_hash).to eq({
+        library: Ont::Library.includes_hash(:flowcell),
+        run: Ont::Run.includes_hash(:flowcells)
+      })
+    end
+
+    it 'removes run from includes_hash' do
+      expect(Ont::Flowcell.includes_hash(:run)).to eq({ library: Ont::Library.includes_hash(:flowcell) })
+    end
+
+    it 'removes library from includes_hash' do
+      expect(Ont::Flowcell.includes_hash(:library)).to eq({ run: Ont::Run.includes_hash(:flowcells) })
     end
   end
 end

--- a/spec/models/ont/flowcell_spec.rb
+++ b/spec/models/ont/flowcell_spec.rb
@@ -48,18 +48,15 @@ RSpec.describe Ont::Flowcell, type: :model, ont: true do
 
   context 'resolve' do
     it 'returns expected includes_args' do
-      expect(Ont::Flowcell.includes_args).to eq([
-        library: Ont::Library.includes_args(:flowcell),
-        run: Ont::Run.includes_args(:flowcells)
-      ])
+      expect(Ont::Flowcell.includes_args.flat_map(&:keys)).to contain_exactly(:library, :run)
     end
 
     it 'removes run from includes_args' do
-      expect(Ont::Flowcell.includes_args(:run)).to eq([library: Ont::Library.includes_args(:flowcell)])
+      expect(Ont::Flowcell.includes_args(:run).flat_map(&:keys)).to_not include(:run)
     end
 
     it 'removes library from includes_args' do
-      expect(Ont::Flowcell.includes_args(:library)).to eq([run: Ont::Run.includes_args(:flowcells)])
+      expect(Ont::Flowcell.includes_args(:library).flat_map(&:keys)).to_not include(:library)
     end
   end
 end

--- a/spec/models/ont/library_spec.rb
+++ b/spec/models/ont/library_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Ont::Library, type: :model do
       it 'returns expected includes_args' do
         expect(Ont::Library.includes_args).to eq([
           flowcell: Ont::Flowcell.includes_args(except: :library),
-          requests: { tags: :tag_set }
+          requests: Ont::Request.includes_args(except: :library)
         ])
       end
 
@@ -105,7 +105,7 @@ RSpec.describe Ont::Library, type: :model do
       end
   
       it 'removes flowcell from includes_args' do
-        expect(Ont::Library.includes_args(except: :flowcell)).to eq([requests: { tags: :tag_set }])
+        expect(Ont::Library.includes_args(except: :flowcell)).to eq([requests: Ont::Request.includes_args(except: :library)])
       end
 
       it 'returns a single library' do

--- a/spec/models/ont/library_spec.rb
+++ b/spec/models/ont/library_spec.rb
@@ -95,17 +95,17 @@ RSpec.describe Ont::Library, type: :model do
     context 'class' do
       it 'returns expected includes_args' do
         expect(Ont::Library.includes_args).to eq([
-          flowcell: Ont::Flowcell.includes_args(:library),
+          flowcell: Ont::Flowcell.includes_args(except: :library),
           requests: { tags: :tag_set }
         ])
       end
 
       it 'removes requests from includes_args' do
-        expect(Ont::Library.includes_args(:requests)).to eq([flowcell: Ont::Flowcell.includes_args(:library)])
+        expect(Ont::Library.includes_args(except: :requests)).to eq([flowcell: Ont::Flowcell.includes_args(except: :library)])
       end
   
       it 'removes flowcell from includes_args' do
-        expect(Ont::Library.includes_args(:flowcell)).to eq([requests: { tags: :tag_set }])
+        expect(Ont::Library.includes_args(except: :flowcell)).to eq([requests: { tags: :tag_set }])
       end
 
       it 'returns a single library' do

--- a/spec/models/ont/library_spec.rb
+++ b/spec/models/ont/library_spec.rb
@@ -93,19 +93,19 @@ RSpec.describe Ont::Library, type: :model do
     end
 
     context 'class' do
-      it 'returns expected includes_hash' do
-        expect(Ont::Library.includes_hash).to eq({
-          flowcell: Ont::Flowcell.includes_hash(:library),
+      it 'returns expected includes_args' do
+        expect(Ont::Library.includes_args).to eq([
+          flowcell: Ont::Flowcell.includes_args(:library),
           requests: { tags: :tag_set }
-        })
+        ])
       end
 
-      it 'removes requests from includes_hash' do
-        expect(Ont::Library.includes_hash(:requests)).to eq({ flowcell: Ont::Flowcell.includes_hash(:library) })
+      it 'removes requests from includes_args' do
+        expect(Ont::Library.includes_args(:requests)).to eq([flowcell: Ont::Flowcell.includes_args(:library)])
       end
   
-      it 'removes flowcell from includes_hash' do
-        expect(Ont::Library.includes_hash(:flowcell)).to eq({ requests: { tags: :tag_set } })
+      it 'removes flowcell from includes_args' do
+        expect(Ont::Library.includes_args(:flowcell)).to eq([requests: { tags: :tag_set }])
       end
 
       it 'returns a single library' do

--- a/spec/models/ont/library_spec.rb
+++ b/spec/models/ont/library_spec.rb
@@ -83,4 +83,40 @@ RSpec.describe Ont::Library, type: :model do
       expect(library.tube_barcode).to eq(tube.barcode)
     end
   end
+
+  context 'resolved' do
+    context 'instance' do
+      it 'returns a single library' do
+        library = create(:ont_library_with_requests)
+        expect(library.resolved_library).to eq(library)
+      end
+    end
+
+    context 'class' do
+      it 'returns expected includes_hash' do
+        expect(Ont::Library.includes_hash).to eq({
+          flowcell: Ont::Flowcell.includes_hash(:library),
+          requests: { tags: :tag_set }
+        })
+      end
+
+      it 'removes requests from includes_hash' do
+        expect(Ont::Library.includes_hash(:requests)).to eq({ flowcell: Ont::Flowcell.includes_hash(:library) })
+      end
+  
+      it 'removes flowcell from includes_hash' do
+        expect(Ont::Library.includes_hash(:flowcell)).to eq({ requests: { tags: :tag_set } })
+      end
+
+      it 'returns a single library' do
+        library = create(:ont_library_with_requests)
+        expect(Ont::Library.resolved_library(id: library.id)).to eq(library)
+      end
+
+      it 'returns all libraries' do
+        libraries = create_list(:ont_library_with_requests, 3)
+        expect(Ont::Library.all_resolved_libraries).to match_array(libraries)
+      end
+    end
+  end
 end

--- a/spec/models/ont/library_spec.rb
+++ b/spec/models/ont/library_spec.rb
@@ -95,17 +95,17 @@ RSpec.describe Ont::Library, type: :model do
     context 'class' do
       it 'returns expected includes_args' do
         expect(Ont::Library.includes_args).to eq([
-          flowcell: Ont::Flowcell.includes_args(except: :library),
-          requests: Ont::Request.includes_args(except: :library)
+          flowcell: Ont::Flowcell.includes_args(:library),
+          requests: Ont::Request.includes_args(:library)
         ])
       end
 
       it 'removes requests from includes_args' do
-        expect(Ont::Library.includes_args(except: :requests)).to eq([flowcell: Ont::Flowcell.includes_args(except: :library)])
+        expect(Ont::Library.includes_args(:requests)).to eq([flowcell: Ont::Flowcell.includes_args(:library)])
       end
   
       it 'removes flowcell from includes_args' do
-        expect(Ont::Library.includes_args(except: :flowcell)).to eq([requests: Ont::Request.includes_args(except: :library)])
+        expect(Ont::Library.includes_args(:flowcell)).to eq([requests: Ont::Request.includes_args(:library)])
       end
 
       it 'returns a single library' do

--- a/spec/models/ont/library_spec.rb
+++ b/spec/models/ont/library_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Ont::Library, type: :model do
@@ -25,9 +27,10 @@ RSpec.describe Ont::Library, type: :model do
     library = create(:ont_library)
     new_library = build(:ont_library, name: library.name)
     expect(new_library).to_not be_valid
-    expect(new_library.errors.full_messages).to contain_exactly('Name must be unique: a pool already exists for this plate')
+    expect(new_library.errors.full_messages)
+      .to contain_exactly('Name must be unique: a pool already exists for this plate')
   end
-  
+
   it 'does not delete associated requests on destroy' do
     library = create(:ont_library)
     num_requests = 3
@@ -47,20 +50,20 @@ RSpec.describe Ont::Library, type: :model do
     end
 
     it 'returns nil with nil pool' do
-      name = Ont::Library.library_name("PLATE-1234", nil)
+      name = Ont::Library.library_name('PLATE-1234', nil)
       expect(name).to be_nil
     end
 
     it 'returns expected name' do
-      name = Ont::Library.library_name("PLATE-1234", 2)
-      expect(name).to eq("PLATE-1234-2")
+      name = Ont::Library.library_name('PLATE-1234', 2)
+      expect(name).to eq('PLATE-1234-2')
     end
   end
 
   context 'plate barcode' do
     it 'returns expected plate barcode' do
       library = create(:ont_library)
-      expect(library.plate_barcode).to eq("PLATE-1-123456")
+      expect(library.plate_barcode).to eq('PLATE-1-123456')
     end
   end
 
@@ -94,28 +97,15 @@ RSpec.describe Ont::Library, type: :model do
 
     context 'class' do
       it 'returns expected includes_args' do
-        expect(Ont::Library.includes_args).to eq([
-          flowcell: Ont::Flowcell.includes_args(:library),
-          requests: Ont::Request.includes_args(:library)
-        ])
+        expect(Ont::Library.includes_args.flat_map(&:keys)).to contain_exactly(:flowcell, :requests)
       end
 
       it 'removes requests from includes_args' do
-        expect(Ont::Library.includes_args(:requests)).to eq([flowcell: Ont::Flowcell.includes_args(:library)])
+        expect(Ont::Library.includes_args(:requests).flat_map(&:keys)).to_not include(:requests)
       end
-  
+
       it 'removes flowcell from includes_args' do
-        expect(Ont::Library.includes_args(:flowcell)).to eq([requests: Ont::Request.includes_args(:library)])
-      end
-
-      it 'returns a single library' do
-        library = create(:ont_library_with_requests)
-        expect(Ont::Library.resolved_library(id: library.id)).to eq(library)
-      end
-
-      it 'returns all libraries' do
-        libraries = create_list(:ont_library_with_requests, 3)
-        expect(Ont::Library.all_resolved_libraries).to match_array(libraries)
+        expect(Ont::Library.includes_args(:flowcell).flat_map(&:keys)).to_not include(:flowcell)
       end
     end
   end

--- a/spec/models/ont/library_spec.rb
+++ b/spec/models/ont/library_spec.rb
@@ -88,25 +88,16 @@ RSpec.describe Ont::Library, type: :model do
   end
 
   context 'resolved' do
-    context 'instance' do
-      it 'returns a single library' do
-        library = create(:ont_library_with_requests)
-        expect(library.resolved_library).to eq(library)
-      end
+    it 'returns expected includes_args' do
+      expect(Ont::Library.includes_args.flat_map(&:keys)).to contain_exactly(:flowcell, :requests)
     end
 
-    context 'class' do
-      it 'returns expected includes_args' do
-        expect(Ont::Library.includes_args.flat_map(&:keys)).to contain_exactly(:flowcell, :requests)
-      end
+    it 'removes requests from includes_args' do
+      expect(Ont::Library.includes_args(:requests).flat_map(&:keys)).to_not include(:requests)
+    end
 
-      it 'removes requests from includes_args' do
-        expect(Ont::Library.includes_args(:requests).flat_map(&:keys)).to_not include(:requests)
-      end
-
-      it 'removes flowcell from includes_args' do
-        expect(Ont::Library.includes_args(:flowcell).flat_map(&:keys)).to_not include(:flowcell)
-      end
+    it 'removes flowcell from includes_args' do
+      expect(Ont::Library.includes_args(:flowcell).flat_map(&:keys)).to_not include(:flowcell)
     end
   end
 end

--- a/spec/models/ont/request_spec.rb
+++ b/spec/models/ont/request_spec.rb
@@ -26,20 +26,20 @@ RSpec.describe Ont::Request, type: :model, ont: true do
       expect(Ont::Request.includes_args).to eq([
         container_material: ContainerMaterial.includes_args(:material),
         library: Ont::Library.includes_args(:requests),
-        tags: :tag_set ])
+        tags: Tag.includes_args ])
     end
 
     it 'removes container from includes_args' do
       expect(Ont::Request.includes_args(:container_material)).to eq([
         library: Ont::Library.includes_args(:requests),
-        tags: :tag_set
+        tags: Tag.includes_args
       ])
     end
 
     it 'removes library from includes_args' do
       expect(Ont::Request.includes_args(:library)).to eq([
         container_material: ContainerMaterial.includes_args(:material),
-        tags: :tag_set
+        tags: Tag.includes_args
       ])
     end
 

--- a/spec/models/ont/request_spec.rb
+++ b/spec/models/ont/request_spec.rb
@@ -25,25 +25,25 @@ RSpec.describe Ont::Request, type: :model, ont: true do
     it 'returns expected includes_args' do
       expect(Ont::Request.includes_args).to eq([
         container_material: :container,
-        library: Ont::Library.includes_args(except: :requests),
+        library: Ont::Library.includes_args(:requests),
         tags: :tag_set ])
     end
 
     it 'removes container from includes_args' do
-      expect(Ont::Request.includes_args(except: :container_material)).to eq([
-        library: Ont::Library.includes_args(except: :requests),
+      expect(Ont::Request.includes_args(:container_material)).to eq([
+        library: Ont::Library.includes_args(:requests),
         tags: :tag_set
       ])
     end
 
     it 'removes library from includes_args' do
-      expect(Ont::Request.includes_args(except: :library)).to eq([container_material: :container, tags: :tag_set])
+      expect(Ont::Request.includes_args(:library)).to eq([container_material: :container, tags: :tag_set])
     end
 
     it 'removes tags from includes_args' do
-      expect(Ont::Request.includes_args(except: :tags)).to eq([
+      expect(Ont::Request.includes_args(:tags)).to eq([
         container_material: :container,
-        library: Ont::Library.includes_args(except: :requests)
+        library: Ont::Library.includes_args(:requests)
       ])
     end
   end

--- a/spec/models/ont/request_spec.rb
+++ b/spec/models/ont/request_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Ont::Request, type: :model, ont: true do
   context 'resolve' do
     it 'returns expected includes_args' do
       expect(Ont::Request.includes_args).to eq([
-        container_material: :container,
+        container_material: ContainerMaterial.includes_args(:material),
         library: Ont::Library.includes_args(:requests),
         tags: :tag_set ])
     end
@@ -37,12 +37,15 @@ RSpec.describe Ont::Request, type: :model, ont: true do
     end
 
     it 'removes library from includes_args' do
-      expect(Ont::Request.includes_args(:library)).to eq([container_material: :container, tags: :tag_set])
+      expect(Ont::Request.includes_args(:library)).to eq([
+        container_material: ContainerMaterial.includes_args(:material),
+        tags: :tag_set
+      ])
     end
 
     it 'removes tags from includes_args' do
       expect(Ont::Request.includes_args(:tags)).to eq([
-        container_material: :container,
+        container_material: ContainerMaterial.includes_args(:material),
         library: Ont::Library.includes_args(:requests)
       ])
     end

--- a/spec/models/ont/request_spec.rb
+++ b/spec/models/ont/request_spec.rb
@@ -20,4 +20,31 @@ RSpec.describe Ont::Request, type: :model, ont: true do
     request = build(:ont_request, external_id: nil)
     expect(request).not_to be_valid
   end
+
+  context 'resolve' do
+    it 'returns expected includes_args' do
+      expect(Ont::Request.includes_args).to eq([
+        container_material: :container,
+        library: Ont::Library.includes_args(except: :requests),
+        tags: :tag_set ])
+    end
+
+    it 'removes container from includes_args' do
+      expect(Ont::Request.includes_args(except: :container_material)).to eq([
+        library: Ont::Library.includes_args(except: :requests),
+        tags: :tag_set
+      ])
+    end
+
+    it 'removes library from includes_args' do
+      expect(Ont::Request.includes_args(except: :library)).to eq([container_material: :container, tags: :tag_set])
+    end
+
+    it 'removes tags from includes_args' do
+      expect(Ont::Request.includes_args(except: :tags)).to eq([
+        container_material: :container,
+        library: Ont::Library.includes_args(except: :requests)
+      ])
+    end
+  end
 end

--- a/spec/models/ont/request_spec.rb
+++ b/spec/models/ont/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Ont::Request, type: :model, ont: true do
@@ -23,31 +25,21 @@ RSpec.describe Ont::Request, type: :model, ont: true do
 
   context 'resolve' do
     it 'returns expected includes_args' do
-      expect(Ont::Request.includes_args).to eq([
-        container_material: ContainerMaterial.includes_args(:material),
-        library: Ont::Library.includes_args(:requests),
-        tags: Tag.includes_args ])
+      expect(Ont::Request.includes_args.flat_map(&:keys))
+        .to contain_exactly(:container_material, :library, :tags)
     end
 
     it 'removes container from includes_args' do
-      expect(Ont::Request.includes_args(:container_material)).to eq([
-        library: Ont::Library.includes_args(:requests),
-        tags: Tag.includes_args
-      ])
+      expect(Ont::Request.includes_args(:container_material).flat_map(&:keys))
+        .to_not include(:container_material)
     end
 
     it 'removes library from includes_args' do
-      expect(Ont::Request.includes_args(:library)).to eq([
-        container_material: ContainerMaterial.includes_args(:material),
-        tags: Tag.includes_args
-      ])
+      expect(Ont::Request.includes_args(:library).flat_map(&:keys)).to_not include(:library)
     end
 
     it 'removes tags from includes_args' do
-      expect(Ont::Request.includes_args(:tags)).to eq([
-        container_material: ContainerMaterial.includes_args(:material),
-        library: Ont::Library.includes_args(:requests)
-      ])
+      expect(Ont::Request.includes_args(:tags).flat_map(&:keys)).to_not include(:tags)
     end
   end
 end

--- a/spec/models/ont/run_spec.rb
+++ b/spec/models/ont/run_spec.rb
@@ -81,4 +81,25 @@ RSpec.describe Ont::Run, type: :model, ont: true do
       end
     end
   end
+
+  context 'resolved' do
+    context 'instance' do
+      it 'returns a single run' do
+        run = create(:ont_run)
+        expect(run.resolved_run).to eq(run)
+      end
+    end
+
+    context 'class' do
+      it 'returns a single run' do
+        run = create(:ont_run)
+        expect(Ont::Run.resolved_run(id: run.id)).to eq(run)
+      end
+
+      it 'returns all runs' do
+        runs = create_list(:ont_run, 3)
+        expect(Ont::Run.all_resolved_runs).to match_array(runs)
+      end
+    end
+  end
 end

--- a/spec/models/ont/run_spec.rb
+++ b/spec/models/ont/run_spec.rb
@@ -92,11 +92,11 @@ RSpec.describe Ont::Run, type: :model, ont: true do
 
     context 'class' do
       it 'returns expected includes_args' do
-        expect(Ont::Run.includes_args).to eq([flowcells: Ont::Flowcell.includes_args(:run)])
+        expect(Ont::Run.includes_args).to eq([flowcells: Ont::Flowcell.includes_args(except: :run)])
       end
 
       it 'removes keys from includes_args' do
-        expect(Ont::Run.includes_args(:flowcells)).to be_empty
+        expect(Ont::Run.includes_args(except: :flowcells)).to be_empty
       end
 
       it 'returns a single run' do

--- a/spec/models/ont/run_spec.rb
+++ b/spec/models/ont/run_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe Ont::Run, type: :model, ont: true do
     end
 
     context 'class' do
+      it 'returns expected includes_hash' do
+        expect(Ont::Run.includes_hash).to eq({ flowcells: Ont::Flowcell.includes_hash(:run) })
+      end
+
+      it 'removes keys from includes_hash' do
+        expect(Ont::Run.includes_hash(:flowcells)).to eq({})
+      end
+
       it 'returns a single run' do
         run = create(:ont_run)
         expect(Ont::Run.resolved_run(id: run.id)).to eq(run)

--- a/spec/models/ont/run_spec.rb
+++ b/spec/models/ont/run_spec.rb
@@ -84,14 +84,12 @@ RSpec.describe Ont::Run, type: :model, ont: true do
   end
 
   context 'resolved' do
-    context 'class' do
-      it 'returns expected includes_args' do
-        expect(Ont::Run.includes_args.flat_map(&:keys)).to contain_exactly(:flowcells)
-      end
+    it 'returns expected includes_args' do
+      expect(Ont::Run.includes_args.flat_map(&:keys)).to contain_exactly(:flowcells)
+    end
 
-      it 'removes keys from includes_args' do
-        expect(Ont::Run.includes_args(:flowcells).flat_map(&:keys)).to_not include(:flowcells)
-      end
+    it 'removes keys from includes_args' do
+      expect(Ont::Run.includes_args(:flowcells).flat_map(&:keys)).to_not include(:flowcells)
     end
   end
 end

--- a/spec/models/ont/run_spec.rb
+++ b/spec/models/ont/run_spec.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Ont::Run, type: :model, ont: true do
-
   context 'on creation' do
     it 'state is pending' do
       run = create(:ont_run)
@@ -83,30 +84,13 @@ RSpec.describe Ont::Run, type: :model, ont: true do
   end
 
   context 'resolved' do
-    context 'instance' do
-      it 'returns a single run' do
-        run = create(:ont_run)
-        expect(run.resolved_run).to eq(run)
-      end
-    end
-
     context 'class' do
       it 'returns expected includes_args' do
-        expect(Ont::Run.includes_args).to eq([flowcells: Ont::Flowcell.includes_args(:run)])
+        expect(Ont::Run.includes_args.flat_map(&:keys)).to contain_exactly(:flowcells)
       end
 
       it 'removes keys from includes_args' do
-        expect(Ont::Run.includes_args(:flowcells)).to be_empty
-      end
-
-      it 'returns a single run' do
-        run = create(:ont_run)
-        expect(Ont::Run.resolved_run(id: run.id)).to eq(run)
-      end
-
-      it 'returns all runs' do
-        runs = create_list(:ont_run, 3)
-        expect(Ont::Run.all_resolved_runs).to match_array(runs)
+        expect(Ont::Run.includes_args(:flowcells).flat_map(&:keys)).to_not include(:flowcells)
       end
     end
   end

--- a/spec/models/ont/run_spec.rb
+++ b/spec/models/ont/run_spec.rb
@@ -92,11 +92,11 @@ RSpec.describe Ont::Run, type: :model, ont: true do
 
     context 'class' do
       it 'returns expected includes_args' do
-        expect(Ont::Run.includes_args).to eq([flowcells: Ont::Flowcell.includes_args(except: :run)])
+        expect(Ont::Run.includes_args).to eq([flowcells: Ont::Flowcell.includes_args(:run)])
       end
 
       it 'removes keys from includes_args' do
-        expect(Ont::Run.includes_args(except: :flowcells)).to be_empty
+        expect(Ont::Run.includes_args(:flowcells)).to be_empty
       end
 
       it 'returns a single run' do

--- a/spec/models/ont/run_spec.rb
+++ b/spec/models/ont/run_spec.rb
@@ -91,12 +91,12 @@ RSpec.describe Ont::Run, type: :model, ont: true do
     end
 
     context 'class' do
-      it 'returns expected includes_hash' do
-        expect(Ont::Run.includes_hash).to eq({ flowcells: Ont::Flowcell.includes_hash(:run) })
+      it 'returns expected includes_args' do
+        expect(Ont::Run.includes_args).to eq([flowcells: Ont::Flowcell.includes_args(:run)])
       end
 
-      it 'removes keys from includes_hash' do
-        expect(Ont::Run.includes_hash(:flowcells)).to eq({})
+      it 'removes keys from includes_args' do
+        expect(Ont::Run.includes_args(:flowcells)).to be_empty
       end
 
       it 'returns a single run' do

--- a/spec/models/plate_spec.rb
+++ b/spec/models/plate_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Plate, type: :model do
 
     context 'class' do
       it 'returns expected includes_args' do
-        expect(Plate.includes_args).to eq([wells: { container_materials: :material }])
+        expect(Plate.includes_args).to eq([wells: Well.includes_args(:plate)])
       end
 
       it 'removes keys from includes_args' do

--- a/spec/models/plate_spec.rb
+++ b/spec/models/plate_spec.rb
@@ -25,4 +25,33 @@ RSpec.describe Plate, type: :model do
     sorted_positions = plate.wells_by_row_then_column.map { |row| row.position }
     expect(sorted_positions).to eq(expected_positions)
   end
+
+  context 'resolved' do
+    context 'instance' do
+      it 'returns a single plate' do
+        plate = create(:plate_with_tagged_ont_requests)
+        expect(plate.resolved_plate).to eq(plate)
+      end
+    end
+
+    context 'class' do
+      it 'returns expected includes_args' do
+        expect(Plate.includes_args).to eq([wells: { container_materials: :material }])
+      end
+
+      it 'removes keys from includes_args' do
+        expect(Plate.includes_args(except: :wells)).to be_empty
+      end
+
+      it 'returns a single plate' do
+        plate = create(:plate_with_tagged_ont_requests)
+        expect(Plate.resolved_plate(id: plate.id)).to eq(plate)
+      end
+
+      it 'returns all plates' do
+        plates = create_list(:plate_with_tagged_ont_requests, 3)
+        expect(Plate.all_resolved_plates).to match_array(plates)
+      end
+    end
+  end
 end

--- a/spec/models/plate_spec.rb
+++ b/spec/models/plate_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Plate, type: :model do
       end
 
       it 'removes keys from includes_args' do
-        expect(Plate.includes_args(except: :wells)).to be_empty
+        expect(Plate.includes_args(:wells)).to be_empty
       end
 
       it 'returns a single plate' do

--- a/spec/models/plate_spec.rb
+++ b/spec/models/plate_spec.rb
@@ -31,21 +31,12 @@ RSpec.describe Plate, type: :model do
   end
 
   context 'resolved' do
-    context 'instance' do
-      it 'returns a single plate' do
-        plate = create(:plate_with_tagged_ont_requests)
-        expect(plate.resolved_plate).to eq(plate)
-      end
+    it 'returns expected includes_args' do
+      expect(Plate.includes_args.flat_map(&:keys)).to contain_exactly(:wells)
     end
 
-    context 'class' do
-      it 'returns expected includes_args' do
-        expect(Plate.includes_args.flat_map(&:keys)).to contain_exactly(:wells)
-      end
-
-      it 'removes keys from includes_args' do
-        expect(Plate.includes_args(:wells).flat_map(&:keys)).to_not include(:wells)
-      end
+    it 'removes keys from includes_args' do
+      expect(Plate.includes_args(:wells).flat_map(&:keys)).to_not include(:wells)
     end
   end
 end

--- a/spec/models/plate_spec.rb
+++ b/spec/models/plate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Plate, type: :model do
@@ -8,21 +10,23 @@ RSpec.describe Plate, type: :model do
 
   it 'returns wells by column then row' do
     plate = create(:plate_with_wells, row_count: 3, column_count: 12)
-    expected_positions = [
-      'A1', 'B1', 'C1', 'A2', 'B2', 'C2', 'A3', 'B3', 'C3', 'A4', 'B4', 'C4',
-      'A5', 'B5', 'C5', 'A6', 'B6', 'C6', 'A7', 'B7', 'C7', 'A8', 'B8', 'C8',
-      'A9', 'B9', 'C9', 'A10', 'B10', 'C10', 'A11', 'B11', 'C11', 'A12', 'B12', 'C12']
-    sorted_positions = plate.wells_by_column_then_row.map { |row| row.position }
+    expected_positions = %w[
+      A1 B1 C1 A2 B2 C2 A3 B3 C3 A4 B4 C4
+      A5 B5 C5 A6 B6 C6 A7 B7 C7 A8 B8 C8
+      A9 B9 C9 A10 B10 C10 A11 B11 C11 A12 B12 C12
+    ]
+    sorted_positions = plate.wells_by_column_then_row.map(&:position)
     expect(sorted_positions).to eq(expected_positions)
   end
 
   it 'returns wells by row then column' do
     plate = create(:plate_with_wells, row_count: 3, column_count: 12)
-    expected_positions = [
-      'A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A11', 'A12',
-      'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10', 'B11', 'B12',
-      'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9', 'C10', 'C11', 'C12']
-    sorted_positions = plate.wells_by_row_then_column.map { |row| row.position }
+    expected_positions = %w[
+      A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12
+      B1 B2 B3 B4 B5 B6 B7 B8 B9 B10 B11 B12
+      C1 C2 C3 C4 C5 C6 C7 C8 C9 C10 C11 C12
+    ]
+    sorted_positions = plate.wells_by_row_then_column.map(&:position)
     expect(sorted_positions).to eq(expected_positions)
   end
 
@@ -36,21 +40,11 @@ RSpec.describe Plate, type: :model do
 
     context 'class' do
       it 'returns expected includes_args' do
-        expect(Plate.includes_args).to eq([wells: Well.includes_args(:plate)])
+        expect(Plate.includes_args.flat_map(&:keys)).to contain_exactly(:wells)
       end
 
       it 'removes keys from includes_args' do
-        expect(Plate.includes_args(:wells)).to be_empty
-      end
-
-      it 'returns a single plate' do
-        plate = create(:plate_with_tagged_ont_requests)
-        expect(Plate.resolved_plate(id: plate.id)).to eq(plate)
-      end
-
-      it 'returns all plates' do
-        plates = create_list(:plate_with_tagged_ont_requests, 3)
-        expect(Plate.all_resolved_plates).to match_array(plates)
+        expect(Plate.includes_args(:wells).flat_map(&:keys)).to_not include(:wells)
       end
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,9 +1,10 @@
-require "rails_helper"
+# frozen_string_literal: true
+
+require 'rails_helper'
 
 RSpec.describe Tag, type: :model do
-
   it 'is valid with all params' do
-    expect(create(:tag, oligo: "CGATCGAATAT", group_id: "1")).to be_valid
+    expect(create(:tag, oligo: 'CGATCGAATAT', group_id: '1')).to be_valid
   end
 
   it 'is not valid without an oligo' do
@@ -58,7 +59,7 @@ RSpec.describe Tag, type: :model do
 
   context 'resolve' do
     it 'returns expected includes_args' do
-      expect(Tag.includes_args).to eq([:tag_set])
+      expect(Tag.includes_args).to eq(:tag_set)
     end
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -55,4 +55,10 @@ RSpec.describe Tag, type: :model do
     expect(TagTaggable.all.count).to eq(0)
     expect(Ont::Request.all.count).to eq(num_taggables)
   end
+
+  context 'resolve' do
+    it 'returns expected includes_args' do
+      expect(Tag.includes_args).to eq([:tag_set])
+    end
+  end
 end

--- a/spec/models/tube_spec.rb
+++ b/spec/models/tube_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe Tube, type: :model do
         expect(Tube.by_pipeline(:pacbio).length).to eq 3
       end
     end
+  end
 
+  context 'resolved' do
+    it 'returns expected includes_args' do
+      expect(Tube.includes_args.flat_map(&:keys)).to contain_exactly(:container_materials)
+    end
+
+    it 'removes container_materials from includes_args' do
+      expect(Tube.includes_args(:container_materials).flat_map(&:keys))
+        .to_not include(:container_materials)
+    end
   end
 end

--- a/spec/models/well_spec.rb
+++ b/spec/models/well_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Well, type: :model do
       end
 
       it 'removes plate from includes_args' do
-        expect(Well.includes_args(:plate)).to eq([container_materials: :material])
+        expect(Well.includes_args(:plate)).to eq([container_materials: ContainerMaterial.includes_args(:container)])
       end
   
       it 'removes container_materials from includes_args' do

--- a/spec/models/well_spec.rb
+++ b/spec/models/well_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Well, type: :model do
   it_behaves_like 'container'
-  
+
   it 'must have plate' do
     expect(build(:well, plate: nil)).to_not be_valid
   end
@@ -36,28 +38,16 @@ RSpec.describe Well, type: :model do
 
     context 'class' do
       it 'returns expected includes_args' do
-        expect(Well.includes_args).to eq([
-          container_materials: :material,
-          plate: Plate.includes_args(:wells)
-        ])
+        expect(Well.includes_args.flat_map(&:keys)).to contain_exactly(:container_materials, :plate)
       end
 
       it 'removes plate from includes_args' do
-        expect(Well.includes_args(:plate)).to eq([container_materials: ContainerMaterial.includes_args(:container)])
+        expect(Well.includes_args(:plate).flat_map(&:keys)).to_not include(:plate)
       end
-  
+
       it 'removes container_materials from includes_args' do
-        expect(Well.includes_args(:container_materials)).to eq([plate: Plate.includes_args(:wells)])
-      end
-
-      it 'returns a single well' do
-        well = create(:well_with_tagged_ont_requests)
-        expect(Well.resolved_well(id: well.id)).to eq(well)
-      end
-
-      it 'returns all wells' do
-        wells = create_list(:well_with_tagged_ont_requests, 3)
-        expect(Well.all_resolved_wells).to match_array(wells)
+        expect(Well.includes_args(:container_materials).flat_map(&:keys))
+          .to_not include(:container_materials)
       end
     end
   end

--- a/spec/models/well_spec.rb
+++ b/spec/models/well_spec.rb
@@ -25,4 +25,40 @@ RSpec.describe Well, type: :model do
     well = create(:well, position: 'B12')
     expect(well.column).to eq(12)
   end
+
+  context 'resolved' do
+    context 'instance' do
+      it 'returns a single well' do
+        well = create(:well_with_tagged_ont_requests)
+        expect(well.resolved_well).to eq(well)
+      end
+    end
+
+    context 'class' do
+      it 'returns expected includes_args' do
+        expect(Well.includes_args).to eq([
+          container_materials: :material,
+          plate: Plate.includes_args(:wells)
+        ])
+      end
+
+      it 'removes plate from includes_args' do
+        expect(Well.includes_args(:plate)).to eq([container_materials: :material])
+      end
+  
+      it 'removes container_materials from includes_args' do
+        expect(Well.includes_args(:container_materials)).to eq([plate: Plate.includes_args(:wells)])
+      end
+
+      it 'returns a single well' do
+        well = create(:well_with_tagged_ont_requests)
+        expect(Well.resolved_well(id: well.id)).to eq(well)
+      end
+
+      it 'returns all wells' do
+        wells = create_list(:well_with_tagged_ont_requests, 3)
+        expect(Well.all_resolved_wells).to match_array(wells)
+      end
+    end
+  end
 end

--- a/spec/models/well_spec.rb
+++ b/spec/models/well_spec.rb
@@ -29,26 +29,17 @@ RSpec.describe Well, type: :model do
   end
 
   context 'resolved' do
-    context 'instance' do
-      it 'returns a single well' do
-        well = create(:well_with_tagged_ont_requests)
-        expect(well.resolved_well).to eq(well)
-      end
+    it 'returns expected includes_args' do
+      expect(Well.includes_args.flat_map(&:keys)).to contain_exactly(:container_materials, :plate)
     end
 
-    context 'class' do
-      it 'returns expected includes_args' do
-        expect(Well.includes_args.flat_map(&:keys)).to contain_exactly(:container_materials, :plate)
-      end
+    it 'removes plate from includes_args' do
+      expect(Well.includes_args(:plate).flat_map(&:keys)).to_not include(:plate)
+    end
 
-      it 'removes plate from includes_args' do
-        expect(Well.includes_args(:plate).flat_map(&:keys)).to_not include(:plate)
-      end
-
-      it 'removes container_materials from includes_args' do
-        expect(Well.includes_args(:container_materials).flat_map(&:keys))
-          .to_not include(:container_materials)
-      end
+    it 'removes container_materials from includes_args' do
+      expect(Well.includes_args(:container_materials).flat_map(&:keys))
+        .to_not include(:container_materials)
     end
   end
 end


### PR DESCRIPTION
Closes #355 

Changes proposed in this pull request:

* Give each active record in the Ont pipeline a `includes_args` class method which returns a list of arguments to call in the `includes` class method.
* Allow specifying arguments to remove from this list to avoid circular dependencies (e.g. when drilling down from a run to a flowcell, you don't want the flowcell's args to again include the run)
* Where needed add a `resolved_query` method that returns a queryable object with all dependencies resolved
* Use the `resolved_query` method for GraphQL queries and mutations
