### PR TITLE
Update seeding data for v11 and v12_revio

### DIFF
--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -116,24 +116,48 @@ namespace :pacbio_data do
 
     print "   -> Creating runs for #{v12_revio.name}..."
     pool_records.each_with_index do |pool, i|
+      plate1 = Pacbio::Plate.new(
+        sequencing_kit_box_barcode: "SKB#{pool.id}",
+        plate_number: 1,
+        wells: [Pacbio::Well.new(
+          pools: [pool],
+          row: 'A',
+          column: 1,
+          pre_extension_time: 2,
+          movie_acquisition_time:	24.0,
+          include_base_kinetics:	'True',
+          library_concentration:	1,
+          polymerase_kit:	"PK12#{i}"
+        )]
+      )
+      plate2 = Pacbio::Plate.new(
+        sequencing_kit_box_barcode: "SKB#{pool.id}",
+        plate_number: 2,
+        wells: [Pacbio::Well.new(
+          pools: [pool],
+          row: 'A',
+          column: 1,
+          pre_extension_time: 2,
+          movie_acquisition_time:	24.0,
+          include_base_kinetics:	'True',
+          library_concentration:	1,
+          polymerase_kit:	"PK12#{i}"
+        ), Pacbio::Well.new(
+          pools: [pool],
+          row: 'B',
+          column: 1,
+          pre_extension_time: 2,
+          movie_acquisition_time:	24.0,
+          include_base_kinetics:	'True',
+          library_concentration:	1,
+          polymerase_kit:	"PK12#{i}"
+        )]
+      )
       Pacbio::Run.create!(
         system_name: Pacbio::Run.system_names['Revio'],
         smrt_link_version: v12_revio,
         dna_control_complex_box_barcode: "DCCB#{pool.id}",
-        plates: [Pacbio::Plate.new(
-          sequencing_kit_box_barcode: "SKB#{pool.id}",
-          plate_number: 1,
-          wells: [Pacbio::Well.new(
-            pools: [pool],
-            row: 'A',
-            column: 1,
-            pre_extension_time: 2,
-            movie_acquisition_time:	24.0,
-            include_base_kinetics:	'True',
-            library_concentration:	1,
-            polymerase_kit:	"PK12#{i}"
-          )]
-        )]
+        plates: [plate1] + (i > 2 ? [plate2] : [])
       )
     end
     print COMPLETED

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -58,7 +58,24 @@ namespace :pacbio_data do
 
     puts '-> Creating pacbio runs...'
     pool_records.each_with_index do |pool, i|
-      Pacbio::Run.create!(name: "Run#{pool.id}", dna_control_complex_box_barcode: "DCCB#{pool.id}", plates: [Pacbio::Plate.new(sequencing_kit_box_barcode: "SKB#{pool.id}", plate_number: 1, wells: [Pacbio::Well.new(pools: [pool], movie_time: 20, on_plate_loading_concentration: 1, row: 'A', column: i + 1, generate_hifi: 'In SMRT Link', ccs_analysis_output: 'Yes', binding_kit_box_barcode: "BKB#{pool.id}")])])
+      Pacbio::Run.create!(
+        name: "Run#{pool.id}",
+        dna_control_complex_box_barcode: "DCCB#{pool.id}",
+        plates: [Pacbio::Plate.new(
+          sequencing_kit_box_barcode: "SKB#{pool.id}",
+          plate_number: 1,
+          wells: [Pacbio::Well.new(
+            pools: [pool],
+            row: 'A',
+            column: i + 1,
+            ccs_analysis_output: 'Yes',
+            generate_hifi: 'In SMRT Link',
+            on_plate_loading_concentration: 1,
+            binding_kit_box_barcode: "BKB#{pool.id}",
+            movie_time: 20
+          )]
+        )]
+      )
     end
     puts '-> Pacbio runs successfully created'
   end

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -64,7 +64,6 @@ namespace :pacbio_data do
     print COMPLETED
 
     print '-> Finding Pacbio SMRT Link versions...'
