### PR TITLE
DPL-1110: Change the estimate_of_gb_required column to a string

### DIFF
--- a/db/migrate/20240227103930_change_estimate_of_gb_required_to_string.rb
+++ b/db/migrate/20240227103930_change_estimate_of_gb_required_to_string.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Change estimate_of_gb_required to a string to support TOL auto-manifests with genome_size.
+class ChangeEstimateOfGbRequiredToString < ActiveRecord::Migration[7.1]
+  def up
+    change_column :pacbio_requests, :estimate_of_gb_required, :string
+  end
+
+  # The conversion back to integer is not possible if any value in the column cannot be converted.
+  # If that happens, the reverse migration will fail.
+  def down
+    change_column :pacbio_requests, :estimate_of_gb_required, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_19_180656) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_27_103930) do
   create_table "aliquots", charset: "utf8mb3", force: :cascade do |t|
     t.float "volume"
     t.float "concentration"
@@ -230,7 +230,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_19_180656) do
 
   create_table "pacbio_requests", charset: "utf8mb3", force: :cascade do |t|
     t.string "library_type"
-    t.integer "estimate_of_gb_required"
+    t.string "estimate_of_gb_required"
     t.integer "number_of_smrt_cells"
     t.string "cost_code"
     t.string "external_study_id"

--- a/spec/factories/pacbio/requests.rb
+++ b/spec/factories/pacbio/requests.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :pacbio_request, class: 'Pacbio::Request' do
     library_type { 'library_type_1' }
-    estimate_of_gb_required { 100 }
+    estimate_of_gb_required { '100' }
     number_of_smrt_cells { 3 }
     cost_code
     external_study_id

--- a/spec/models/pacbio/request_spec.rb
+++ b/spec/models/pacbio/request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Pacbio::Request, :pacbio do
   context 'cost_code default value' do
     it 'sets cost_code to a default value if not entered' do
       request = described_class.create(library_type: 'library_type_1',
-                                       estimate_of_gb_required: 10,
+                                       estimate_of_gb_required: '10',
                                        number_of_smrt_cells: 1,
                                        external_study_id: 1)
       expect(request.cost_code).to eq(Rails.application.config.pacbio_request_cost_code) #= config value is'S4699'
@@ -21,7 +21,7 @@ RSpec.describe Pacbio::Request, :pacbio do
 
     it 'sets cost_code to entered value if inputted' do
       request = described_class.create(library_type: 'library_type_1',
-                                       estimate_of_gb_required: 10,
+                                       estimate_of_gb_required: '10',
                                        number_of_smrt_cells: 1,
                                        external_study_id: 1,
                                        cost_code: 'PSD123')


### PR DESCRIPTION
The down method will only be successful if the data in the column is still all integers. If values have been populated with non-integers, the migration cannot be rolled back without altering the database first.

Closes #1225 

#### Changes proposed in this pull request

- Create a migration to change the estimate_of_gb_required to a string.
- Ensuree the migration could be rolled back so long as the data is still all integers.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  