### PR TITLE
DPL 1070 - aliquotable volume check

### DIFF
--- a/app/models/concerns/aliquotable.rb
+++ b/app/models/concerns/aliquotable.rb
@@ -50,7 +50,7 @@ module Aliquotable
       primary_aliquot.volume - used_volume
     end
 
-    # Method: available_volume_check
+    # Method: is_available_volume_sufficient
     #
     # This method is used to validate if the available volume is sufficient for a required volume.
     #
@@ -63,14 +63,14 @@ module Aliquotable
     # @param required_volume [Numeric] The volume that is required.
     #
     # @return [Boolean] Returns true if the available volume is sufficient, false otherwise.
-    def available_volume_check(required_volume)
+    def available_volume_sufficient(required_volume)
       return true if available_volume >= required_volume
 
       errors.add(:base, 'Insufficient volume available')
       false
     end
 
-    # Method: used_volume_check
+    # Method: primary_aliquot_volume_sufficient
     #
     # This method is used to validate the volume of the primary aliquot in the library.
     # It is typically used as a callback before updating a library record.
@@ -87,7 +87,7 @@ module Aliquotable
     #  true if the volume of the primary aliquot is greater than or equal to the used volume, and
     # false if the volume of the primary aliquot is less than the used volume.
 
-    def used_volume_check
+    def primary_aliquot_volume_sufficient
       return unless primary_aliquot&.volume_changed?
       return true if primary_aliquot.volume >= used_volume
 

--- a/app/models/concerns/aliquotable.rb
+++ b/app/models/concerns/aliquotable.rb
@@ -88,8 +88,7 @@ module Aliquotable
     # false if the volume of the primary aliquot is less than the used volume.
 
     def used_volume_check
-      return unless primary_aliquot&.saved_change_to_volume?
-
+      return unless primary_aliquot&.volume_changed?
       return true if primary_aliquot.volume >= used_volume
 
       errors.add(:volume, 'Volume must be greater than the current used volume')

--- a/app/models/concerns/aliquotable.rb
+++ b/app/models/concerns/aliquotable.rb
@@ -8,7 +8,7 @@
 module Aliquotable
   extend ActiveSupport::Concern
 
-  included do
+  included do # rubocop:disable Metrics/BlockLength
     # Associations
     # Aliquots a general term to get all aliquots from a given source
     # Aliquots are polymorphic and can belong to any model
@@ -50,19 +50,50 @@ module Aliquotable
       primary_aliquot.volume - used_volume
     end
 
-    # Method to check if there is enough volume available.
-    # It compares the available volume with the required volume.
+    # Method: available_volume_check
     #
-    # @param required_volume [Numeric] The volume required for the operation.
+    # This method is used to validate if the available volume is sufficient for a required volume.
     #
-    # @return [Boolean] Returns true if the available volume is greater than
-    # or equal to the required volume.
-    # If not, it adds an error message to `errors` and returns false.
-    def volume_check(required_volume)
+    # The method performs the following checks:
+    # 1. If the available volume is greater than or equal to the required volume,
+    # the method returns true.
+    # 2. If the available volume is less than the required volume, the method adds an error to the
+    # base attribute of the record and returns false.
+    #
+    # @param required_volume [Numeric] The volume that is required.
+    #
+    # @return [Boolean] Returns true if the available volume is sufficient, false otherwise.
+    def available_volume_check(required_volume)
       return true if available_volume >= required_volume
 
       errors.add(:base, 'Insufficient volume available')
       false
+    end
+
+    # Method: used_volume_check
+    #
+    # This method is used to validate the volume of the primary aliquot in the library.
+    # It is typically used as a callback before updating a library record.
+    #
+    # The method performs the following checks:
+    # 1. If the primary aliquot has not changed its volume, the method returns immediately
+    # without performing any further checks.
+    # 2. If the volume of the primary aliquot is greater than or equal to the used volume,
+    # the method returns true.
+    # 3. If the volume of the primary aliquot is less than the used volume,
+    # the method adds an error to the library record and aborts the update operation.
+    #
+    # @return [nil, true, false] Returns nil if the primary aliquot has not changed its volume,
+    #  true if the volume of the primary aliquot is greater than or equal to the used volume, and
+    # false if the volume of the primary aliquot is less than the used volume.
+
+    def used_volume_check
+      return unless primary_aliquot&.saved_change_to_volume?
+
+      return true if primary_aliquot.volume >= used_volume
+
+      errors.add(:volume, 'Volume must be greater than the current used volume')
+      throw(:abort)
     end
   end
 end