-    v10 = Pacbio::SmrtLinkVersion.find_by(name: 'v10')
     v11 = Pacbio::SmrtLinkVersion.find_by(name: 'v11')
     v12_revio = Pacbio::SmrtLinkVersion.find_by(name: 'v12_revio')
     print COMPLETED
@@ -87,31 +86,6 @@ namespace :pacbio_data do
     #     option_versions.id
 
     # TODO: create the seed data below with the appropiate options dynamically sourced from config
-
-    print "   -> Creating runs for #{v10.name}..."
-    pool_records.each_with_index do |pool, i|
-      Pacbio::Run.create!(
-        name: "Run10#{pool.id}",
-        system_name: Pacbio::Run.system_names['Sequel II'],
-        smrt_link_version: v10,
-        dna_control_complex_box_barcode: "DCCB#{pool.id}",
-        plates: [Pacbio::Plate.new(
-          sequencing_kit_box_barcode: "SKB#{pool.id}",
-          plate_number: 1,
-          wells: [Pacbio::Well.new(
-            pools: [pool],
-            row: 'A',
-            column: i + 1,
-            ccs_analysis_output: 'Yes',
-            generate_hifi: 'In SMRT Link',
-            on_plate_loading_concentration: 1,
-            binding_kit_box_barcode: "BKB#{pool.id}",
-            movie_time: 20
-          )]
-        )]
-      )
-    end
-    print COMPLETED
 
     print "   -> Creating runs for #{v11.name}..."
     pool_records.each_with_index do |pool, i|

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -66,7 +66,7 @@ namespace :pacbio_data do
     puts "   -> Creating runs for #{v10.name}..."
     pool_records.each_with_index do |pool, i|
       Pacbio::Run.create!(
-        name: "Run#{pool.id}",
+        name: "Run10#{pool.id}",
         system_name: Pacbio::Run.system_names['Sequel II'],
         smrt_link_version: v10,
         dna_control_complex_box_barcode: "DCCB#{pool.id}",
@@ -90,7 +90,7 @@ namespace :pacbio_data do
     puts "   -> Creating runs for #{v11.name}..."
     pool_records.each_with_index do |pool, i|
       Pacbio::Run.create!(
-        name: "Run#{pool.id}",
+        name: "Run11#{pool.id}",
         system_name: Pacbio::Run.system_names['Sequel IIe'],
         smrt_link_version: v11,
         dna_control_complex_box_barcode: "DCCB#{pool.id}",
@@ -101,8 +101,10 @@ namespace :pacbio_data do
             pools: [pool],
             row: 'A',
             column: i + 1,
-            ccs_analysis_output: 'Yes',
-            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output_include_kinetics_information:	'Yes',
+            ccs_analysis_output_include_low_quality_reads:	'Yes',
+            include_fivemc_calls_in_cpg_motifs:	'Yes',
+            demultiplex_barcodes:	'In SMRT Link',
             on_plate_loading_concentration: 1,
             binding_kit_box_barcode: "BKB#{pool.id}",
             movie_time: 20
@@ -125,8 +127,10 @@ namespace :pacbio_data do
             pools: [pool],
             row: 'A',
             column: i + 1,
-            ccs_analysis_output: 'Yes',
-            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output_include_kinetics_information:	'Yes',
+            ccs_analysis_output_include_low_quality_reads:	'Yes',
+            include_fivemc_calls_in_cpg_motifs:	'Yes',
+            demultiplex_barcodes:	'In SMRT Link',
             on_plate_loading_concentration: 1,
             binding_kit_box_barcode: "BKB#{pool.id}",
             movie_time: 20

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -28,6 +28,7 @@ namespace :pacbio_data do
 
     print '-> Creating pacbio libraries...'
 
+    # TODO: refactor the pools array below to better correspond to requests, libraries, and pools
     pools = [
       { library_type: 'Pacbio_HiFi', tag_set: nil, size: 1 },
       { library_type: 'Pacbio_HiFi', tag_set: 'Sequel_16_barcodes_v3', size: 1 },

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -116,7 +116,6 @@ namespace :pacbio_data do
     puts "   -> Creating runs for #{v12_revio.name}..."
     pool_records.each_with_index do |pool, i|
       Pacbio::Run.create!(
-        name: "Run#{pool.id}",
         system_name: Pacbio::Run.system_names['Revio'],
         smrt_link_version: v12_revio,
         dna_control_complex_box_barcode: "DCCB#{pool.id}",
@@ -126,14 +125,12 @@ namespace :pacbio_data do
           wells: [Pacbio::Well.new(
             pools: [pool],
             row: 'A',
-            column: i + 1,
-            ccs_analysis_output_include_kinetics_information:	'Yes',
-            ccs_analysis_output_include_low_quality_reads:	'Yes',
-            include_fivemc_calls_in_cpg_motifs:	'Yes',
-            demultiplex_barcodes:	'In SMRT Link',
-            on_plate_loading_concentration: 1,
-            binding_kit_box_barcode: "BKB#{pool.id}",
-            movie_time: 20
+            column: 1,
+            pre_extension_time: 2,
+            movie_acquisition_time:	24.0,
+            include_base_kinetics:	'True',
+            library_concentration:	1,
+            polymerase_kit:	"PK12#{i}"
           )]
         )]
       )

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -107,7 +107,7 @@ namespace :pacbio_data do
             demultiplex_barcodes:	'In SMRT Link',
             on_plate_loading_concentration: 1,
             binding_kit_box_barcode: "BKB#{pool.id}",
-            movie_time: 20
+            movie_time: '20.0'
           )]
         )]
       )
