### PR TITLE
Add RuboCop factory_bot to RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-factory_bot
 
 AllCops:
   NewCops: enable


### PR DESCRIPTION
Changes proposed in this pull request:

- removes the following suggestion displayed at the end of every RuboCop run
  ```
  The following RuboCop extension libraries are installed but not loaded in config:
    * rubocop-factory_bot
  
  You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
    AllCops:
      SuggestExtensions: false
  ```
- makes no additional changes or suggestions