### PR TITLE
DPL-1112 - Handle used_aliquots for run creation

### DIFF
--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -8,6 +8,7 @@ module Pacbio
 
     include Uuidable
     include SampleSheet::Well
+    include Aliquotable
 
     belongs_to :plate, class_name: 'Pacbio::Plate', foreign_key: :pacbio_plate_id,
                        inverse_of: :wells

--- a/app/resources/v1/pacbio/aliquot_resource.rb
+++ b/app/resources/v1/pacbio/aliquot_resource.rb
@@ -14,6 +14,12 @@ module V1
       has_one :source, polymorphic: true, polymorphic_types: POLYMORPHIC_TYPES
       has_one :used_by, polymorphic: true, polymorphic_types: POLYMORPHIC_TYPES
 
+      # Required to get around polymorphism when trying to access nested includes data
+      # e.g. aliquot.source.x becomes aliquot.request.x, aliquot.pool.x, aliquot.library.x etc
+      has_one :request, class_name: 'Request', relation_name: :request
+      has_one :pool, class_name: 'Pool', relation_name: :pool
+      has_one :library, class_name: 'Library', relation_name: :library
+
       #  # Aliquot polymorphism support
       # # This fixes the polymorphic relationships in json-api resources
       # # as json-api resources underscores and pluralizes the type

--- a/app/resources/v1/pacbio/runs/aliquot_resource.rb
+++ b/app/resources/v1/pacbio/runs/aliquot_resource.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module V1
+  module Pacbio
+    module Runs
+      # AliquotResource
+      class AliquotResource < V1::Pacbio::AliquotResource
+      end
+    end
+  end
+end

--- a/app/resources/v1/pacbio/runs/request_resource.rb
+++ b/app/resources/v1/pacbio/runs/request_resource.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module V1
+  # RequestResource
+  module Pacbio
+    module Runs
+      # RequestResource - Returns the available tags for Pacbio
+      class RequestResource < V1::Pacbio::RequestResource
+      end
+    end
+  end
+end

--- a/app/resources/v1/pacbio/runs/tag_resource.rb
+++ b/app/resources/v1/pacbio/runs/tag_resource.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module V1
+  # TagResource
+  module Pacbio
+    module Runs
+      # TagResource - Returns the available tags for Pacbio
+      class TagResource < V1::Pacbio::TagResource
+      end
+    end
+  end
+end

--- a/app/resources/v1/pacbio/runs/tube_resource.rb
+++ b/app/resources/v1/pacbio/runs/tube_resource.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module V1
+  module Pacbio
+    module Runs
+      # TubeResource
+      class TubeResource < V1::Pacbio::TubeResource
+      end
+    end
+  end
+end

--- a/app/resources/v1/pacbio/runs/well_resource.rb
+++ b/app/resources/v1/pacbio/runs/well_resource.rb
@@ -17,6 +17,7 @@ module V1
                    :demultiplex_barcodes, :movie_acquisition_time, :include_base_kinetics,
                    :library_concentration, :polymerase_kit
 
+        has_many :used_aliquots, class_name: 'Aliquot', relation_name: :used_aliquots
         has_many :libraries
         has_many :pools
 

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -3,3 +3,4 @@
 # The key should be lowecase and snake case, and prefixes with the issue number to allow easy identification
 
 multiplexing_phase_2_aliquot: Enables Revio Multiplexing Phase 2 via Aliquots
+dpl_1112: Enables used_aliquots in wells

--- a/lib/tasks/migrate_pacbio_aliquot_data.rake
+++ b/lib/tasks/migrate_pacbio_aliquot_data.rake
@@ -126,6 +126,50 @@ namespace :pacbio_aliquot_data do
     end
   end
 