@@ -124,7 +124,7 @@ namespace :pacbio_data do
           row: 'A',
           column: 1,
           pre_extension_time: 2,
-          movie_acquisition_time:	24.0,
+          movie_acquisition_time:	'24.0',
           include_base_kinetics:	'True',
           library_concentration:	1,
           polymerase_kit:	"PK12#{i}"
@@ -138,7 +138,7 @@ namespace :pacbio_data do
           row: 'A',
           column: 1,
           pre_extension_time: 2,
-          movie_acquisition_time:	24.0,
+          movie_acquisition_time:	'24.0',
           include_base_kinetics:	'True',
           library_concentration:	1,
           polymerase_kit:	"PK12#{i}"
@@ -147,7 +147,7 @@ namespace :pacbio_data do
           row: 'B',
           column: 1,
           pre_extension_time: 2,
-          movie_acquisition_time:	24.0,
+          movie_acquisition_time:	'24.0',
           include_base_kinetics:	'True',
           library_concentration:	1,
           polymerase_kit:	"PK12#{i}"

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -117,7 +117,7 @@ namespace :pacbio_data do
     print "   -> Creating runs for #{v12_revio.name}..."
     pool_records.each_with_index do |pool, i|
       plate1 = Pacbio::Plate.new(
-        sequencing_kit_box_barcode: "SKB#{pool.id}",
+        sequencing_kit_box_barcode: "SKB#{pool.id}1",
         plate_number: 1,
         wells: [Pacbio::Well.new(
           pools: [pool],
@@ -131,7 +131,7 @@ namespace :pacbio_data do
         )]
       )
       plate2 = Pacbio::Plate.new(
-        sequencing_kit_box_barcode: "SKB#{pool.id}",
+        sequencing_kit_box_barcode: "SKB#{pool.id}2",
         plate_number: 2,
         wells: [Pacbio::Well.new(
           pools: [pool],

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -69,6 +69,23 @@ namespace :pacbio_data do
     print COMPLETED
 
     puts '-> Creating pacbio runs:'
+    # See required structure in 'config/pacbio_smrt_link_versions.yml'
+    # Or execute the DB query below:
+    #
+    # SELECT
+    #   versions.name,
+    #   options_.key,
+    #   options_.default_value
+    # FROM
+    #   pacbio_smrt_link_option_versions AS option_versions
+    #   JOIN pacbio_smrt_link_versions AS versions
+    #     ON option_versions.pacbio_smrt_link_version_id = versions.id
+    #   JOIN pacbio_smrt_link_options AS options_
+    #     ON option_versions.pacbio_smrt_link_option_id = options_.id
+    # ORDER BY
+    #     option_versions.id
+
+    # TODO: create the seed data below with the appropiate options dynamically sourced from config
 
     print "   -> Creating runs for #{v10.name}..."
     pool_records.each_with_index do |pool, i|

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -56,10 +56,19 @@ namespace :pacbio_data do
     end
     puts '-> Pacbio libraries successfully created'
 
+    puts '-> Finding Pacbio SMRT Link versions'
+    v10 = Pacbio::SmrtLinkVersion.find_by(name: 'v10')
+    v11 = Pacbio::SmrtLinkVersion.find_by(name: 'v11')
+    v12_revio = Pacbio::SmrtLinkVersion.find_by(name: 'v12_revio')
+
     puts '-> Creating pacbio runs...'
+
+    puts "   -> Creating runs for #{v10.name}..."
     pool_records.each_with_index do |pool, i|
       Pacbio::Run.create!(
         name: "Run#{pool.id}",
+        system_name: Pacbio::Run.system_names['Sequel II'],
+        smrt_link_version: v10,
         dna_control_complex_box_barcode: "DCCB#{pool.id}",
         plates: [Pacbio::Plate.new(
           sequencing_kit_box_barcode: "SKB#{pool.id}",
@@ -77,6 +86,55 @@ namespace :pacbio_data do
         )]
       )
     end
+
+    puts "   -> Creating runs for #{v11.name}..."
+    pool_records.each_with_index do |pool, i|
+      Pacbio::Run.create!(
+        name: "Run#{pool.id}",
+        system_name: Pacbio::Run.system_names['Sequel IIe'],
+        smrt_link_version: v11,
+        dna_control_complex_box_barcode: "DCCB#{pool.id}",
+        plates: [Pacbio::Plate.new(
+          sequencing_kit_box_barcode: "SKB#{pool.id}",
+          plate_number: 1,
+          wells: [Pacbio::Well.new(
+            pools: [pool],
+            row: 'A',
+            column: i + 1,
+            ccs_analysis_output: 'Yes',
+            generate_hifi: 'In SMRT Link',
+            on_plate_loading_concentration: 1,
+            binding_kit_box_barcode: "BKB#{pool.id}",
+            movie_time: 20
+          )]
+        )]
+      )
+    end
+
+    puts "   -> Creating runs for #{v12_revio.name}..."
+    pool_records.each_with_index do |pool, i|
+      Pacbio::Run.create!(
+        name: "Run#{pool.id}",
+        system_name: Pacbio::Run.system_names['Revio'],
+        smrt_link_version: v12_revio,
+        dna_control_complex_box_barcode: "DCCB#{pool.id}",
+        plates: [Pacbio::Plate.new(
+          sequencing_kit_box_barcode: "SKB#{pool.id}",
+          plate_number: 1,
+          wells: [Pacbio::Well.new(
+            pools: [pool],
+            row: 'A',
+            column: i + 1,
+            ccs_analysis_output: 'Yes',
+            generate_hifi: 'In SMRT Link',
+            on_plate_loading_concentration: 1,
+            binding_kit_box_barcode: "BKB#{pool.id}",
+            movie_time: 20
+          )]
+        )]
+      )
+    end
+
     puts '-> Pacbio runs successfully created'
   end
 

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -2,12 +2,18 @@
 
 require 'securerandom'
 
+BACKSPACE = "\b"
+SUCCESS = '√'
+NEWLINE = "\n"
+# COMPLETED replaces '...' on the previous line with a success symbol, used with print, not puts
+COMPLETED = (BACKSPACE * 3) + " #{SUCCESS} " + NEWLINE
+
 namespace :pacbio_data do
   desc 'Populate the database with pacbio plates and runs'
   task create: [:environment, 'tags:create:pacbio_sequel', 'tags:create:pacbio_isoseq'] do
     require_relative 'reception_generator'
 
-    puts '-> Creating pacbio plates and tubes...'
+    print '-> Creating pacbio plates and tubes...'
 
     reception_generator = ReceptionGenerator.new(
       number_of_plates: 5,
@@ -18,9 +24,9 @@ namespace :pacbio_data do
 
     requests = reception_generator.reception.requests.each
 
-    puts '-> Pacbio plates successfully created'
+    print COMPLETED
 
-    puts '-> Creating pacbio libraries...'
+    print '-> Creating pacbio libraries...'
 
     pools = [
       { library_type: 'Pacbio_HiFi', tag_set: nil, size: 1 },
@@ -54,16 +60,17 @@ namespace :pacbio_data do
         end.pool
       end
     end
-    puts '-> Pacbio libraries successfully created'
+    print COMPLETED
 
-    puts '-> Finding Pacbio SMRT Link versions'
+    print '-> Finding Pacbio SMRT Link versions...'
     v10 = Pacbio::SmrtLinkVersion.find_by(name: 'v10')
     v11 = Pacbio::SmrtLinkVersion.find_by(name: 'v11')
     v12_revio = Pacbio::SmrtLinkVersion.find_by(name: 'v12_revio')
+    print COMPLETED
 
-    puts '-> Creating pacbio runs...'
+    puts '-> Creating pacbio runs:'
 
-    puts "   -> Creating runs for #{v10.name}..."
+    print "   -> Creating runs for #{v10.name}..."
     pool_records.each_with_index do |pool, i|
       Pacbio::Run.create!(
         name: "Run10#{pool.id}",
@@ -86,8 +93,9 @@ namespace :pacbio_data do
         )]
       )
     end
+    print COMPLETED
 
-    puts "   -> Creating runs for #{v11.name}..."
+    print "   -> Creating runs for #{v11.name}..."
     pool_records.each_with_index do |pool, i|
       Pacbio::Run.create!(
         name: "Run11#{pool.id}",
@@ -112,8 +120,9 @@ namespace :pacbio_data do
         )]
       )
     end
+    print COMPLETED
 
-    puts "   -> Creating runs for #{v12_revio.name}..."
+    print "   -> Creating runs for #{v12_revio.name}..."
     pool_records.each_with_index do |pool, i|
       Pacbio::Run.create!(
         system_name: Pacbio::Run.system_names['Revio'],
@@ -135,6 +144,7 @@ namespace :pacbio_data do
         )]
       )
     end
