### PR TITLE
DPL-888 - Add page by page pagination

### DIFF
--- a/app/resources/v1/ont/run_resource.rb
+++ b/app/resources/v1/ont/run_resource.rb
@@ -17,6 +17,8 @@ module V1
                foreign_key: 'ont_run_id',
                class_name: 'Flowcell'
 
+      filters :experiment_name, :state
+
       paginator :paged
 
       def self.default_sort

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -8,6 +8,8 @@ JSONAPI.configure do |config|
   # If we apply a filter that returns more than 1000 results some will be hidden
   # from the user. May need to address in future
   config.maximum_page_size = 1000
+  # Enables the requestor to know the total number of pages
+  config.top_level_meta_include_page_count = true
 
   # TODO: we have to set this to false for tests. Why?
   config.warn_on_missing_routes = false

--- a/spec/requests/v1/ont/runs_spec.rb
+++ b/spec/requests/v1/ont/runs_spec.rb
@@ -21,6 +21,65 @@ RSpec.describe 'RunsController' do
     end
   end
 
+  describe 'filter' do
+    let(:run1) { create(:ont_gridion_run, flowcell_count: 5, state: 'pending') }
+    let(:run2) { create(:ont_gridion_run, flowcell_count: 5, state: 'restart') }
+
+    describe 'experiment_name' do
+      before do
+        get "#{v1_ont_runs_path}?filter[experiment_name]=#{run1.experiment_name}",
+            headers: json_api_headers
+      end
+
+      it 'has a success status' do
+        expect(response).to have_http_status(:success), response.body
+      end
+
+      it 'returns a list of runs' do
+        expect(json['data'].length).to eq(1)
+      end
+
+      it 'returns the correct attributes' do
+        json = ActiveSupport::JSON.decode(response.body)
+        run_attributes = json['data'][0]['attributes']
+
+        expect(run_attributes).to include(
+          'ont_instrument_id' => run1.instrument.id,
+          'experiment_name' => run1.experiment_name,
+          'state' => run1.state,
+          'created_at' => run1.created_at.to_fs(:us)
+        )
+      end
+    end
+
+    describe 'state' do
+      before do
+        get "#{v1_ont_runs_path}?filter[state]=#{run1.state}",
+            headers: json_api_headers
+      end
+
+      it 'has a success status' do
+        expect(response).to have_http_status(:success), response.body
+      end
+
+      it 'returns a list of runs' do
+        expect(json['data'].length).to eq(1)
+      end
+
+      it 'returns the correct attributes' do
+        json = ActiveSupport::JSON.decode(response.body)
+        run_attributes = json['data'][0]['attributes']
+
+        expect(run_attributes).to include(
+          'ont_instrument_id' => run1.instrument.id,
+          'experiment_name' => run1.experiment_name,
+          'state' => run1.state,
+          'created_at' => run1.created_at.to_fs(:us)
+        )
+      end
+    end
+  end
+
   describe 'create' do
     context 'on success' do
       let(:instrument) { create(:ont_gridion) }


### PR DESCRIPTION
Required for DPL-888 (UI add page by page pagination)

#### Changes proposed in this pull request

- json api resources return page count in response meta
- Adds experiment_name and state filters to ONT run resource

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
