### PR TITLE
Bug fix - QC Result pipeline was not being loaded correctly.

### DIFF
--- a/app/pipelines/pipelines.rb
+++ b/app/pipelines/pipelines.rb
@@ -8,11 +8,12 @@ module Pipelines
   # In order to maintain consistent numbering, this has been pulled out into
   # a constant. Please do *not* remove entries from this list, as it could
   # result in legacy data being reassigned to the incorrect pipelines
-  ENUMS = { pacbio: 0, ont: 1, saphyr: 2 }.freeze
+  ENUMS = { pacbio: 0, ont: 1, saphyr: 2, qc_result: 3 }.freeze
   HANDLERS = {
     pacbio: Pacbio,
     ont: Ont,
-    saphyr: Saphyr
+    saphyr: Saphyr,
+    qc_result: QcResult
   }.with_indifferent_access.freeze
   PIPELINES_DIR = 'config/pipelines'
 


### PR DESCRIPTION
Fixed issue where QcResult pipeline wasn't being loaded in the pipelines config
This was introduced when I changed the way pipelines were loaded in #888 
