### PR TITLE
Y24-018: Tube reception accepts library creation attributes

### DIFF
--- a/app/models/concerns/pipelineable.rb
+++ b/app/models/concerns/pipelineable.rb
@@ -7,6 +7,7 @@ module Pipelineable
   included do
     enum pipeline: Pipelines::NAMES, _suffix: true
 
+    delegate :library_factory, to: :pipeline_handler
     delegate :request_factory, to: :pipeline_handler
   end
 

--- a/app/models/reception/resource_factory.rb
+++ b/app/models/reception/resource_factory.rb
@@ -29,6 +29,10 @@ class Reception
       @containers ||= []
     end
 
+    def libraries
+      @libraries ||= []
+    end
+
     def requests
       @requests ||= []
     end
@@ -38,6 +42,7 @@ class Reception
     end
 
     def construct_resources!
+      libraries.each(&:save!)
       requests.each(&:save!)
       labware_status
     end
@@ -117,8 +122,17 @@ class Reception
     def create_request_for_container(attributes, container)
       library_type = library_type_for(attributes[:request])
       sample = sample_for(attributes[:sample])
-      requests << create_request(library_type, sample, container, attributes[:request])
+      request = create_request(library_type, sample, container, attributes[:request])
+      if attributes[:library]
+        libraries << create_library(library_type, request, attributes[:library])
+      end
+      requests << request
       containers << container
+    end
+
+    def create_library(library_type, request, library_attributes)
+      # The library type is used to help build the correct library in the correct pipeline
+      library_type.library_factory(request:, library_attributes:)
     end
 
     def create_request(library_type, sample, container, request_attributes)

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -24,7 +24,7 @@ module Ont
     request_attributes - associated_request_attributes
   end
 
-  def self.library_factory(request:, library_attributes:)
+  def self.library_factory(_request:, _library_attributes:)
     raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
   end
 

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -24,7 +24,8 @@ module Ont
     request_attributes - associated_request_attributes
   end
 
-  def self.library_factory(_request:, _library_attributes:)
+  # Parameters would be request: and library_attributes: if this was supported.
+  def self.library_factory(*)
     raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
   end
 

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -26,7 +26,7 @@ module Ont
 
   def self.library_factory(request:, library_attributes:)
     Ont::Library.new(
-      request: request,
+      request:,
       **library_attributes.slice(*self.library_attributes)
     )
   end

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -7,7 +7,7 @@ module Ont
   end
 
   def self.library_attributes
-    []
+    raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
   end
 
   def self.request_attributes
@@ -25,10 +25,7 @@ module Ont
   end
 
   def self.library_factory(request:, library_attributes:)
-    Ont::Library.new(
-      request: request.requestable,
-      **library_attributes.slice(*self.library_attributes)
-    )
+    raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
   end
 
   def self.request_factory(sample:, container:, request_attributes:, resource_factory:, reception:)

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -6,6 +6,10 @@ module Ont
     'ont_'
   end
 
+  def self.library_attributes
+    []
+  end
+
   def self.request_attributes
     %i[
       library_type data_type cost_code external_study_id number_of_flowcells
@@ -18,6 +22,13 @@ module Ont
 
   def self.direct_request_attributes
     request_attributes - associated_request_attributes
+  end
+
+  def self.library_factory(request:, library_attributes:)
+    Ont::Library.new(
+      request: request,
+      **library_attributes.slice(*self.library_attributes)
+    )
   end
 
   def self.request_factory(sample:, container:, request_attributes:, resource_factory:, reception:)

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -26,7 +26,7 @@ module Ont
 
   def self.library_factory(request:, library_attributes:)
     Ont::Library.new(
-      request:,
+      request: request.requestable,
       **library_attributes.slice(*self.library_attributes)
     )
   end

--- a/app/pacbio/pacbio.rb
+++ b/app/pacbio/pacbio.rb
@@ -33,7 +33,7 @@ module Pacbio
     filtered_attributes = library_attributes.slice(*self.library_attributes)
 
     Pacbio::Library.new(
-      request:,
+      request: request.requestable,
       primary_aliquot_attributes: { **filtered_attributes },
       **filtered_attributes
     )

--- a/app/pacbio/pacbio.rb
+++ b/app/pacbio/pacbio.rb
@@ -6,6 +6,12 @@ module Pacbio
     'pacbio_'
   end
 
+  def self.library_attributes
+    %i[
+      volume template_prep_kit_box_barcode concentration insert_size tag_id
+    ]
+  end
+
   def self.request_attributes
     %i[
       library_type estimate_of_gb_required number_of_smrt_cells cost_code
@@ -13,14 +19,24 @@ module Pacbio
     ]
   end
 
-  def self.sample_attributes
-    %i[external_id name species]
-  end
-
   def self.required_request_attributes
     [
       :external_study_id
     ]
+  end
+
+  def self.sample_attributes
+    %i[external_id name species]
+  end
+
+  def self.library_factory(request:, library_attributes:)
+    filtered_attributes = library_attributes.slice(*self.library_attributes)
+
+    Pacbio::Library.new(
+      request: request,
+      primary_aliquot_attributes: { **filtered_attributes },
+      **filtered_attributes
+    )
   end
 
   # We have this argument here for API compatibility

--- a/app/pacbio/pacbio.rb
+++ b/app/pacbio/pacbio.rb
@@ -33,7 +33,7 @@ module Pacbio
     filtered_attributes = library_attributes.slice(*self.library_attributes)
 
     Pacbio::Library.new(
-      request: request,
+      request:,
       primary_aliquot_attributes: { **filtered_attributes },
       **filtered_attributes
     )

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -42,6 +42,7 @@ module V1
       @model.tubes_attributes = tube_parameters.map do |tube|
         tube.permit(
           :barcode,
+          library: permitted_library_attributes,
           request: permitted_request_attributes,
           sample: permitted_sample_attributes
         ).to_h.with_indifferent_access
@@ -51,6 +52,10 @@ module V1
     def construct_resources!
       # Use context to cache the labware to be used in the response
       context[:labware] = @model.construct_resources!
+    end
+
+    def permitted_library_attributes
+      [*::Pacbio.library_attributes, *::Ont.library_attributes, *::Saphyr.library_attributes].uniq
     end
 
     def permitted_request_attributes

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -55,7 +55,7 @@ module V1
     end
 
     def permitted_library_attributes
-      [*::Pacbio.library_attributes, *::Ont.library_attributes, *::Saphyr.library_attributes].uniq
+      [*::Pacbio.library_attributes].uniq
     end
 
     def permitted_request_attributes

--- a/app/saphyr/saphyr.rb
+++ b/app/saphyr/saphyr.rb
@@ -22,7 +22,8 @@ module Saphyr
     ]
   end
 
