### PR TITLE
DPL-705 Prevent pacbio pulling back all records

### DIFF
--- a/app/resources/v1/pacbio/plate_resource.rb
+++ b/app/resources/v1/pacbio/plate_resource.rb
@@ -10,14 +10,11 @@ module V1
 
       has_many :wells
 
-      # We can only make this endpoint paginated when pacbio pool/new page
-      # No longer requires all records to be pulled back
-      #
-      # paginator :paged
+      paginator :paged
 
-      # def self.default_sort
-      #   [{ field: 'created_at', direction: :desc }]
-      # end
+      def self.default_sort
+        [{ field: 'created_at', direction: :desc }]
+      end
 
       filter :barcode
 

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -20,14 +20,11 @@ module V1
                  :library_attributes
       attribute :source_identifier, readonly: true
 
-      # We can only make this endpoint paginated when pacbio run create/edit page
-      # No longer requires all records to be pulled back
-      #
-      # paginator :paged
+      paginator :paged
 
-      # def self.default_sort
-      #   [{ field: 'created_at', direction: :desc }]
-      # end
+      def self.default_sort
+        [{ field: 'created_at', direction: :desc }]
+      end
 
       filter :sample_name, apply: lambda { |records, value, _options|
         # We have to join requests and samples here in order to find by sample name

--- a/app/resources/v1/pacbio/request_resource.rb
+++ b/app/resources/v1/pacbio/request_resource.rb
@@ -16,9 +16,7 @@ module V1
       has_one :plate, relation_name: :plate
       has_one :tube, relation_name: :tube
 
-      # Commented out until we have updates pacbio pools/new to search for plates/tubes
-      # via the service
-      # paginator :paged
+      paginator :paged
 
       filter :species, apply: lambda { |records, value, _options|
         # We have to join requests and samples here in order to find by sample name

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -7,11 +7,11 @@ namespace :pacbio_data do
   task create: [:environment, 'tags:create:pacbio_sequel', 'tags:create:pacbio_isoseq'] do
     require_relative 'reception_generator'
 
-    puts '-> Creating pacbio plates...'
+    puts '-> Creating pacbio plates and tubes...'
 
     reception_generator = ReceptionGenerator.new(
       number_of_plates: 5,
-      number_of_tubes: 0,
+      number_of_tubes: 5,
       wells_per_plate: 48,
       pipeline: :pacbio
     ).tap(&:construct_resources!)

--- a/lib/tasks/reception_generator.rb
+++ b/lib/tasks/reception_generator.rb
@@ -62,7 +62,7 @@ class ReceptionGenerator
     @number_of_tubes.times.map do
       barcode = @barcodes.next
       library_type = @library_types.next
-      data_type = @data_types.next
+      data_type = begin; @data_types.next; rescue StopIteration; nil; end
       {
         request: request(library_type, data_type),
         sample:,

--- a/lib/tasks/reception_generator.rb
+++ b/lib/tasks/reception_generator.rb
@@ -35,11 +35,14 @@ class ReceptionGenerator
 
   private
 
+  # Rubocop wants us to use .empty instead of size > 0
+  # But enumerators don't have a .empty method
+  # rubocop:disable Style/ZeroLengthPredicate
   def plates
     @number_of_plates.times.flat_map do
       barcode = @barcodes.next
       library_type = @library_types.next
-      data_type = begin; @data_types.next; rescue StopIteration; nil; end
+      data_type = @data_types.next if @data_types.size > 0
       @well_positions.take(@wells_per_plate).map do |position|
         {
           request: request(library_type, data_type),
@@ -62,7 +65,7 @@ class ReceptionGenerator
     @number_of_tubes.times.map do
       barcode = @barcodes.next
       library_type = @library_types.next
-      data_type = begin; @data_types.next; rescue StopIteration; nil; end
+      data_type = @data_types.next if @data_types.size > 0
       {
         request: request(library_type, data_type),
         sample:,
@@ -70,4 +73,5 @@ class ReceptionGenerator
       }
     end
   end
+  # rubocop:enable Style/ZeroLengthPredicate
 end

--- a/spec/requests/v1/pacbio/plates_spec.rb
+++ b/spec/requests/v1/pacbio/plates_spec.rb
@@ -124,10 +124,13 @@ RSpec.describe 'PlatesController' do
         get "#{v1_pacbio_plates_path}?filter[barcode]=#{barcodes.join(',')}",
             headers: json_api_headers
         expect(response).to have_http_status(:success)
-        json = ActiveSupport::JSON.decode(response.body)
-        expect(json['data'].length).to eq(barcodes.length)
-        expect(json['data'][0]['attributes']['barcode']).to eq barcodes[0]
-        expect(json['data'][1]['attributes']['barcode']).to eq barcodes[1]
+        pacbio_plates[0..1].each do |plate|
+          plate_attributes = find_resource(type: 'plates', id: plate.id)['attributes']
+          expect(plate_attributes).to include(
+            'barcode' => plate.barcode,
+            'created_at' => plate.created_at.to_fs(:us)
+          )
+        end
       end
     end
   end

--- a/spec/requests/v1/pacbio/plates_spec.rb
+++ b/spec/requests/v1/pacbio/plates_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'PlatesController' do
       end
     end
 
-    context 'pagination', skip: 'Pagination is disabled until pacbio pool/new page is changed' do
+    context 'pagination' do
       let!(:expected_plates) { create_list(:plate_with_wells_and_requests, 5, pipeline: 'pacbio', created_at: Time.zone.now + 10) }
 
       before do

--- a/spec/requests/v1/pacbio/pools_spec.rb
+++ b/spec/requests/v1/pacbio/pools_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'PoolsController', pacbio: true do
       expect(library_attributes['insert_size']).to eq(library.insert_size)
     end
 
-    context 'pagination', skip: 'Pagination is disabled until pacbio runs page is changed' do
+    context 'pagination' do
       let!(:expected_pools) { create_list(:pacbio_pool, 2, created_at: Time.zone.now + 10) }
 
       before do

--- a/spec/requests/v1/pacbio/requests_spec.rb
+++ b/spec/requests/v1/pacbio/requests_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'RequestsController', pacbio: true do
     end
 
     context 'pagination' do
-      context 'default', skip: 'Pagination is disabled until pacbio pool/new page is changed' do
+      context 'default' do
         let!(:expected_requests) { create_list(:pacbio_request, 2, created_at: Time.zone.now + 10) }
 
         before do

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -41,13 +41,14 @@ RSpec.describe 'RunsController' do
       expect(response).to have_http_status(:success), response.body
       json = ActiveSupport::JSON.decode(response.body)
 
-      expect(json['data'][0]['relationships']['plate']).to be_present
-      expect(json['data'][0]['relationships']['plate']['data']['type']).to eq 'plates'
-      expect(json['data'][0]['relationships']['plate']['data']['id']).to eq plate1.id.to_s
-
-      expect(json['data'][1]['relationships']['plate']).to be_present
-      expect(json['data'][1]['relationships']['plate']['data']['type']).to eq 'plates'
-      expect(json['data'][1]['relationships']['plate']['data']['id']).to eq plate2.id.to_s
+      plate1_attributes = find_included_resource(type: 'plates', id: plate1.id)['attributes']
+      expect(plate1_attributes).to include(
+        'pacbio_run_id' => run1.id
+      )
+      plate2_attributes = find_included_resource(type: 'plates', id: plate2.id)['attributes']
+      expect(plate2_attributes).to include(
+        'pacbio_run_id' => run2.id
+      )
 
       expect(json['data'][0]['relationships']['smrt_link_version']).to be_present
       expect(json['data'][0]['relationships']['smrt_link_version']['data']['type']).to eq 'smrt_link_versions'

--- a/spec/requests/v1/pacbio/tubes_spec.rb
+++ b/spec/requests/v1/pacbio/tubes_spec.rb
@@ -24,4 +24,54 @@ RSpec.describe 'TubesController' do
       expect(find_included_resource(type: 'pools', id: pacbio_pool.id)).to be_present
     end
   end
+
+  describe 'filter' do
+    context 'when filtering by barcode' do
+      let(:tubes_with_request) { create_list(:tube_with_pacbio_request, 2) }
+
+      it 'returns the correct tube' do
+        barcode = tubes_with_request[0].barcode
+        get "#{v1_pacbio_tubes_path}?filter[barcode]=#{barcode}", headers: json_api_headers
+        expect(response).to have_http_status(:success)
+        json = ActiveSupport::JSON.decode(response.body)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['barcode']).to eq barcode
+      end
+
+      it 'accepts case-insensitive barcode' do
+        barcode = tubes_with_request[0].barcode
+        downcased = barcode.downcase
+        get "#{v1_pacbio_tubes_path}?filter[barcode]=#{downcased}", headers: json_api_headers
+        expect(response).to have_http_status(:success)
+        json = ActiveSupport::JSON.decode(response.body)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['barcode']).to eq barcode
+      end
+    end
+
+    context 'filtering by barcodes' do
+      let(:tubes_with_library) { create_list(:tube_with_pacbio_library, 4) }
+
+      it 'returns the correct tubes' do
+        barcodes = tubes_with_library.map(&:barcode)[0..1]
+        get "#{v1_pacbio_tubes_path}?filter[barcode]=#{barcodes.join(',')}", headers: json_api_headers
+        expect(response).to have_http_status(:success)
+        json = ActiveSupport::JSON.decode(response.body)
+        expect(json['data'].length).to eq(barcodes.length)
+        expect(json['data'][0]['attributes']['barcode']).to eq barcodes[0]
+        expect(json['data'][1]['attributes']['barcode']).to eq barcodes[1]
+      end
+
+      it 'accepts multiple case-insensitive barcodes' do
+        barcodes = tubes_with_library.map(&:barcode)[0..1]
+        downcased = barcodes.map(&:downcase)
+        get "#{v1_pacbio_tubes_path}?filter[barcode]=#{downcased.join(',')}", headers: json_api_headers
+        expect(response).to have_http_status(:success)
+        json = ActiveSupport::JSON.decode(response.body)
+        expect(json['data'].length).to eq(barcodes.length)
+        expect(json['data'][0]['attributes']['barcode']).to eq barcodes[0]
+        expect(json['data'][1]['attributes']['barcode']).to eq barcodes[1]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changes proposed in this pull request:

* Updated pacbio resources missing pagination. (plates, tubes and requests)
* Updated reception generator to handle iteration errors for tube creation

This PR is coupled with: https://github.com/sanger/traction-ui/pull/1110