### PR TITLE
Fix for libraries created without costcode

### DIFF
--- a/app/models/pacbio/library_factory.rb
+++ b/app/models/pacbio/library_factory.rb
@@ -134,7 +134,8 @@ module Pacbio
       def check_cost_codes
         request_libraries.each do |rl|
           id = rl.pacbio_request_id
-          errors.add('cost code', 'must be present') if Pacbio::Request.find(id).cost_code.empty?
+          request = Pacbio::Request.find(id)
+          errors.add('cost code', 'must be present') if ( request.cost_code.nil? || request.cost_code.empty? )
         end
       end
 

--- a/app/models/pacbio/library_factory.rb
+++ b/app/models/pacbio/library_factory.rb
@@ -135,7 +135,7 @@ module Pacbio
         request_libraries.each do |rl|
           id = rl.pacbio_request_id
           request = Pacbio::Request.find(id)
-          errors.add('cost code', 'must be present') if ( request.cost_code.nil? || request.cost_code.empty? )
+          errors.add('cost code', 'must be present') if request.cost_code.blank?
         end
       end
 

--- a/spec/models/pacbio/library_factory_spec.rb
+++ b/spec/models/pacbio/library_factory_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe Pacbio::LibraryFactory, type: :model, pacbio: true do
 
         context 'when the request libraries are invalid' do
           let(:request_empty_cost_code) { create(:pacbio_request, cost_code: "")}
+          let(:request_nil_cost_code) { create(:pacbio_request, cost_code: nil)}
 
           it 'produces an error if there is more than one request and a tag is missing' do
             invalid_request_attributes = [{id: requests[0].id, type: 'requests'}, {id: requests[1].id, type: 'requests', tag: { id: tags[0].id, type: 'tags'}}]
@@ -121,6 +122,15 @@ RSpec.describe Pacbio::LibraryFactory, type: :model, pacbio: true do
 
           it 'produces an error if any request contains an empty cost code' do
             invalid_request_attributes = [{id: request_empty_cost_code.id, type: 'requests', tag: { id: tags[0].id, type: 'tags'} }]
+            library_attributes = attributes_for(:pacbio_library).merge(requests: invalid_request_attributes)
+
+            factory = Pacbio::LibraryFactory.new(library_attributes)
+            expect(factory.valid?).to be_falsy
+            expect(factory.errors.full_messages).to eq(['Cost code must be present'])
+          end
+
+          it 'produces an error if any request contains a nil cost code' do
+            invalid_request_attributes = [{id: request_nil_cost_code.id, type: 'requests', tag: { id: tags[0].id, type: 'tags'} }]
             library_attributes = attributes_for(:pacbio_library).merge(requests: invalid_request_attributes)
 
             factory = Pacbio::LibraryFactory.new(library_attributes)


### PR DESCRIPTION
Changes proposed in this pull request:

* Updated library factory function to check for nil cost_code
* Added supporting test
* ...