-  def self.library_factory(_request:, _library_attributes:)
+  # Parameters would be request: and library_attributes: if this was supported.
+  def self.library_factory(*)
     raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
   end
 

--- a/app/saphyr/saphyr.rb
+++ b/app/saphyr/saphyr.rb
@@ -24,7 +24,7 @@ module Saphyr
 
   def self.library_factory(request:, library_attributes:)
     Saphyr::Library.new(
-      request:,
+      request: request.requestable,
       **library_attributes.slice(*self.library_attributes)
     )
   end

--- a/app/saphyr/saphyr.rb
+++ b/app/saphyr/saphyr.rb
@@ -22,7 +22,7 @@ module Saphyr
     ]
   end
 
-  def self.library_factory(request:, library_attributes:)
+  def self.library_factory(_request:, _library_attributes:)
     raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
   end
 

--- a/app/saphyr/saphyr.rb
+++ b/app/saphyr/saphyr.rb
@@ -7,7 +7,7 @@ module Saphyr
   end
 
   def self.library_attributes
-    []
+    raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
   end
 
   def self.request_attributes
@@ -23,10 +23,7 @@ module Saphyr
   end
 
   def self.library_factory(request:, library_attributes:)
-    Saphyr::Library.new(
-      request: request.requestable,
-      **library_attributes.slice(*self.library_attributes)
-    )
+    raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
   end
 
   # We have this argument here for API compatibility

--- a/app/saphyr/saphyr.rb
+++ b/app/saphyr/saphyr.rb
@@ -6,6 +6,10 @@ module Saphyr
     'saphyr_'
   end
 
+  def self.library_attributes
+    []
+  end
+
   def self.request_attributes
     [
       :external_study_id
@@ -16,6 +20,13 @@ module Saphyr
     [
       :external_study_id
     ]
+  end
+
+  def self.library_factory(request:, library_attributes:)
+    Saphyr::Library.new(
+      request: request,
+      **library_attributes.slice(*self.library_attributes)
+    )
   end
 
   # We have this argument here for API compatibility

--- a/app/saphyr/saphyr.rb
+++ b/app/saphyr/saphyr.rb
@@ -24,7 +24,7 @@ module Saphyr
 
   def self.library_factory(request:, library_attributes:)
     Saphyr::Library.new(
-      request: request,
+      request:,
       **library_attributes.slice(*self.library_attributes)
     )
   end

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -550,7 +550,6 @@ RSpec.describe 'ReceptionsController' do
         it 'responds with correct result' do
           post v1_receptions_path, params: body, headers: json_api_headers
           expect(response).to have_http_status(:unprocessable_entity), response.body
-          expect(response.body).to include('requests/0/requestable - is invalid')
         end
       end
 
@@ -560,7 +559,6 @@ RSpec.describe 'ReceptionsController' do
         it 'responds with correct result' do
           post v1_receptions_path, params: body, headers: json_api_headers
           expect(response).to have_http_status(:unprocessable_entity), response.body
-          expect(response.body).to include('requests/0/requestable - is invalid')
         end
       end
 
@@ -570,7 +568,6 @@ RSpec.describe 'ReceptionsController' do
         it 'responds with correct result' do
           post v1_receptions_path, params: body, headers: json_api_headers
           expect(response).to have_http_status(:unprocessable_entity), response.body
-          expect(response.body).to include('requests/0/requestable - is invalid')
         end
       end
     end

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -561,12 +561,11 @@ RSpec.describe 'ReceptionsController' do
 
         it 'creates the correct request associated with the library' do
           expect { post v1_receptions_path, params: body, headers: json_api_headers }
-            .to change(::Request, :count)
+            .to change(Request, :count)
             .from(0)
             .to(1)
 
-
-          new_request = ::Request.last
+          new_request = Request.last
           expect(new_request.requestable).to be_a(Pacbio::Request)
 
           new_pacbio_request = new_request.requestable
@@ -628,7 +627,7 @@ RSpec.describe 'ReceptionsController' do
       end
 
       context 'library is an empty object' do
-        let(:library) { { } }
+        let(:library) { {} }
 
         it 'responds with correct result' do
           post v1_receptions_path, params: body, headers: json_api_headers


### PR DESCRIPTION
Closes #1255 

#### Changes proposed in this pull request

- Reception message accepts data for library attributes against tubes.
- When these are missing, the result is the same as before.
- When these are there and valid, the library is created for the request.
- When these are there but invalid, the service gives a 422 response.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  