+  task migrate_well_data: :environment do
+    puts '-> Creating used aliquots for all libraries/pools used in wells'
+    # Create primary aliquots for all wells
+    Pacbio::Well.find_each do |well|
+      # Skip if aliquots already exist (shouldn't happen but just in case)
+      next if well.aliquots.any?
+
+      # Create used aliquots for all libraries/pools used in wells
+      well.libraries.each do |library|
+        Aliquot.create!(
+          volume: library.volume,
+          concentration: library.concentration,
+          template_prep_kit_box_barcode: library.template_prep_kit_box_barcode,
+          insert_size: library.insert_size,
+          source: library,
+          used_by: well,
+          aliquot_type: :derived,
+          state: :created
+        )
+      end
+
+      well.pools.each do |pool|
+        Aliquot.create!(
+          volume: pool.volume,
+          concentration: pool.concentration,
+          template_prep_kit_box_barcode: pool.template_prep_kit_box_barcode,
+          insert_size: pool.insert_size,
+          source: pool,
+          used_by: well,
+          aliquot_type: :derived,
+          state: :created
+        )
+      end
+    end
+  end
+
+  task revert_well_data: :environment do
+    puts '-> Deleting all PacBio well used aliquots'
+    # Delete all usedd aliquots
+    Pacbio::Well.find_each do |well|
+      well.used_aliquots.destroy_all
+    end
+  end
+
   # This task is used to revert the changes made by the above tasks
   # This can be more sophisticated as we add more elements to the migration
   task revert_all_data: :environment do

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -140,7 +140,7 @@ namespace :pacbio_data do
             sequencing_kit_box_barcode: "SKB_#{barcode(length: 21 - 4)}",
             plate_number:,
             wells: [Pacbio::Well.new(
-              pools: [pool],
+              pool_ids: [pool.id],
               row: 'A',
               column: 1,
               ccs_analysis_output_include_kinetics_information:	'Yes',
@@ -172,7 +172,7 @@ namespace :pacbio_data do
             sequencing_kit_box_barcode:,
             plate_number:,
             wells: [Pacbio::Well.new(
-              pools: [pool],
+              pool_ids: [pool.id],
               row: 'A',
               column: 1,
               pre_extension_time: 2,
@@ -199,7 +199,7 @@ namespace :pacbio_data do
             sequencing_kit_box_barcode: '130429101826100021624',
             plate_number:,
             wells: [Pacbio::Well.new(
-              pools: [pool],
+              pool_ids: [pool.id],
               row: 'A',
               column: 1,
               pre_extension_time: 2,
@@ -232,7 +232,7 @@ namespace :pacbio_data do
             sequencing_kit_box_barcode:,
             plate_number:,
             wells: [Pacbio::Well.new(
-              pools: [pool],
+              pool_ids: [pool.id],
               row: 'A',
               column: 1,
               pre_extension_time: 2,
@@ -259,7 +259,7 @@ namespace :pacbio_data do
             sequencing_kit_box_barcode: '130429101826100021624',
             plate_number:,
             wells: [Pacbio::Well.new(
-              pools: [pool],
+              pool_ids: [pool.id],
               row: 'A',
               column: 1,
               pre_extension_time: 2,

--- a/spec/factories/pacbio/wells.rb
+++ b/spec/factories/pacbio/wells.rb
@@ -30,6 +30,15 @@ FactoryBot.define do
       build_list(library_factory, library_count)
     end
 
+    after(:build) do |well|
+      well.libraries.each do |lib|
+        well.used_aliquots << build(:aliquot, source: lib, aliquot_type: :derived, used_by: well)
+      end
+      well.pools.each do |pool|
+        well.used_aliquots << build(:aliquot, source: pool, aliquot_type: :derived, used_by: well)
+      end
+    end
+
     # v10
     generate_hifi { 'In SMRT Link' }
     ccs_analysis_output { 'Yes' }

--- a/spec/factories/pacbio/wells.rb
+++ b/spec/factories/pacbio/wells.rb
@@ -17,10 +17,17 @@ FactoryBot.define do
       pool_count { 5 }
       pool_factory { :pacbio_pool }
       pool_max { 2 }
+      library_count { 0 }
+      library_factory { :pacbio_library }
+      library_max { 2 }
     end
 
     pools do
       build_list(pool_factory, pool_count)
+    end
+
+    libraries do
+      build_list(library_factory, library_count)
     end
 
     # v10

--- a/spec/lib/tasks/migrate_pacbio_aliquot_data.rake_spec.rb
+++ b/spec/lib/tasks/migrate_pacbio_aliquot_data.rake_spec.rb
@@ -128,10 +128,7 @@ RSpec.describe 'RakeTasks' do
       pools = wells.map(&:pools).flatten
 
       # Get rid of aliquots that were created by the factory
-      pools.each do |pool|
-        pool.primary_aliquot.destroy
-        pool.used_aliquots.destroy_all
-      end
+      Aliquot.destroy_all
 
       # Run the rake task
       # It outputs the correct text
@@ -160,14 +157,10 @@ RSpec.describe 'RakeTasks' do
   describe 'pacbio_aliquot_data:revert_pool_data' do
     it 'deletes primary and used aliquots for each pool' do
       # Create some pools with wells
-      wells = create_list(:pacbio_well, 5, pool_count: 2)
-      pools = wells.map(&:pools).flatten
+      create_list(:pacbio_well, 5, pool_count: 2)
 
       # Get rid of aliquots that were created by the factory
-      pools.each do |pool|
-        pool.primary_aliquot.destroy
-        pool.used_aliquots.destroy_all
-      end
+      Aliquot.destroy_all
 
       # Run the rake task
       # It outputs the correct text
@@ -185,7 +178,7 @@ RSpec.describe 'RakeTasks' do
           -> Deleting all pool primary and used aliquots
         HEREDOC
       ).to_stdout
-        .and change(Aliquot, :count).from(40).to(20)
+        .and change(Aliquot, :count).from(20).to(0)
 
       expect(Pacbio::Pool.all.select { |pool| pool.primary_aliquot.present? }).to be_empty
       expect(Pacbio::Pool.all.map(&:used_aliquots).flatten).to be_empty
@@ -271,7 +264,7 @@ RSpec.describe 'RakeTasks' do
       ).to_stdout
 
       # Should be 10 primary aliquots and 10 derived aliquots
-      expect(Aliquot.count).to eq(75)
+      expect(Aliquot.count).to eq(85)
 
       # Run the revert task
       # It outputs the correct text
@@ -280,7 +273,7 @@ RSpec.describe 'RakeTasks' do
           -> Deleting all aliquots
         HEREDOC
       ).to_stdout
-        .and change(Aliquot, :count).from(75).to(0)
+        .and change(Aliquot, :count).from(85).to(0)
     end
   end
 end

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Pacbio::Well, :pacbio do
   let!(:version11) { create(:pacbio_smrt_link_version, name: 'v11', default: true) }
   let!(:version12_revio) { create(:pacbio_smrt_link_version, name: 'v12_revio') }
 
+  before do
+    Flipper.enable(:dpl_1112)
+  end
+
   context 'uuidable' do
     let(:uuidable_model) { :pacbio_well }
 
@@ -87,6 +91,26 @@ RSpec.describe Pacbio::Well, :pacbio do
     it 'no libraries' do
       well = build(:pacbio_well, libraries: [])
       expect(well.libraries?).to be false
+    end
+  end
+
+  describe 'used_aliquots' do
+    it 'is invalid without used_aliquots when feature flag is on' do
+      Flipper.enable(:dpl_1112)
+      # A pool will create a used_aliquot
+      well = create(:pacbio_well, pool_count: 1)
+      well.used_aliquots.destroy_all
+
+      expect(well).not_to be_valid
+    end
+
+    it 'is valid without used_aliquots when feature flag is off' do
+      Flipper.disable(:dpl_1112)
+      # A pool will create a used_aliquot
+      well = create(:pacbio_well, pool_count: 1)
+      well.used_aliquots.destroy_all
+
+      expect(well).to be_valid
     end
   end
 

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -125,6 +125,62 @@ RSpec.describe Pacbio::Well, :pacbio do
     end
   end
 
+  context 'pool_ids=' do
+    it 'creates well_pools and used_aliquots from pool_ids' do
+      pools_ids = create_list(:pacbio_pool, 2).collect(&:id)
+      well = build(:pacbio_well, pool_count: 0)
+
+      expect(well.pools.length).to eq(0)
+      expect(well.used_aliquots.length).to eq(0)
+      well.pool_ids = pools_ids
+      well.save
+
+      expect(well.pools.length).to eq(2)
+      expect(well.used_aliquots.length).to eq(2)
+    end
+
+    it 'destroys well_pools and used_aliquots from pool_ids' do
+      well = create(:pacbio_well, pool_count: 2)
+
+      expect(well.pools.length).to eq(2)
+      expect(well.used_aliquots.length).to eq(2)
+
+      well.pool_ids = [well.pools.first.id]
+      well.reload
+
+      expect(well.pools.length).to eq(1)
+      expect(well.used_aliquots.length).to eq(1)
+    end
+  end
+
+  context 'library_ids=' do
+    it 'creates well_libraries and used_aliquots from library_ids' do
+      library_ids = create_list(:pacbio_library, 2).collect(&:id)
+      well = build(:pacbio_well, pool_count: 0, library_count: 0)
+
+      expect(well.libraries.length).to eq(0)
+      expect(well.used_aliquots.length).to eq(0)
+      well.library_ids = library_ids
+      well.save
+
+      expect(well.libraries.length).to eq(2)
+      expect(well.used_aliquots.length).to eq(2)
+    end
+
+    it 'destroys well_pools and used_aliquots from pool_ids' do
+      well = create(:pacbio_well, pool_count: 0, library_count: 2)
+
+      expect(well.libraries.length).to eq(2)
+      expect(well.used_aliquots.length).to eq(2)
+
+      well.library_ids = [well.libraries.first.id]
+      well.reload
+
+      expect(well.libraries.length).to eq(1)
+      expect(well.used_aliquots.length).to eq(1)
+    end
+  end
+
   context 'all_libraries' do
     let(:pools) { create_list(:pacbio_pool, 2, library_count: 1) }
     let(:libraries) { create_list(:pacbio_library, 2) }

--- a/spec/requests/v1/pacbio/runs/wells_spec.rb
+++ b/spec/requests/v1/pacbio/runs/wells_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'WellsController' do
 
     describe 'has the correct attributes' do
       before do
-        get "#{v1_pacbio_runs_wells_path}?include=pools.libraries", headers: json_api_headers
+        get "#{v1_pacbio_runs_wells_path}?include=pools.libraries,used_aliquots", headers: json_api_headers
       end
 
       let!(:well) { wells.first }
@@ -60,6 +60,15 @@ RSpec.describe 'WellsController' do
             'insert_size' => library.insert_size,
             'state' => library.state,
             'created_at' => library.created_at.to_fs(:us)
+          )
+        end
+
+        wells.collect(&:used_aliquots).flatten.each do |aliquot|
+          aliquot_attributes = find_included_resource(type: 'aliquots', id: aliquot.id)['attributes']
+          expect(aliquot_attributes).to include(
+            'volume' => aliquot.volume,
+            'concentration' => aliquot.concentration,
+            'aliquot_type' => aliquot.aliquot_type
           )
         end
       end

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -242,6 +242,12 @@ RSpec.describe 'RunsController' do
         expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::WellPool, :count).by(1)
       end
 
+      it 'creates a used_aliquot' do
+        # Preloaded so its aliquots are built and don't affect the test below
+        pool1.reload
+        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Aliquot, :count).by(1)
+      end
+
       it 'creates a run with the correct attributes' do
         post v1_pacbio_runs_path, params: body, headers: json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
@@ -321,6 +327,14 @@ RSpec.describe 'RunsController' do
         expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::WellLibrary, :count).by(1)
       end
 
+      it 'creates 2 used_aliquots' do
+        # Preloaded so its aliquots are built and don't affect the test below
+        pool1.reload
+        library1.reload
+        # One aliquot for the library and one for the pool
+        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Aliquot, :count).by(2)
+      end
+
       it 'creates a run with the correct attributes' do
         post v1_pacbio_runs_path, params: body, headers: json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
@@ -394,6 +408,12 @@ RSpec.describe 'RunsController' do
 
       it 'creates a well pool' do
         expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::WellPool, :count).by(1)
+      end
+
+      it 'creates a used_aliquot' do
+        # Preloaded so its aliquots are built and don't affect the test below
+        pool1.reload
+        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Aliquot, :count).by(1)
       end
 
       it 'creates a run with the correct attributes' do
