### PR TITLE
DPL-725 - Added ability to wildcard search by barcode for pacbio library resource

### DIFF
--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -34,6 +34,11 @@ module V1
         records.joins(:sample).where(sample: { name: value })
       }
       filter :barcode, apply: lambda { |records, value, _options|
+        # If wildcard is the last value passed we want to do a wildcard search
+        if value.last == 'wildcard'
+          return records.joins(:tube).where('tubes.barcode LIKE ?', "%#{value[0]}%")
+        end
+
         records.joins(:tube).where(tube: { barcode: value })
       }
       filter :source_identifier, apply: lambda { |records, value, _options|

--- a/spec/requests/v1/pacbio/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/libraries_spec.rb
@@ -229,6 +229,54 @@ RSpec.describe 'LibrariesController', pacbio: true do
           )
         end
       end
+
+      context 'filters - barcode' do
+        it 'returns the correct library' do
+          pacbio_library = create(:pacbio_library)
+          # Create extra libraries to prevent false positive
+          create_list(:pacbio_library, 5)
+          get "#{v1_pacbio_libraries_path}?filter[barcode]=#{pacbio_library.tube.barcode}",
+              headers: json_api_headers
+
+          expect(response).to have_http_status(:success)
+          expect(json['data'].length).to eq(1)
+          library_attributes = find_resource(type: 'libraries', id: pacbio_library.id)['attributes']
+          expect(library_attributes).to include(
+            'concentration' => pacbio_library.concentration,
+            'volume' => pacbio_library.volume,
+            'template_prep_kit_box_barcode' => pacbio_library.template_prep_kit_box_barcode,
+            'insert_size' => pacbio_library.insert_size,
+            'state' => pacbio_library.state,
+            'created_at' => pacbio_library.created_at.to_fs(:us)
+          )
+        end
+
+        it 'returns the correct libraries from a wildcard search' do
+          pacbio_libraries = []
+          (1..5).each do |i|
+            pacbio_tube = create(:tube_with_pacbio_request, barcode: "test-100#{i}")
+            pacbio_libraries << create(:pacbio_library, tube: pacbio_tube)
+          end
+          # Create extra libraries to prevent false positive
+          create_list(:pacbio_library, 5)
+          get "#{v1_pacbio_libraries_path}?filter[barcode]=test-100,wildcard",
+              headers: json_api_headers
+
+          expect(response).to have_http_status(:success)
+          expect(json['data'].length).to eq(5)
+          pacbio_libraries.each do |library|
+            library_attributes = find_resource(type: 'libraries', id: library.id)['attributes']
+            expect(library_attributes).to include(
+              'concentration' => library.concentration,
+              'volume' => library.volume,
+              'template_prep_kit_box_barcode' => library.template_prep_kit_box_barcode,
+              'insert_size' => library.insert_size,
+              'state' => library.state,
+              'created_at' => library.created_at.to_fs(:us)
+            )
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Added ability to wildcard search by barcode for pacbio library resource


Note:
Im not the biggest fan of having to pass a 'wildcard' string with the search value but jsonapi-resources doesn't allow any extra values to be passed in the filters.