### PR TITLE
Issue752/dpl 396 as a team lead {james} i would like to create libraries without the qc data so we can print barcodes in the lab and freeze them

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,7 +74,6 @@ RSpec/IdenticalEqualityAssertion:
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Exclude:
-    - 'spec/models/pacbio/library_factory_spec.rb'
     - 'spec/requests/v1/pacbio/runs_spec.rb'
     - 'spec/requests/v1/saphyr/runs_spec.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,6 @@
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/pipelines/pipelines_spec.rb'
-    - 'spec/requests/v1/pacbio/libraries_spec.rb'
 
 # Offense count: 1
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
@@ -82,8 +81,6 @@ RSpec/LetSetup:
   Exclude:
     - 'spec/models/plate_spec.rb'
     - 'spec/models/tube_spec.rb'
-    - 'spec/requests/v1/pacbio/libraries_spec.rb'
-    - 'spec/requests/v1/pacbio/pools_spec.rb'
     - 'spec/requests/v1/pacbio/runs/plates_spec.rb'
     - 'spec/requests/v1/pacbio/runs/wells_spec.rb'
     - 'spec/requests/v1/pacbio/runs_spec.rb'

--- a/app/models/concerns/nested_validation.rb
+++ b/app/models/concerns/nested_validation.rb
@@ -30,7 +30,7 @@ module NestedValidation
 
     def validate_each(record, attribute, value)
       Array(value).each do |nested|
-        next if nested.valid?
+        next if nested.valid?(options[:context])
 
         add_errors(nested, record, attribute)
       end
@@ -42,10 +42,10 @@ module NestedValidation
       nested.errors.each do |error|
         if @flatten_keys
           record.errors.add(error.attribute, error.message)
-        elsif nested_attribute == :base
-          record.errors.add(attribute, nested_error)
+        elsif error.attribute == :base
+          record.errors.add(attribute, error.message)
         else
-          record.errors.add("#{attribute}.#{nested_attribute}", nested_error)
+          record.errors.add("#{attribute}.#{error.attribute}", error.message)
         end
       end
     end

--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -14,7 +14,9 @@ module Pacbio
     include SampleSheet::Library
 
     validates :volume, :concentration,
-              :insert_size, presence: true
+              :insert_size, presence: true, on: :run_creation
+    validates :volume, :concentration,
+              :insert_size, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 
     belongs_to :request, class_name: 'Pacbio::Request', foreign_key: :pacbio_request_id,
                          inverse_of: :libraries

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -18,6 +18,11 @@ module Pacbio
     validates :libraries, presence: true
     validates_with TagValidator
 
+    validates :volume, :concentration,
+              :insert_size, :template_prep_kit_box_barcode, presence: true, on: :run_creation
+    validates :volume, :concentration,
+              :insert_size, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+
     def library_attributes=(library_options)
       self.libraries = library_options.map do |attributes|
         if attributes['id']

--- a/app/models/pacbio/well_factory.rb
+++ b/app/models/pacbio/well_factory.rb
@@ -11,7 +11,6 @@ module Pacbio
     extend NestedValidation
 
     validates_nested :wells
-    # validates :wells, presence: { message: :empty }
     validates :wells, presence: true
 
     def initialize(attributes = [])
@@ -93,11 +92,14 @@ module Pacbio
 
       # WellFactory::Well::Pools
       class Pools
+        extend NestedValidation
         include ActiveModel::Model
+
         attr_reader :well, :pools
 
         validate :check_tags_present, if: :multiple_libraries
         validate :check_tags_uniq, if: :multiple_libraries
+        validates_nested :libraries, context: :run_creation
 
         def initialize(well, pool_attributes)
           @well = well

--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require './app/resources/v1/shared/run_suitability'
+
 module V1
   module Pacbio
     # LibraryResource
     class LibraryResource < JSONAPI::Resource
+      include RunSuitability
+
       model_name 'Pacbio::Library'
 
       attributes :state, :volume, :concentration, :template_prep_kit_box_barcode,

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require './app/resources/v1/shared/run_suitability'
+
 module V1
   module Pacbio
     # PoolResource
     class PoolResource < JSONAPI::Resource
+      include RunSuitability
+
       model_name 'Pacbio::Pool'
 
       # If we don't specify the relation_name here, jsonapi-resources

