### PR TITLE
Make method name generic

### DIFF
--- a/app/models/qc_results_upload_factory.rb
+++ b/app/models/qc_results_upload_factory.rb
@@ -160,7 +160,7 @@ class QcResultsUploadFactory
       assay_type ? assay_type.key : header.strip
     end
 
-    csv = CSV.new(csv_string_without_groups, headers: true, header_converters: header_converter)
+    csv = CSV.new(csv_string_without_first_row, headers: true, header_converters: header_converter)
 
     arr_of_hashes = csv.to_a.map(&:to_hash)
 
@@ -173,7 +173,7 @@ class QcResultsUploadFactory
 
   # Returns the CSV, with the first row (groupings) removed
   # @return [String] CSV
-  def csv_string_without_groups
+  def csv_string_without_first_row
     csv_data.split("\n")[1..].join("\n")
   end
 end

--- a/spec/models/qc_results_upload_factory_spec.rb
+++ b/spec/models/qc_results_upload_factory_spec.rb
@@ -255,11 +255,12 @@ RSpec.describe QcResultsUploadFactory do
     end
   end
 
-  describe '#csv_string_without_groups' do
+  describe '#csv_string_without_first_row' do
     let(:factory) { build(:qc_results_upload_factory) }
 
     it 'returns the csv header row' do
-      expect(factory.csv_string_without_groups).to be_a String
+      expect(factory.csv_string_without_first_row).to be_a String
+      expect(factory.csv_string_without_first_row).not_to include 'SAMPLE INFORMATION'
     end
   end
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Changed a method name to make it more generic

Non-blocking relationship with: https://github.com/sanger/traction-ui/pull/1038