+    print COMPLETED
 
     puts '-> Pacbio runs successfully created'
   end
@@ -147,6 +157,6 @@ namespace :pacbio_data do
      Pacbio::WellPool, Pacbio::Pool].each(&:delete_all)
     Plate.by_pipeline('Pacbio').destroy_all
 
-    puts '-> Pacbio data successfully deleted'
+    print '-> Pacbio data successfully deleted'
   end
 end

--- a/spec/lib/tasks_spec.rb
+++ b/spec/lib/tasks_spec.rb
@@ -38,8 +38,23 @@ RSpec.describe 'RakeTasks' do
     it 'creates the correct number of runs' do
       Rake::Task['tags:create:pacbio_sequel'].reenable
       Rake::Task['tags:create:pacbio_isoseq'].reenable
-      Rake::Task['pacbio_data:create'].invoke
-      expect(Pacbio::Run.count).to eq(6)
+      expect { Rake::Task['pacbio_data:create'].invoke }
+        .to output(
+          "-> Creating Sequel_16_barcodes_v3 tag set and tags\n" \
+          "-> Tag Set successfully created\n" \
+          "-> Sequel_16_barcodes_v3 tags successfully created\n" \
+          "-> Creating Pacbio IsoSeq tag set and tags\n" \
+          "-> Tag Set successfully created\n" \
+          "-> IsoSeq_Primers_12_Barcodes_v1 created\n" \
+          "-> Creating pacbio plates and tubes...\n" \
+          "-> Pacbio plates successfully created\n" \
+          "-> Creating pacbio libraries...\n" \
+          "-> Pacbio libraries successfully created\n" \
+          "-> Creating pacbio runs...\n" \
+          "-> Pacbio runs successfully created\n"
+        ).to_stdout
+      expect(Pacbio::Run.count)
+        .to eq(6)
     end
   end
 

