### PR TITLE
DPL-1066 - Modifies the pacbio library endpoint to only return libraries without pools.

### DIFF
--- a/app/resources/v1/pacbio/library_pool_resource.rb
+++ b/app/resources/v1/pacbio/library_pool_resource.rb
@@ -2,8 +2,9 @@
 
 module V1
   module Pacbio
-    # LibraryResource
-    class LibraryResource < JSONAPI::Resource
+    # A temporary PacBio Library resource that returns all libraries
+    # This allows for pool libraries to be retrieved from the pools resource
+    class LibraryPoolResource < JSONAPI::Resource
       include Shared::RunSuitability
 
       model_name 'Pacbio::Library'
@@ -18,6 +19,7 @@ module V1
       # In this case I can see it using container_associations
       # so seems to be linking the wrong tube relationship.
       has_one :tag, always_include_optional_linkage_data: true
+      has_one :pool, always_include_optional_linkage_data: true
       has_one :tube, relation_name: :tube, always_include_optional_linkage_data: true
       has_one :source_well, relation_name: :source_well, class_name: 'Well'
       has_one :source_plate, relation_name: :source_plate, class_name: 'Plate'
@@ -29,12 +31,6 @@ module V1
 
       def self.default_sort
         [{ field: 'created_at', direction: :desc }]
-      end
-
-      def self.records(_options = {})
-        # We only want to include only libraries without pools
-        # Libraries with pools should be referenced via the LibraryPoolResource
-        _model_class.where(pool: nil)
       end
 
       filter :sample_name, apply: lambda { |records, value, _options|

--- a/app/resources/v1/pacbio/library_pool_resource.rb
+++ b/app/resources/v1/pacbio/library_pool_resource.rb
@@ -11,7 +11,7 @@ module V1
 
       attributes :state, :volume, :concentration, :template_prep_kit_box_barcode,
                  :insert_size, :created_at, :deactivated_at, :source_identifier,
-                 :pacbio_request_id, :tag_id, :primary_aliquot_attributes
+                 :pacbio_request_id, :tag_id
 
       has_one :request, always_include_optional_linkage_data: true
       # If we don't specify the relation_name here, jsonapi-resources
@@ -31,17 +31,6 @@ module V1
         super.preload(source_well: :plate, request: :sample,
                       tag: :tag_set,
                       container_material: { container: :barcode })
-      end
-
-      def primary_aliquot_attributes=(primary_aliquot_parameters)
-        @model.primary_aliquot_attributes = primary_aliquot_parameters.permit(
-          :id, :volume, :template_prep_kit_box_barcode,
-          :concentration, :insert_size, :tag_id
-        )
-      end
-
-      def fetchable_fields
-        super - [:primary_aliquot_attributes]
       end
 
       def created_at

--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -33,7 +33,7 @@ module V1
       end
 
       def self.records(options = {})
-        # If we go directly to the library resource we want to include only libraries withput pools
+        # If we go directly to the library resource we want to include only libraries without pools
         # Otherwise we only want to return all libraries
         if options[:include_directives]
            .instance_variable_get(:@resource_klass) == V1::Pacbio::LibraryResource

--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -32,6 +32,17 @@ module V1
         [{ field: 'created_at', direction: :desc }]
       end
 
+      def self.records(options = {})
+        # If we go directly to the library resource we want to include only libraries withput pools
+        # Otherwise we only want to return all libraries
+        if options[:include_directives]
+           .instance_variable_get(:@resource_klass) == V1::Pacbio::LibraryResource
+          _model_class.where(pool: nil)
+        else
+          _model_class.all
+        end
+      end
+
       filter :sample_name, apply: lambda { |records, value, _options|
         # We have to join requests and samples here in order to find by sample name
         records.joins(:sample).where(sample: { name: value })

--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -34,7 +34,7 @@ module V1
       def self.records(_options = {})
         # We only want to include only libraries without pools
         # Libraries with pools should be referenced via the LibraryPoolResource
-        _model_class.where(pool: nil)
+        super.where(pool: nil)
       end
 
       filter :sample_name, apply: lambda { |records, value, _options|

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -13,7 +13,7 @@ module V1
       # In this case I can see it using container_associations
       # so seems to be linking the wrong tube relationship.
       has_one :tube, relation_name: :tube
-      has_many :libraries
+      has_many :libraries, class_name: 'LibraryPool'
 
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
                  :insert_size, :created_at, :updated_at,

--- a/spec/factories/pacbio/libraries.rb
+++ b/spec/factories/pacbio/libraries.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     insert_size { 100 }
     request { association :pacbio_request }
     tag
-    pool { association :pacbio_pool, libraries: [instance] }
     tube { nil }
     primary_aliquot { association :aliquot, source: instance, aliquot_type: :primary }
 

--- a/spec/lib/tasks/migrate_pacbio_aliquot_data.rake_spec.rb
+++ b/spec/lib/tasks/migrate_pacbio_aliquot_data.rake_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'RakeTasks' do
         <<~HEREDOC
           -> Deleting all request primary aliquots
         HEREDOC
-      ).to_stdout.and change(Aliquot, :count).from(10).to(5)
+      ).to_stdout.and change(Aliquot, :count).from(15).to(10)
     end
   end
 

--- a/spec/requests/v1/pacbio/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/libraries_spec.rb
@@ -119,11 +119,6 @@ RSpec.describe 'LibrariesController', :pacbio do
         tube_resource = find_included_resource(type: 'tubes', id: tube.id)
         tube_attributes = tube_resource['attributes']
         expect(tube_attributes['barcode']).to eq(tube.barcode)
-
-        pool = library.pool
-        pool_relationship = library_relationships.fetch('pool')
-        expect(pool_relationship['data']['id']).to eq(pool.id.to_s)
-        expect(pool_relationship['data']['type']).to eq('pools')
       end
 
       it 'has a relationship with source_well' do


### PR DESCRIPTION
#### Changes proposed in this pull request

- Adds PacBio LibraryPoolResource. This is so the Pacbio PoolResource can access all PacBio Libraries.
- Updates PacBio LibraryResource to only return records without pools (new libraries).

One alternative approach is to this is to create a separate endpoint for the libraries without pools. I don't feel strongly about either approach as they both have their own issues.

Another approach is to filter out libraries with pools in the front end. However this will break pagination completely because the service and UI will be out of sync. e.g. service sends 25 libraries (some with pools), Ui only shows libraries without pools e.g. 10 libraries.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
