### PR TITLE
Service work for - Bug library creation from sample

### DIFF
--- a/app/controllers/v1/pacbio/libraries_controller.rb
+++ b/app/controllers/v1/pacbio/libraries_controller.rb
@@ -4,68 +4,6 @@ module V1
   module Pacbio
     # LibrariesController
     class LibrariesController < ApplicationController
-      def create
-        @library_factory = ::Pacbio::LibraryFactory.new(params_names)
-        if @library_factory.save
-          @resources = LibraryResource.new(@library_factory.library, nil)
-          render json: serialize_resource(@resources), status: :created
-        else
-          render json: { data: { errors: @library_factory.errors.messages } },
-                 status: :unprocessable_entity
-        end
-      end
-
-      def update
-        library.update(library_update_params)
-        render_json(:ok)
-      rescue StandardError => e
-        render json: { data: { errors: e.message } }, status: :unprocessable_entity
-      end
-
-      def destroy
-        library.destroy
-        head :no_content
-      rescue StandardError => e
-        render json: { data: { errors: e.message } }, status: :unprocessable_entity
-      end
-
-      private
-
-      def library
-        @library = (params[:id] && ::Pacbio::Library.find_by(id: params[:id]))
-      end
-
-      # TODO: abtsract behaviour for params names into separate library.
-      def params_names
-        attributes.merge(relationships)
-      end
-
-      def attributes
-        params.require(:data).require(:attributes)
-              .permit(:volume, :concentration, :template_prep_kit_box_barcode,
-                      :insert_size, :relationships, :request_id, :tag_id)
-              .to_h
-      end
-
-      def relationships
-        relationships_data = params.require(:data).require(:relationships)
-        {
-          pacbio_request_id: relationships_data.dig(:request, :data, :id),
-          tag_id: relationships_data.dig(:tag, :data, :id)
-        }
-      end
-
-      # necessary so only certain library params can be updated without
-      # having to send unneccessary data in body of request
-      def library_update_params
-        params.require(:data).require(:attributes)
-              .permit(:volume, :concentration, :template_prep_kit_box_barcode, :insert_size)
-      end
-
-      def render_json(status)
-        render json: serialize_resource(LibraryResource.new(@library, nil)),
-               status: status
-      end
     end
   end
 end

--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -23,6 +23,7 @@ module Pacbio
                       inverse_of: :libraries
 
     has_one :sample, through: :request
+    has_one :tube, through: :pool
 
     # # This is dependent on the request association, so needs to be included
     # # after that is defined

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
         jsonapi_resources(:wells,         only: %i[index create update destroy]) {}
       end
 
-      jsonapi_resources :libraries,       only: %i[index create update destroy]
+      jsonapi_resources :libraries,       only: %i[index update destroy]
       jsonapi_resources :requests,        only: %i[index create update destroy]
       jsonapi_resources :tubes,           only: %i[index]
       jsonapi_resources :pools,           except: %i[destroy]

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -39,7 +39,7 @@ namespace :pacbio_data do
 
     Pacbio::Request.all.each_with_index do |request, _i|
       tube = Tube.create
-      library = Pacbio::Library.create!(
+      Pacbio::Library.create!(
         volume: 1,
         concentration: 1,
         template_prep_kit_box_barcode: 'LK12345',
@@ -54,8 +54,6 @@ namespace :pacbio_data do
                                     insert_size: lib.insert_size,
                                     libraries: [lib])
       end
-
-      ContainerMaterial.create(container: tube, material: library)
     end
     puts '-> Pacbio libraries successfully created'
 

--- a/spec/models/pacbio/library_spec.rb
+++ b/spec/models/pacbio/library_spec.rb
@@ -39,11 +39,9 @@ RSpec.describe Pacbio::Library, type: :model, pacbio: true do
     expect(build(:pacbio_library, pool: pool).pool).to eq(pool)
   end
 
-  it 'can have a tube' do
-    library = create(:pacbio_library)
-    tube = create(:tube)
-    create(:container_material, container: tube, material: library)
-    expect(library.tube).to eq tube
+  it 'can have a tube through pool' do
+    pool = create(:pacbio_pool)
+    expect(build(:pacbio_library, pool: pool).tube).to eq(pool.tube)
   end
 
   describe '#request' do
@@ -65,11 +63,6 @@ RSpec.describe Pacbio::Library, type: :model, pacbio: true do
     let(:library_model) { Pacbio::Library }
 
     it_behaves_like 'library'
-  end
-
-  context 'tube material' do
-    let(:material_model) { :pacbio_library }
-    it_behaves_like "tube_material"
   end
 
   describe '#source_identifier' do


### PR DESCRIPTION
Closes #
Service work for https://github.com/sanger/traction-ui/pull/671

Changes proposed in this pull request:

* Removed ability to create library (single plexed pool) from library resource
* Added tube relationship to library via its parent pool
* ...