--- a/spec/lib/tasks_spec.rb
+++ b/spec/lib/tasks_spec.rb
@@ -244,9 +244,37 @@ RSpec.describe 'RakeTasks' do
       end
     end
 
+    it 'creates smrt link versions and options for v12_revio' do
+      Rake::Task['pacbio_runs:migrate_pacbio_run_smrt_link_versions'].reenable
+      Rake::Task['pacbio_runs:migrate_pacbio_run_smrt_link_versions'].invoke
+
+      version = Pacbio::SmrtLinkVersion.find_by(name: 'v12_revio', default: false, active: true)
+      expect(version).not_to be_nil
+      expect(version.smrt_link_options).not_to be_nil
+      expect(version.default).to be false
+      expect(version.active).to be true
+
+      keys = %w[
+        ccs_analysis_output_include_low_quality_reads
+        ccs_analysis_output_include_kinetics_information
+        include_fivemc_calls_in_cpg_motifs
+        on_plate_loading_concentration
+        binding_kit_box_barcode
+        pre_extension_time
+        loading_target_p1_plus_p2
+        movie_time
+      ]
+
+      keys.each do |key|
+        obj = version.smrt_link_options.where(key:)
+        expect(obj).not_to be_nil
+      end
+    end
+
     it 'sets pacbio smrt link versions' do
       run10 = create(:pacbio_run, system_name: 0, smrt_link_version_deprecated: 'v10')
       run11 = create(:pacbio_run, system_name: 0, smrt_link_version_deprecated: 'v11')
