### PR TITLE
DPL-993 - Disallow deletion of libraries that are part of pools 

### DIFF
--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -34,4 +34,5 @@ class Aliquot < ApplicationRecord
             :insert_size, presence: true, on: :run_creation
   validates :volume, :concentration, :insert_size,
             numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  delegate :is_a?, to: :used_by, prefix: true
 end

--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -104,9 +104,9 @@ module Pacbio
 
     def check_for_associated_pools
       # Gets the library derived aliquots and gets where they are used and checks if any are a pool
-      is_used_by_pacbio_pool = derived_aliquots.collect(&:used_by)
-                                               .flatten.any? { |used_by| used_by.is_a? Pacbio::Pool }
-      if is_used_by_pacbio_pool
+      used_by_pool = derived_aliquots.collect(&:used_by)
+                                     .flatten.any? { |used_by| used_by.is_a? Pacbio::Pool }
+      if used_by_pool
         errors.add(:base, 'Cannot delete a library that is associated with a pool')
         throw(:abort)
       else

--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -103,15 +103,12 @@ module Pacbio
     end
 
     def check_for_associated_pools
-      # Gets the library derived aliquots and gets where they are used and checks if any are a pool
-      used_by_pool = derived_aliquots.collect(&:used_by)
-                                     .flatten.any? { |used_by| used_by.is_a? Pacbio::Pool }
-      if used_by_pool
-        errors.add(:base, 'Cannot delete a library that is associated with a pool')
-        throw(:abort)
-      else
-        true
-      end
+      return true unless derived_aliquots.any? do |aliquot|
+                           aliquot.used_by_is_a?(Pacbio::Pool)
+                         end
+
+      errors.add(:base, 'Cannot delete a library that is associated with a pool')
+      throw(:abort)
     end
   end
 end

--- a/spec/models/aliquot_spec.rb
+++ b/spec/models/aliquot_spec.rb
@@ -79,6 +79,18 @@ RSpec.describe Aliquot do
     expect(aliquot.used_by).to eq(pacbio_library)
   end
 
+  it 'returns true if used_by is an instance of the specified class' do
+    pacbio_library = create(:pacbio_library)
+    aliquot = build(:aliquot, used_by: pacbio_library)
+    expect(aliquot.used_by_is_a?(Pacbio::Library)).to be true
+  end
+
+  it 'returns false if used_by is not an instance of the specified class' do
+    pacbio_library = create(:pacbio_library)
+    aliquot = build(:aliquot, used_by: pacbio_library)
+    expect(aliquot.used_by_is_a?(Pacbio::Pool)).to be false
+  end
+
   describe '#valid?(:run_creation)' do
     subject { build(:aliquot, params).valid?(:run_creation) }
 

--- a/spec/models/pacbio/library_spec.rb
+++ b/spec/models/pacbio/library_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Pacbio::Library, :pacbio do
   end
 
   describe 'destroy' do
-    it 'gets destroyed if there are no associated wells' do
+    it 'gets destroyed if there are no associated wells and associated pools' do
       library = create(:pacbio_library)
       expect { library.destroy }.to change(described_class, :count).by(-1).and change(Aliquot, :count).by(-2)
     end
@@ -140,6 +140,15 @@ RSpec.describe Pacbio::Library, :pacbio do
       library = create(:pacbio_library)
       create(:pacbio_well, libraries: [library])
       expect { library.destroy }.not_to change(described_class, :count)
+    end
+
+    it 'does not get destroyed if there are associated pools' do
+      pool = build(:pacbio_pool)
+      aliquot = create(:aliquot, used_by: pool)
+      library = create(:pacbio_library, derived_aliquots: [aliquot])
+      expect { library.destroy }.not_to change(described_class, :count)
+      # Check that the library has the expected error message
+      expect(library.errors[:base]).to include('Cannot delete a library that is associated with a pool')
     end
   end
 


### PR DESCRIPTION
This PR includes
Added checks for  associated pools in a library before destroying a library


