### PR TITLE
Removed duplicate barcode filters in pacbio pool resource

### DIFF
--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -29,25 +29,18 @@ module V1
       #   [{ field: 'created_at', direction: :desc }]
       # end
 
-      # This could be changed so a pool has a barcode through tube
-      filter :barcode, apply: lambda { |records, value, _options|
-        records.where(tube: Tube.find_by(barcode: value))
-      }
-
       filter :sample_name, apply: lambda { |records, value, _options|
         # We have to join requests and samples here in order to find by sample name
         records.joins(libraries: :sample).where(sample: { name: value })
       }
 
+      filter :barcode, apply: lambda { |records, value, _options|
+        records.joins(:tube).where(tube: { barcode: value })
+      }
+
       # When a pool is updated and it is attached to a run we need
       # to republish the messages for the run
       after_update :publish_messages
-
-      # Filters
-      # join pool with tube as a pool has a barcode through tube
-      filter :barcode, apply: lambda { |records, value, _options|
-                                records.joins(:tube).where(tube: { barcode: value })
-                              }
 
       def library_attributes=(library_parameters)
         @model.library_attributes = library_parameters.map do |library|


### PR DESCRIPTION
Remove duplicate pool barcode filter in pacbio pool resource. Spotted in PR from develop -> master. Should make no impact but for clarity it should be cleaned up.
