### PR TITLE
fix(ont-pools): fixes tag validation to go via libraries

### DIFF
--- a/app/validators/tag_validator.rb
+++ b/app/validators/tag_validator.rb
@@ -6,7 +6,7 @@
 # if there is more than one library each tag will need to be unique
 class TagValidator < ActiveModel::Validator
   def validate(record)
-    if Flipper.enabled?(:multiplexing_phase_2_aliquot)
+    if Flipper.enabled?(:multiplexing_phase_2_aliquot) && record.respond_to?(:used_aliquots)
       validate_used_aliquots(record)
     else
       validate_libraries(record)

--- a/spec/models/ont/pool_spec.rb
+++ b/spec/models/ont/pool_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Ont::Pool, :ont do
       expect(build(:ont_pool, libraries: [build(:ont_library, tag: nil)])).to be_valid
     end
 
-    it 'does not be valid if there are multiple libraries and any of them dont have tags' do
+    it 'is not valid if there are multiple libraries and any of them dont have tags' do
       untagged_library = build(:ont_library, tag: nil)
 
       expect(build(:ont_pool, libraries: libraries + [untagged_library])).not_to be_valid


### PR DESCRIPTION
TagValidator is a shared class between PacBio and ONT. With the introduction of the aliquot work this has broken tag validation in ONT which does not have aliquots. 

#### Changes proposed in this pull request

- Updates TagValidator to only validate via used_aliquots if the record can respond to used_aliquots.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
