### PR TITLE
updated pool resource to return a formatted created_at timestamp

### DIFF
--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -28,6 +28,14 @@ module V1
       def self.records_for_populate(*_args)
         super.preload(source_wells: :plate)
       end
+
+      def created_at
+        @model.created_at.to_s(:us)
+      end
+
+      def updated_at
+        @model.updated_at.to_s(:us)
+      end
     end
   end
 end

--- a/spec/requests/v1/pacbio/pools_spec.rb
+++ b/spec/requests/v1/pacbio/pools_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'PoolsController', type: :request, pacbio: true do
       expect(pool_resource['concentration']).to eq(pool.concentration)
       expect(pool_resource['template_prep_kit_box_barcode']).to eq(pool.template_prep_kit_box_barcode)
       expect(pool_resource['insert_size']).to eq(pool.insert_size)
+      expect(pool_resource['created_at']).to eq(pool.created_at.to_s(:us))
     end
 
     it 'returns the correct attributes', aggregate_failures: true do


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* The timestamp needs to be formatted so it is easy to understand for the users and so that it can be filtered correctly
*
* ...