@@ -568,6 +588,17 @@ RSpec.describe 'RunsController' do
           end.not_to change(Pacbio::Well, :count)
         end
 
+        it 'does not create any used_aliquots' do
+          # Preloaded so its aliquots are built and don't affect the test below
+          pool1.reload
+          library1.reload
+
+          expect do
+            post v1_pacbio_runs_path, params: body,
+                                      headers: json_api_headers
+          end.not_to change(Aliquot, :count)
+        end
+
         it 'has the correct error messages' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
@@ -632,6 +663,13 @@ RSpec.describe 'RunsController' do
           end.not_to change(Pacbio::Well, :count)
         end
 
+        it 'does not create any used_aliquots' do
+          expect do
+            post v1_pacbio_runs_path, params: body,
+                                      headers: json_api_headers
+          end.not_to change(Aliquot, :count)
+        end
+
         it 'has the correct error messages' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
@@ -691,6 +729,13 @@ RSpec.describe 'RunsController' do
             post v1_pacbio_runs_path, params: body,
                                       headers: json_api_headers
           end.not_to change(Pacbio::Well, :count)
+        end
+
+        it 'does not create any used_aliquots' do
+          expect do
+            post v1_pacbio_runs_path, params: body,
+                                      headers: json_api_headers
+          end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
@@ -756,6 +801,13 @@ RSpec.describe 'RunsController' do
           end.not_to change(Pacbio::Well, :count)
         end
 
