### PR TITLE
Y24-059 - Fix data that violates volume checks

### DIFF
--- a/lib/tasks/volume_tracking.rake
+++ b/lib/tasks/volume_tracking.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Rake tasks associated with volume tracking
+namespace :volume_tracking do
+  # A rake task to be run once in production to clear the volume of all well aliquots
+  # As we have assumed we should take the full volume of each library / pool used in a well
+  # But this is arbitrary and causes volume_check failures
+  desc 'Clear the volume and concentration of all well aliquots'
+  task clear_well_aliquot_volume: :environment do
+    puts '-> Clearing volume of all well aliquots'
+
+    ActiveRecord::Base.transaction do
+      # If an aliquot is used by a well set its volume and conc to 0
+      Aliquot.where(used_by_type: 'Pacbio::Well').find_each do |aliquot|
+        aliquot.update!(volume: 0, concentration: 0)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/volume_tracking.rake_spec.rb
+++ b/spec/lib/tasks/volume_tracking.rake_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+# only load Rake tasks if they haven't been loaded already
+Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+RSpec.describe 'RakeTasks' do
+  # Create a default SMRTLink version to be used by factories
+  before do
+    Pacbio::SmrtLinkVersion.find_by(name: 'v13_sequel_iie') || create(:pacbio_smrt_link_version, name: 'v13_sequel_iie', default: true)
+  end
+
+  describe 'volume_tracking:clear_well_aliquot_volume' do
+    it 'sets the volume and concentration of all well aliquots to 0' do
+      # Create some other aliquots to check they are not affected
+      pool_aliquots = create_list(:aliquot, 5, used_by: create(:pacbio_pool), volume: 10, concentration: 10)
+      create_list(:aliquot, 5, used_by: create(:pacbio_library), volume: 10, concentration: 10)
+
+      # Data we want to change
+      well_aliquots = create_list(:aliquot, 10, used_by: create(:pacbio_well), volume: 10, concentration: 10)
+
+      # We shouldnt change the amount of aliquots
+      expect { Rake::Task['volume_tracking:clear_well_aliquot_volume'].invoke }.not_to change(Aliquot, :count)
+
+      # Well aliquots should have their volume and concentration set to 0
+      well_aliquots.each do |aliquot|
+        aliquot.reload
+        expect(aliquot.volume).to eq 0
+        expect(aliquot.concentration).to eq 0
+      end
+
+      # Other aliquots should not be affected
+      pool_aliquots.each do |aliquot|
+        aliquot.reload
+        expect(aliquot.volume).to eq 10
+        expect(aliquot.concentration).to eq 10
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1293 

#### Changes proposed in this pull request

- Adds volume_tracking rake file
  - Adds clear_well_aliquot_volume rake task to clear volume and conc in aliquots used by wells to ensure old arbitrary data doesn't violate volume checks.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