--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -44,10 +44,10 @@ module Pacbio
 
     after_create :create_used_aliquot
 
-    # Before updating the record, the `check_volume` method is called.
-    # This is a callback that checks if the volume has been changed and
+    # Before updating the record, the `used_volume_check` method is called.
+    # This is a callback that checks if the primary_aliquot volume has been changed and
     # if the new volume is greater than the used volume.
-    before_update :check_volume
+    before_update :used_volume_check
 
     before_destroy :check_for_derived_aliquots, prepend: true
 
@@ -90,23 +90,6 @@ module Pacbio
       return true if derived_aliquots.empty?
 
       errors.add(:base, 'Cannot delete a library that is used in a pool or run')
-      throw(:abort)
-    end
-
-    # Checks if the volume has been changed and if the new volume is greater than the used volume.
-    # If the volume has not been changed, the method immediately returns.
-    # If the new volume is greater than the used volume, the method returns true.
-    # If the new volume is less than or equal to the used volume
-    # - an error is added to the volume attribute and
-    # - the update operation is aborted.
-    #
-    # @return [TrueClass, nil]
-    # Returns true if the new volume is greater than the used volume, nil otherwise.
-    def check_volume
-      return unless volume_changed?
-      return true if volume > used_volume
-
-      errors.add(:volume, 'Volume must be greater than the current used volume')
       throw(:abort)
     end
   end

--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -43,6 +43,12 @@ module Pacbio
     accepts_nested_attributes_for :primary_aliquot
 
     after_create :create_used_aliquot
+
+    # Before updating the record, the `check_volume` method is called.
+    # This is a callback that checks if the volume has been changed and
+    # if the new volume is greater than the used volume.
+    before_update :check_volume
+
     before_destroy :check_for_derived_aliquots, prepend: true
 
     def create_used_aliquot
@@ -84,6 +90,23 @@ module Pacbio
       return true if derived_aliquots.empty?
 
       errors.add(:base, 'Cannot delete a library that is used in a pool or run')
+      throw(:abort)
+    end
+
+    # Checks if the volume has been changed and if the new volume is greater than the used volume.
+    # If the volume has not been changed, the method immediately returns.
+    # If the new volume is greater than the used volume, the method returns true.
+    # If the new volume is less than or equal to the used volume
+    # - an error is added to the volume attribute and
+    # - the update operation is aborted.
+    #
+    # @return [TrueClass, nil]
+    # Returns true if the new volume is greater than the used volume, nil otherwise.
+    def check_volume
+      return unless volume_changed?
+      return true if volume > used_volume
+
+      errors.add(:volume, 'Volume must be greater than the current used volume')
       throw(:abort)
     end
   end

--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -44,11 +44,6 @@ module Pacbio
 
     after_create :create_used_aliquot
 
-    # Before updating the record, the `used_volume_check` method is called.
-    # This is a callback that checks if the primary_aliquot volume has been changed and
-    # if the new volume is greater than the used volume.
-    before_update :used_volume_check
-
     before_destroy :check_for_derived_aliquots, prepend: true
 
     def create_used_aliquot

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Aliquotable do
       library.primary_aliquot.volume = 50
       library.save
       required_volume = 10
-      expect(library.available_volume_check(required_volume)).to be(true)
+      expect(library.available_volume_sufficient(required_volume)).to be(true)
     end
 
     it 'returns false if there is not enough volume' do
@@ -90,7 +90,7 @@ RSpec.describe Aliquotable do
       library.primary_aliquot.volume = 10
       library.save
       required_volume = 20
-      expect(library.available_volume_check(required_volume)).to be(false)
+      expect(library.available_volume_sufficient(required_volume)).to be(false)
       expect(library.errors[:base]).to include('Insufficient volume available')
     end
   end