+        it 'does not create any used_aliquots' do
+          expect do
+            post v1_pacbio_runs_path, params: body,
+                                      headers: json_api_headers
+          end.not_to change(Aliquot, :count)
+        end
+
         it 'has the correct error messages' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
@@ -817,6 +869,13 @@ RSpec.describe 'RunsController' do
             post v1_pacbio_runs_path, params: body,
                                       headers: json_api_headers
           end.not_to change(Pacbio::Well, :count)
+        end
+
+        it 'does not create any used_aliquots' do
+          expect do
+            post v1_pacbio_runs_path, params: body,
+                                      headers: json_api_headers
+          end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
@@ -897,6 +956,10 @@ RSpec.describe 'RunsController' do
           expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::WellPool, :count).by(2)
         end
 
+        it 'creates 2 used_aliquots' do
+          expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Aliquot, :count).by(2)
+        end
+
         it 'creates a run with the correct attributes' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
@@ -956,11 +1019,22 @@ RSpec.describe 'RunsController' do
           end.not_to change(Pacbio::Run, :count)
         end
 
-        it 'does not create a a well' do
+        it 'does not create a well' do
           expect do
             post v1_pacbio_runs_path, params: body,
                                       headers: json_api_headers
           end.not_to change(Pacbio::Well, :count)
