### PR TITLE
Rake task fix for smrt link versions on training

### DIFF
--- a/config/pacbio_smrt_link_versions.yml
+++ b/config/pacbio_smrt_link_versions.yml
@@ -151,9 +151,8 @@ default: &default
         - v11
 
 development: *default
-
 test: *default
-
 production: *default
-
 uat: *default
+training: *default
+


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

Use default block for training in config/pacbio_smrt_link_versions.yml
