### PR TITLE
DPL-831: Refactor sample sheets to use existing messaging config structure

### DIFF
--- a/app/exchanges/README.md
+++ b/app/exchanges/README.md
@@ -1,10 +1,12 @@
-# Sample Sheet Generator
+# Exchanges Output Generator
 
-The sample sheets are defined through configuration in
-[/config/pipelines/](/config/pipelines/)`{pipeline}.yml` for ONT and PacBio.
+The exchanges codebase generates messages and sample sheets for external interfaces.
 
-This configuration is parsed using
-[/app/exchanges/run_csv/](/app/exchanges/run_csv/)`{pipeline}_sample_sheet.rb` as appropriate.
+The messages and sample sheets are defined through configuration in
+[/config/pipelines/](/config/pipelines/)`{pipeline}.yml` for ONT and PacBio. The
+[DataStructureBuilder](/app/exchanges/data_structure_builder.rb) parses the configuration with
+additional functionality added to
+[/app/exchanges/run_csv/](/app/exchanges/run_csv/)`{pipeline}_sample_sheet.rb` as required.
 
 The required format of the sample sheets can be found in the SMRT Link User Guides
 (https://www.pacb.com/support/documentation/).
@@ -18,6 +20,75 @@ UAT.
 - PacBio uses `well` and `sample`
 
 ## Configuration
+
+_As implemented in [data_structure_builder.rb](/app/exchanges/data_structure_builder.rb) and
+[pacbio_sample_sheet.rb](/app/exchanges/run_csv/pacbio_sample_sheet.rb)_
+
+The `DataStructureBuilder::data_structure` method parses the configuration for the pipeline and
+returns a hash containing the requested data.
+
+### Column Order
+
+The `column_order` key defines the order in which the columns should be displayed in the sample
+sheet. The value of each item should match the name of the fields as defined in `fields.children`.
+
+### Fields
+
+Each field is defined with a `type` and a `value`. The `type` defines how the value is populated and
+the `value` defines what the value is populated with.
+
+If the field is a:
+
+- **[string]** => return the value as a constant
+- **[constant]** => evaluate the first item as a Rails constant and apply the method chain to it,  
+  eg: `DateTime.now`
+- **[model]** => take the value split it by the full stop and recursively send the method to the
+  model object,  
+  eg: `object.foo.bar` will first evaluate foo and then apply bar
+- **[parent_model]** => as above, but for the direct parent of the current model
+- **[array]** => evaluate the value as a method on the object and return an array of the results
+
+Methods that are available for use are defined for `:model` and `:parent_model` in the models
+themselves as well as in [/app/models/concerns/sample_sheet.rb](/app/models/concerns/sample_sheet.rb)
+
+Example:
+
+```yaml
+v12_revio: # version name
+  column_order: # list of columns in the order they should appear in the sample sheet
+    - Library Type
+    - Reagent Plate
+    - Bio Sample Name
+  fields: # list of fields to be populated
+    _sorted_wells: # a placeholder field for all the rows in the sample sheet
+      type: :array # process the value as an array
+      value: sorted_wells # call the sorted_wells method in 'app/models/concerns/sample_sheet.rb'
+      children: # placeholder field 'containing' the elements from the sorted_wells array (Wells)
+        Library Type: # column name
+          type: :string # return the value as a string constant
+          value: Standard # literally the text 'Standard'
+        Reagent Plate: # another column name
+          type: :model # this time call a method on the model
+          value: plate.plate_number # the method chain should be (well).plate.plate_number
+        Bio Sample Name: # yet another column name
+          type: :model # call a method on the Well model
+          value: find_sample_name # call the find_sample_name method on the Well
+        samples: # this field is not in the column_order list above and so will not be included
+          type: :array # process the returned value as an array
+          value: libraries_to_show_per_row # well.libraries_to_show_per_row (might be nil)
+          children: # placeholder
+            Reagent Plate: # as this column is repeated from above the same column in the sample sheet will be used
+              type: :parent_model # call the method on the parent model (well)
+              value: plate.plate_number # call well.plate.plate_number again
+            Bio Sample Name: # this column is also repeated from above
+              type: :model # this time call a method on the Sample
+              value: find_sample_name # call sample.find_sample_name
+```
+
+## Deprecated Configuration
+
+_As implemented in
+[deprecated_pacbio_sample_sheet.rb](/app/exchanges/run_csv/deprecated_pacbio_sample_sheet.rb)_
 
 If the column does not need to be populated for the row_type return empty string.  
 If the column does need to be populated then return the value from the object.  
@@ -58,18 +129,3 @@ populate:
 
 means that sample well needs to be populated for both samples and wells but needs to use the well
 method
-
-Find the instance value for each field
-
-If the field is a:
-
-- [string] => return the value
-- [model] => take the value split it by the full stop and recursively send the method to the object
-  e.g. it is object.foo.bar will first evaluate foo and then apply bar
-- [parent_model] => as above, but for the direct parent of the current model
-- [constant] => take the constant and applies the method chain to it e.g DateTime.now
-
-### Functions
-
-Functions are defined for `:model` and `:parent_model` in the models themselves and in
-`app/models/concerns/sample_sheet.rb`


### PR DESCRIPTION
Closes #1058 (part 1)

Changes proposed in this pull request:

- Refactor sample sheets to use existing messaging config structure
- Use a multi-stage abstraction to compile down the Data -> JSON -> CSV
- Refactor the config parsing into a common class for both messaging and sample sheets
- CSVs return a nil field instead of an empty string for nil data
- Update documentation

Dependencies:
- #1091

Sample Sheet Changes:

[sample-sheets-diff.pdf](https://github.com/sanger/traction-service/files/12464051/sample-sheets-diff.pdf)

created with:  
_./scripts/download-sample-sheets $TRACTION_DEV_HOST 1 8 new-style_  
_git diff --no-index --word-diff=color --word-diff-regex=. storage/deprecated storage/new-style --color | [ansi2html](http://www.pixelbeat.org/scripts/ansi2html.sh) | [wkhtmltopdf](https://wkhtmltopdf.org/) - sample-sheets-diff.pdf_