--- a/app/resources/v1/shared/run_suitability.rb
+++ b/app/resources/v1/shared/run_suitability.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Include in a resource to add the run suitability attribute which evalutates
+# if the resource can be used to generate a run. It does this by:
+# - Calling valid? in the run_creation context
+#   @see https://guides.rubyonrails.org/active_record_validations.html#on
+# - Uses the JsonAPI resources ValidationErrors object to generate JSON-API
+#   compatible errors objects. Status is removed as it is not relevant in
+#   this context. @see https://jsonapi.org/format/#error-objects
+module RunSuitability
+  extend ActiveSupport::Concern
+
+  included do
+    attribute :run_suitability, readonly: true
+  end
+
+  def run_suitability
+    {
+      ready_for_run: @model.valid?(:run_creation),
+      errors: inline_errors_object
+    }
+  end
+
+  private
+
+  def inline_errors_object
+    JSONAPI::Exceptions::ValidationErrors.new(self).errors.as_json.map do |err|
+      err.except('status')
+    end
+  end
+end

--- a/spec/factories/pacbio/libraries.rb
+++ b/spec/factories/pacbio/libraries.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
     tag { create(:tag) }
     pool { association :pacbio_pool, libraries: [instance] }
 
+    factory :pacbio_incomplete_library do
+      insert_size { nil }
+    end
+
     # Untagged should possibly be the default
     factory :pacbio_library_without_tag do
       untagged

--- a/spec/models/pacbio/library_spec.rb
+++ b/spec/models/pacbio/library_spec.rb
@@ -3,18 +3,84 @@
 require 'rails_helper'
 
 RSpec.describe Pacbio::Library, type: :model, pacbio: true do
+  subject { build(:pacbio_library, params) }
+
   context 'uuidable' do
     let(:uuidable_model) { :pacbio_library }
 
     it_behaves_like 'uuidable'
   end
 
-  it 'must have a volume' do
-    expect(build(:pacbio_library, volume: nil)).not_to be_valid
+  context 'when volume is nil' do
+    let(:params) { { volume: nil } }
+
+    it { is_expected.to be_valid }
   end
 
