### PR TITLE
Allow fetching a run's experiment name

### DIFF
--- a/app/graphql/types/outputs/ont/run_type.rb
+++ b/app/graphql/types/outputs/ont/run_type.rb
@@ -8,6 +8,7 @@ module Types
         field :state, Types::Enums::Ont::RunStateEnum, 'The state of this run.', null: false
         field :deactivated_at, String, 'The date this run was deactivated.', null: true
         field :flowcells, [FlowcellType], 'An array of flowcells in this run.', null: false
+        field :experiment_name, String, 'The experiment name of this run.', null: false
       end
     end
   end

--- a/app/views/graphql/object/run/index.html
+++ b/app/views/graphql/object/run/index.html
@@ -450,6 +450,12 @@
   </div>
 </div>
 <div class="field-entry ">
+  <span id="experimentname" class="field-name anchored">experimentName (<code><a href="/v2/docs/scalar/string">String!</a></code>)</span>
+  <div class="description-wrapper">
+   <p>The experiment name of this run.</p>
+  </div>
+</div>
+<div class="field-entry ">
   <span id="flowcells" class="field-name anchored">flowcells (<code><a href="/v2/docs/object/flowcell">[Flowcell!]!</a></code>)</span>
   <div class="description-wrapper">
    <p>An array of flowcells in this run.</p>

--- a/lib/graphql_schema.graphql
+++ b/lib/graphql_schema.graphql
@@ -405,6 +405,11 @@ type Run {
   deactivatedAt: String
 
   """
+  The experiment name of this run.
+  """
+  experimentName: String!
+
+  """
   An array of flowcells in this run.
   """
   flowcells: [Flowcell!]!

--- a/lib/graphql_schema.json
+++ b/lib/graphql_schema.json
@@ -1466,6 +1466,24 @@
               "deprecationReason": null
             },
             {
+              "name": "experimentName",
+              "description": "The experiment name of this run.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "flowcells",
               "description": "An array of flowcells in this run.",
               "args": [

--- a/spec/requests/v2/ont/runs_spec.rb
+++ b/spec/requests/v2/ont/runs_spec.rb
@@ -15,12 +15,13 @@ RSpec.describe 'GraphQL', type: :request do
 
       it 'returns the run with valid ID' do
         post v2_path, params: { query:
-          "{ ontRun(id: #{run.id}) { id state deactivatedAt flowcells { id } } }" }
+          "{ ontRun(id: #{run.id}) { id state deactivatedAt experimentName flowcells { id } } }" }
         expect(response).to have_http_status(:success)
         json = ActiveSupport::JSON.decode(response.body)
         expect(json['data']['ontRun']).to include(
           'id' => run.id.to_s, 'state' => run.state.to_s.upcase,
           'deactivatedAt' => run.deactivated_at,
+          'experimentName' => run.experiment_name,
           'flowcells' => run.flowcells.map { |fc| { 'id' => fc.id.to_s } }
         )
       end


### PR DESCRIPTION
Links to https://github.com/sanger/traction-ui/issues/445

* Expose a run's experiment name in GraphQL queries

