### PR TITLE
DPL-871 View old runs

### DIFF
--- a/app/resources/v1/pacbio/smrt_link_version_resource.rb
+++ b/app/resources/v1/pacbio/smrt_link_version_resource.rb
@@ -6,14 +6,9 @@ module V1
     class SmrtLinkVersionResource < JSONAPI::Resource
       model_name 'Pacbio::SmrtLinkVersion'
 
-      attributes :name, :default
+      attributes :name, :default, :active
 
       has_many :smrt_link_option_versions, class_name: 'SmrtLinkOptionVersion'
-
-      # Returns active versions.
-      def self.records(_options = {})
-        super.active
-      end
     end
   end
 end

--- a/spec/requests/v1/pacbio/smrt_link_versions_spec.rb
+++ b/spec/requests/v1/pacbio/smrt_link_versions_spec.rb
@@ -21,13 +21,15 @@ RSpec.describe 'SmrtLinkVersionsController' do
       expect(response).to have_http_status(:success)
     end
 
-    it 'only includes active versions' do
-      expect(json['data'].length).to eq(6)
+    it 'includes active and inactive versions' do
+      expect(json['data'].length).to eq(8)
     end
 
     it 'will include the correct data' do
       expect(json['data'][0]['attributes']['name']).to eq(default_smrt_link_version.name)
       expect(json['data'][0]['attributes']['default']).to be_truthy
+      expect(json['data'][0]['attributes']['active']).to be true
+      expect(json['data'][7]['attributes']['active']).to be false
     end
   end
 


### PR DESCRIPTION
Pass through all SMRT Link Versions, not just the active ones
- pass through the active attribute so that the UI can decide what to do with it
- allows a bug to be fixed where the UI wasn't rendering old runs properly
- checked as well as I could and seems to be a safe change

See comment https://github.com/sanger/traction-ui/issues/1300#issuecomment-1748946591 and screenshots on story https://github.com/sanger/traction-ui/issues/1300#issuecomment-1749062904

Closes #

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