-  it 'must have a concentration' do
-    expect(build(:pacbio_library, concentration: nil)).not_to be_valid
+  context 'when volume is positive' do
+    let(:params) { { volume: 23 } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when volume is negative' do
+    let(:params) { { volume: -23 } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when volume is "a word"' do
+    let(:params) { { volume: 'a word' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when concentration is nil' do
+    let(:params) { { concentration: nil } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when concentration is positive' do
+    let(:params) { { concentration: 23 } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when concentration is negative' do
+    let(:params) { { concentration: -23 } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when concentration is "a word"' do
+    let(:params) { { concentration: 'a word' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when insert_size is nil' do
+    let(:params) { { insert_size: nil } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when insert_size is positive' do
+    let(:params) { { insert_size: 23 } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when insert_size is negative' do
+    let(:params) { { insert_size: -23 } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when insert_size is "a word"' do
+    let(:params) { { insert_size: 'a word' } }
+
+    it { is_expected.not_to be_valid }
   end
 
   it 'can have a template prep kit box barcode' do
@@ -22,27 +88,23 @@ RSpec.describe Pacbio::Library, type: :model, pacbio: true do
     expect(create(:pacbio_library).template_prep_kit_box_barcode).to be_present
   end
 
-  it 'must have a insert size' do
-    expect(build(:pacbio_library, insert_size: nil)).not_to be_valid
-  end
-
   it 'can have a request' do
-    request = create(:pacbio_request)
+    request = build(:pacbio_request)
     expect(build(:pacbio_library, request: request).request).to eq(request)
   end
 
   it 'can have a tag' do
-    tag = create(:tag)
+    tag = build(:tag)
     expect(build(:pacbio_library, tag: tag).tag).to eq(tag)
   end
 
   it 'can have a pool' do
-    pool = create(:pacbio_pool)
+    pool = build(:pacbio_pool)
     expect(build(:pacbio_library, pool: pool).pool).to eq(pool)
   end
 
   it 'can have a tube through pool' do
-    pool = create(:pacbio_pool)
+    pool = build(:pacbio_pool)
     expect(build(:pacbio_library, pool: pool).tube).to eq(pool.tube)
   end
 

--- a/spec/models/pacbio/pool_spec.rb
+++ b/spec/models/pacbio/pool_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Pacbio::Pool, type: :model, pacbio: true do
+  subject(:pool) { build(:pacbio_pool, params) }
+
   let(:libraries) { create_list(:pacbio_library, 5) }
+  let(:params) { {} }
 
   it 'will have a tube on validation' do
-    pool = build(:pacbio_pool)
     pool.valid?
     expect(pool.tube).to be_a(Tube)
   end
@@ -17,22 +19,18 @@ RSpec.describe Pacbio::Pool, type: :model, pacbio: true do
   end
 
   it 'can have a template prep kit box barcode' do
-    pool = build(:pacbio_pool)
     expect(pool.template_prep_kit_box_barcode).to be_present
   end
 
   it 'can have a volume' do
-    pool = build(:pacbio_pool)
     expect(pool.volume).to be_present
   end
 
   it 'can have a concentration' do
-    pool = build(:pacbio_pool)
     expect(pool.concentration).to be_present
   end
 
   it 'can have a insert size' do
-    pool = build(:pacbio_pool)
     expect(pool.insert_size).to be_present
   end
 
@@ -44,6 +42,130 @@ RSpec.describe Pacbio::Pool, type: :model, pacbio: true do
     dodgy_library = build(:pacbio_library, volume: 'big')
 
     expect(build(:pacbio_pool, libraries: libraries + [dodgy_library])).not_to be_valid
+  end
+
+  describe '#valid?(:run_creation)' do
+    subject { pool.valid?(:run_creation) }
+
+    context 'when volume is nil' do
+      let(:params) { { volume: nil } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when concentration is nil' do
+      let(:params) { { concentration: nil } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when insert_size is nil' do
+      let(:params) { { insert_size: nil } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when template_prep_kit_box_barcode is nil' do
+      let(:params) { { template_prep_kit_box_barcode: nil } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when volume is 12.0' do
+      let(:params) { { volume: 12.0 } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when concentration is 12.0' do
+      let(:params) { { concentration: 12.0 } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when insert_size is 12.0' do
+      let(:params) { { insert_size: 12.0 } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when template_prep_kit_box_barcode is "1234"' do
+      let(:params) { { template_prep_kit_box_barcode: '1234' } }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  context 'when volume is nil' do
+    let(:params) { { volume: nil } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when volume is positive' do
+    let(:params) { { volume: 23 } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when volume is negative' do
+    let(:params) { { volume: -23 } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when volume is "a word"' do
+    let(:params) { { volume: 'a word' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when concentration is nil' do
+    let(:params) { { concentration: nil } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when concentration is positive' do
+    let(:params) { { concentration: 23 } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when concentration is negative' do
+    let(:params) { { concentration: -23 } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when concentration is "a word"' do
+    let(:params) { { concentration: 'a word' } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when insert_size is nil' do
+    let(:params) { { insert_size: nil } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when insert_size is positive' do
+    let(:params) { { insert_size: 23 } }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when insert_size is negative' do
+    let(:params) { { insert_size: -23 } }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when insert_size is "a word"' do
+    let(:params) { { insert_size: 'a word' } }
+
+    it { is_expected.not_to be_valid }
   end
 
   describe '#library_attributes=' do

--- a/spec/models/pacbio/pool_spec.rb
+++ b/spec/models/pacbio/pool_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Pacbio::Pool, type: :model, pacbio: true do
   end
 
   it 'is not valid unless all of the associated libraries are valid' do
-    dodgy_library = build(:pacbio_library, volume: nil)
+    dodgy_library = build(:pacbio_library, volume: 'big')
 
     expect(build(:pacbio_pool, libraries: libraries + [dodgy_library])).not_to be_valid
   end

--- a/spec/models/pacbio/well_factory_spec.rb
+++ b/spec/models/pacbio/well_factory_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe Pacbio::WellFactory, type: :model, pacbio: true do
         expect(factory.save).to be_falsey
         expect(factory.errors.messages[:wells]).not_to be_empty
       end
+
+      context 'if pools are invalid for run creation' do
+        let(:pools) { create_list(:pacbio_pool, 3, library_factory: :pacbio_incomplete_library) }
+
+        it 'will make sure wells are valid for run creation' do
+          factory = described_class.new(wells_attributes)
+          expect(factory.save).to be_falsey
+        end
+      end
     end
 
     describe '#errors' do

--- a/spec/requests/v1/pacbio/pools_spec.rb
+++ b/spec/requests/v1/pacbio/pools_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe 'PoolsController', type: :request, pacbio: true do
                       template_prep_kit_box_barcode: 'LK1234567',
                       volume: 1.11,
                       concentration: 2.22,
+                      insert_size: 'Sausages',
                       pacbio_request_id: request.id,
                       tag_id: tag.id
                     }


### PR DESCRIPTION
Closes #752

Changes proposed in this pull request:

* Removes validation of presence of volume, concentration, insert size on library creation
* Adds run_creation validation scope which enforces this instead
* Refines validation on volume, concentration, insert size
* Validates libraries are valid for run creation on run creation
* Adds field describing suitability for run creation to API