+        end
+
+        it 'does not create a used_aliquot' do
+          # Preloaded so its aliquots are built and don't affect the test below
+          pool1.reload
+          pool2.reload
+
+          expect do
+            post v1_pacbio_runs_path, params: body,
+                                      headers: json_api_headers
+          end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
@@ -1290,6 +1364,17 @@ RSpec.describe 'RunsController' do
           end.to change(Pacbio::WellPool, :count).from(10).to(2)
         end
 
+        it 'creates the correct number of used_aliquots' do
+          # Aliquot count should be reduced by 8, see above
+          # Preloaded so its aliquots are built and don't affect the test below
+          pool1.reload
+          well1.pools[0].reload
+
+          expect do
+            patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          end.to change(Aliquot, :count).from(54).to(46)
+        end
+
         it 'updates a well' do
           patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
           run.reload
@@ -1358,6 +1443,12 @@ RSpec.describe 'RunsController' do
           expect do
             patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
           end.to change(Pacbio::WellPool, :count).from(20).to(13)
+        end
+
+        it 'creates the correct number of used_aliquots' do
+          expect do
+            patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          end.to change(Aliquot, :count).by(-7)
         end
 
         it 'updates a well' do

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe 'RunsController' do
   let!(:version12) { create(:pacbio_smrt_link_version, name: 'v12_revio') }
   let!(:version13) { create(:pacbio_smrt_link_version, name: 'v13_revio') }
 
+  before do
+    Flipper.enable(:dpl_1112)
+  end
+
   shared_examples 'publish_messages_on_create' do
     it 'publishes a message' do
       expect(Messages).to receive(:publish).with(instance_of(Pacbio::Run), having_attributes(pipeline: 'pacbio'))
@@ -674,7 +678,8 @@ RSpec.describe 'RunsController' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
-          expect(errors[0]['detail']).to eq 'plates.wells.base - There must be at least 1 pool or library for well A1'
+          expect(errors[0]['detail']).to eq("plates.wells.used_aliquots - can't be blank")
+          expect(errors[1]['detail']).to eq 'plates.wells.base - There must be at least 1 pool or library for well A1'
         end
       end
 


### PR DESCRIPTION
Closes #1226 

#### Changes proposed in this pull request

- Overloads well pool_ids and library_ids method to also handle used_aliquots creation and deletion

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
