### PR TITLE
fix (config): add missing pre_extension_time to v12_revio

### DIFF
--- a/config/pacbio_smrt_link_versions.yml
+++ b/config/pacbio_smrt_link_versions.yml
@@ -127,6 +127,7 @@ default: &default
       versions:
         - v10
         - v11
+        - v12_revio
     loading_target_p1_plus_p2:
       key: loading_target_p1_plus_p2
       label: 'Loading Target (P1 + P2)'
@@ -205,4 +206,3 @@ test: *default
 production: *default
 uat: *default
 training: *default
-


### PR DESCRIPTION
Changes proposed in this pull request:

- Add missing `pre_extension_time` key to config for v12_revio