@@ -101,7 +101,7 @@ RSpec.describe Aliquotable do
         library = build(:pacbio_library, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         create_list(:aliquot, 4, aliquot_type: :derived, source: library, volume: 2)
         library.primary_aliquot.volume = 15
-        expect(library.used_volume_check).to be true
+        expect(library.primary_aliquot_volume_sufficient).to be true
         expect(library.errors[:volume]).to be_empty
       end
     end
@@ -111,7 +111,7 @@ RSpec.describe Aliquotable do
         library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         create_list(:aliquot, 5, aliquot_type: :derived, source: library, volume: 2)
         library.primary_aliquot.volume = 5
-        expect { library.used_volume_check }.to throw_symbol(:abort)
+        expect { library.primary_aliquot_volume_sufficient }.to throw_symbol(:abort)
         expect(library.errors[:volume]).to include('Volume must be greater than the current used volume')
       end
     end
@@ -120,7 +120,7 @@ RSpec.describe Aliquotable do
       it 'returns without checking volume' do
         library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         library.primary_aliquot.concentration = 5
-        expect(library.used_volume_check).to be_nil
+        expect(library.primary_aliquot_volume_sufficient).to be_nil
       end
     end
   end

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -74,14 +74,14 @@ RSpec.describe Aliquotable do
     end
   end
 
-  describe '#volume_check' do
+  describe '#available_volume_check' do
     it 'returns true if there is enough volume' do
       library = create(:pacbio_library)
       create_list(:aliquot, 5, aliquot_type: :derived, source: library, volume: 3)
       library.primary_aliquot.volume = 50
       library.save
       required_volume = 10
-      expect(library.volume_check(required_volume)).to be(true)
+      expect(library.available_volume_check(required_volume)).to be(true)
     end
 
     it 'returns false if there is not enough volume' do
@@ -90,8 +90,41 @@ RSpec.describe Aliquotable do
       library.primary_aliquot.volume = 10
       library.save
       required_volume = 20
-      expect(library.volume_check(required_volume)).to be(false)
+      expect(library.available_volume_check(required_volume)).to be(false)
       expect(library.errors[:base]).to include('Insufficient volume available')
+    end
+  end
+
+  describe '#used_volume_check' do
+    context 'when primary aliquot volume has increased' do
+      it 'does not add any error' do
+        library = build(:pacbio_library, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
+        create_list(:aliquot, 4, aliquot_type: :derived, source: library, volume: 2)
+        library.primary_aliquot.update(volume: 15)
+        library.save
+        expect(library.used_volume_check).to be true
+        expect(library.errors[:volume]).to be_empty
+      end
+    end
+
+    context 'when primary aliquot volume is less than used volume' do
+      it 'adds an error' do
+        library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
+        create_list(:aliquot, 5, aliquot_type: :derived, source: library, volume: 2)
+        library.primary_aliquot.update(volume: 5)
+        library.save
+        expect { library.used_volume_check }.to throw_symbol(:abort)
+        expect(library.errors[:volume]).to include('Volume must be greater than the current used volume')
+      end
+    end
+
+    context 'when primary_aliquot volume has not changed' do
+      it 'returns without checking volume' do
+        library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
+        library.primary_aliquot.update(concentration: 5)
+        library.save
+        expect(library.used_volume_check).to be_nil
+      end
     end
   end
 end

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -100,8 +100,7 @@ RSpec.describe Aliquotable do
       it 'does not add any error' do
         library = build(:pacbio_library, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         create_list(:aliquot, 4, aliquot_type: :derived, source: library, volume: 2)
-        library.primary_aliquot.update(volume: 15)
-        library.save
+        library.primary_aliquot.volume = 15
         expect(library.used_volume_check).to be true
         expect(library.errors[:volume]).to be_empty
       end
@@ -111,8 +110,7 @@ RSpec.describe Aliquotable do
       it 'adds an error' do
         library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         create_list(:aliquot, 5, aliquot_type: :derived, source: library, volume: 2)
-        library.primary_aliquot.update(volume: 5)
-        library.save
+        library.primary_aliquot.volume = 5
         expect { library.used_volume_check }.to throw_symbol(:abort)
         expect(library.errors[:volume]).to include('Volume must be greater than the current used volume')
       end
@@ -121,8 +119,7 @@ RSpec.describe Aliquotable do
     context 'when primary_aliquot volume has not changed' do
       it 'returns without checking volume' do
         library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
-        library.primary_aliquot.update(concentration: 5)
-        library.save
+        library.primary_aliquot.concentration = 5
         expect(library.used_volume_check).to be_nil
       end
     end

--- a/spec/models/pacbio/library_spec.rb
+++ b/spec/models/pacbio/library_spec.rb
@@ -287,13 +287,4 @@ RSpec.describe Pacbio::Library, :pacbio do
       expect(library.wells.count).to eq(5)
     end
   end
-
-  context 'before_update' do
-    it 'calls used_volume_check method' do
-      library = create(:pacbio_library)
-      expect(library).to receive(:used_volume_check)
-      library.primary_aliquot.update(volume: 10)
-      library.save
-    end
-  end
 end


### PR DESCRIPTION
This story aims to split the PRs for volume checks in the 'Aliquotable' concern from the callback hook in the 'Library' model ([PR](https://github.com/sanger/traction-service/pull/1288)) 
This separation enables independent deployment of this story, whereas changes to the Library model necessitate more extensive testing.