### PR TITLE
Fix for intermittent pacbio data rake task spec failures

### DIFF
--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -109,7 +109,7 @@ namespace :pacbio_data do
     # Gets a random date in the next year
     # This is mainly use when generating valid sequencing kit box barcodes to ensure uniqueness
     # See https://www.pacb.com/wp-content/uploads/SMRT-Link-User-Guide-v13.0.pdf pg 42
-    def random_date
+    def random_expiration_date
       (DateTime.now + (rand * 365)).strftime('%Y%m%d')
     end
 
@@ -159,7 +159,7 @@ namespace :pacbio_data do
         dna_control_complex_box_barcode: 'Lxxxxx102249600123199',
         plates: (1..total_plate).map do |plate_number|
           serial = barcode(length: 3)
-          sequencing_kit_box_barcode = "10211880003110400#{serial}#{random_date}"
+          sequencing_kit_box_barcode = "10211880003110400#{serial}#{random_expiration_date}"
           Pacbio::Plate.new(
             sequencing_kit_box_barcode:,
             plate_number:,
@@ -219,7 +219,7 @@ namespace :pacbio_data do
         dna_control_complex_box_barcode: 'Lxxxxx102249600123199',
         plates: (1..total_plate).map do |plate_number|
           serial = barcode(length: 3)
-          sequencing_kit_box_barcode = "10211880003110400#{serial}#{random_date}"
+          sequencing_kit_box_barcode = "10211880003110400#{serial}#{random_expiration_date}"
           Pacbio::Plate.new(
             sequencing_kit_box_barcode:,
             plate_number:,

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -106,6 +106,13 @@ namespace :pacbio_data do
       rand(bits**length).to_s(bits).rjust(length, '0')
     end
 
+    # Gets a random date in the next year
+    # This is mainly use when generating valid sequencing kit box barcodes to ensure uniqueness
+    # See https://www.pacb.com/wp-content/uploads/SMRT-Link-User-Guide-v13.0.pdf pg 42
+    def random_date
+      (DateTime.now + (rand * 365)).strftime('%Y%m%d')
+    end
+
     # combinations
     total_plates = { sequel_iie: [1], revio: [1, 2] }
     pools = {
@@ -152,7 +159,7 @@ namespace :pacbio_data do
         dna_control_complex_box_barcode: 'Lxxxxx102249600123199',
         plates: (1..total_plate).map do |plate_number|
           serial = barcode(length: 3)
-          sequencing_kit_box_barcode = "10211880003110400#{serial}20231226"
+          sequencing_kit_box_barcode = "10211880003110400#{serial}#{random_date}"
           Pacbio::Plate.new(
             sequencing_kit_box_barcode:,
             plate_number:,
@@ -212,7 +219,7 @@ namespace :pacbio_data do
         dna_control_complex_box_barcode: 'Lxxxxx102249600123199',
         plates: (1..total_plate).map do |plate_number|
           serial = barcode(length: 3)
-          sequencing_kit_box_barcode = "10211880003110400#{serial}20231226"
+          sequencing_kit_box_barcode = "10211880003110400#{serial}#{random_date}"
           Pacbio::Plate.new(
             sequencing_kit_box_barcode:,
             plate_number:,


### PR DESCRIPTION
#### Changes proposed in this pull request

- Changes sequencing kit box barcode generation to include random date string to reduce possibility of duplicate barcodes in data generation.

This change is required because there is validation that a sequencing kit box barcode is not reused on multiple plates. This validation sometimes gets tripped in the pacbio data rake spec because there is a low chance of two plates being randomly generated with the same sequencing kit box barcode and causing the spec to fail. This PR aims to make that chance much lower while maintaining barcode validity.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