+      run12_revio = create(:pacbio_run, system_name: 0, smrt_link_version_deprecated: 'v12_revio')
 
       Rake::Task['smrt_link_versions:create'].reenable
       Rake::Task['pacbio_runs:migrate_pacbio_run_smrt_link_versions'].reenable
@@ -254,6 +282,7 @@ RSpec.describe 'RakeTasks' do
 
       run10.reload
       run11.reload
+      run12_revio.reload
 
       expect(run10.smrt_link_version).not_to be_nil
       expect(run10.smrt_link_version.name).to eq('v10')

--- a/spec/lib/tasks_spec.rb
+++ b/spec/lib/tasks_spec.rb
@@ -46,15 +46,16 @@ RSpec.describe 'RakeTasks' do
           "-> Creating Pacbio IsoSeq tag set and tags\n" \
           "-> Tag Set successfully created\n" \
           "-> IsoSeq_Primers_12_Barcodes_v1 created\n" \
-          "-> Creating pacbio plates and tubes...\n" \
-          "-> Pacbio plates successfully created\n" \
-          "-> Creating pacbio libraries...\n" \
-          "-> Pacbio libraries successfully created\n" \
-          "-> Creating pacbio runs...\n" \
+          "-> Creating pacbio plates and tubes...\b\b\b √ \n" \
+          "-> Creating pacbio libraries...\b\b\b √ \n" \
+          "-> Finding Pacbio SMRT Link versions...\b\b\b √ \n" \
+          "-> Creating pacbio runs:\n   " \
+          "-> Creating runs for v11...\b\b\b √ \n   " \
+          "-> Creating runs for v12_revio...\b\b\b √ \n" \
           "-> Pacbio runs successfully created\n"
         ).to_stdout
       expect(Pacbio::Run.count)
-        .to eq(6)
+        .to eq(12)
     end
   end
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Removes `v10` seeding data
- Adds `v11` seeding data
  - Wells incomplete and showing red (as in v`10`)
- Adds `v12_revio` seeding data
  - Wells complete and showing green
  - 3 x 1-plate runs
  - 3 x 2-plate runs
