### PR TITLE
Y24-073 - Populate PacBio run comments with pool barcode + concentration

### DIFF
--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -12,6 +12,11 @@ module Pacbio
     # Sequel II and Sequel I are now deprecated
     enum system_name: { 'Sequel II' => 0, 'Sequel I' => 1, 'Sequel IIe' => 2, 'Revio' => 3 }
 
+    # before_create :generate_comment, unless: -> { wells.nil? }
+
+    # We want to generate comments before the run was created
+    # but tube barcodes aren't generated until the run is created.
+
     after_create :generate_name, :generate_comment
 
     has_many :plates, foreign_key: :pacbio_run_id,

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -56,7 +56,7 @@ module Pacbio
         " #{well.used_aliquots.first.source.tube.barcode} #{well.library_concentration}pM"
       end.join(' ')
 
-      update(comments: (comments + comment)[0, 65535])
+      update(comments: (comments + comment))
     end
 
     def comments

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -47,14 +47,14 @@ module Pacbio
     # if comments are nil this blows up so add try.
 
     def generate_comment
-      new_comment = "#{comments} ".presence || ''
+      comment = "#{comments} ".presence || ''
 
       wells.collect do |well|
-        new_comment += "#{well.used_aliquots.first.source.tube.barcode} " \
-                       "#{well.library_concentration}pM"
-      end.join(' ')
+        comment += " #{well.used_aliquots.first.source.tube.barcode} " \
+                   "#{well.library_concentration}pM"
+      end
 
-      update(comments: new_comment)
+      update(comments: comment[0..65534])
     end
 
     def comments

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -51,13 +51,13 @@ module Pacbio
 
       wells.collect do |well|
         new_comment += "#{well.used_aliquots.first.source.tube.barcode} " \
-          "#{well.library_concentration}pM "
+                       "#{well.library_concentration}pM"
       end.join(' ')
 
       update(comments: new_comment)
     end
 
-    def comments()
+    def comments
       super || ''
     end
 

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -46,7 +46,11 @@ module Pacbio
 
     # if comments are nil this blows up so add try.
     def comments
-      super || wells.try(:collect, &:summary).try(:join, ':')
+      return super if super.present?
+    
+      wells.collect.with_index do |well|
+        "#{well.used_aliquots.first.source.tube.barcode} #{well.smrt_link_options['library_concentration']}pM"
+      end.join(' ')
     end
 
     # returns sample sheet csv for a Pacbio::Run

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -47,9 +47,10 @@ module Pacbio
     # if comments are nil this blows up so add try.
     def comments
       return super if super.present?
-    
-      wells.collect.with_index do |well|
-        "#{well.used_aliquots.first.source.tube.barcode} #{well.smrt_link_options['library_concentration']}pM"
+
+      wells.collect do |well|
+        "#{well.used_aliquots.first.source.tube.barcode} " \
+          "#{well.smrt_link_options['library_concentration']}pM"
       end.join(' ')
     end
 

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -50,7 +50,7 @@ module Pacbio
 
       wells.collect do |well|
         "#{well.used_aliquots.first.source.tube.barcode} " \
-          "#{well.smrt_link_options['library_concentration']}pM"
+          "#{well.library_concentration}pM"
       end.join(' ')
     end
 

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -52,14 +52,11 @@ module Pacbio
     # if comments are nil this blows up so add try.
 
     def generate_comment
-      comment = "#{comments} ".presence || ''
-
-      wells.collect do |well|
-        comment += " #{well.used_aliquots.first.source.tube.barcode} " \
-                   "#{well.library_concentration}pM"
-      end
-
-      update(comments: comment[0..65534])
+      comment = wells.collect do |well|
+        " #{well.used_aliquots.first.source.tube.barcode} #{well.library_concentration}pM"
+      end.join(' ')
+  
+      update(comments: comments + comment)
     end
 
     def comments

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -55,8 +55,8 @@ module Pacbio
       comment = wells.collect do |well|
         " #{well.used_aliquots.first.source.tube.barcode} #{well.library_concentration}pM"
       end.join(' ')
-  
-      update(comments: comments + comment)
+
+      update(comments: (comments + comment)[0, 65535])
     end
 
     def comments

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Pacbio::Run, :pacbio do
       run = create(:pacbio_generic_run, plates: [plate], comments: nil)
       expect(run.comments).to eq(
         wells.collect do |well|
-          "#{well.used_aliquots.first.source.tube.barcode} #{well.smrt_link_options['library_concentration']}pM"
+          "#{well.used_aliquots.first.source.tube.barcode} #{well.library_concentration}pM"
         end.join(' ')
       )
     end

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -88,13 +88,10 @@ RSpec.describe Pacbio::Run, :pacbio do
     it 'can have run comments' do
       run = create(:pacbio_sequel_run)
 
-      comment = ''
-      run.wells.collect do |well|
-        comment += " #{well.used_aliquots.first.source.tube.barcode} " \
-                   "#{well.library_concentration}pM"
-      end
-
-      expect(run.comments).to eq("A Run Comment #{comment}")
+      comment = run.wells.collect do |well|
+        " #{well.used_aliquots.first.source.tube.barcode} #{well.library_concentration}pM"
+      end.join(' ')
+      expect(run.comments).to eq("A Run Comment#{comment}")
     end
 
     it 'can have long run comments' do
@@ -108,11 +105,10 @@ RSpec.describe Pacbio::Run, :pacbio do
       wells = create_list(:pacbio_well, 2)
       plate = build(:pacbio_plate, wells:)
       run = create(:pacbio_generic_run, plates: [plate], comments: nil)
-      comment = ''
-      wells.collect do |well|
-        comment += " #{well.used_aliquots.first.source.tube.barcode} " \
-                   "#{well.library_concentration}pM"
-      end
+
+      comment = run.wells.collect do |well|
+        " #{well.used_aliquots.first.source.tube.barcode} #{well.library_concentration}pM"
+      end.join(' ')
       expect(run.comments).to eq(comment)
     end
   end

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -87,7 +87,14 @@ RSpec.describe Pacbio::Run, :pacbio do
   describe '#comments' do
     it 'can have run comments' do
       run = create(:pacbio_sequel_run)
-      expect(run.comments).to eq('A Run Comment')
+
+      comment = ''
+      run.wells.collect do |well|
+        comment += " #{well.used_aliquots.first.source.tube.barcode} " \
+                   "#{well.library_concentration}pM"
+      end
+
+      expect(run.comments).to eq("A Run Comment #{comment}")
     end
 
     it 'can have long run comments' do
@@ -101,11 +108,12 @@ RSpec.describe Pacbio::Run, :pacbio do
       wells = create_list(:pacbio_well, 2)
       plate = build(:pacbio_plate, wells:)
       run = create(:pacbio_generic_run, plates: [plate], comments: nil)
-      expect(run.comments).to eq(
-        wells.collect do |well|
-          "#{well.used_aliquots.first.source.tube.barcode} #{well.library_concentration}pM"
-        end.join(' ')
-      )
+      comment = ''
+      wells.collect do |well|
+        comment += " #{well.used_aliquots.first.source.tube.barcode} " \
+                   "#{well.library_concentration}pM"
+      end
+      expect(run.comments).to eq(comment)
     end
   end
 
@@ -212,13 +220,17 @@ RSpec.describe Pacbio::Run, :pacbio do
     end
 
     it 'if added should not be written over' do
-      run = create(:pacbio_revio_run, name: 'run1')
+      wells = create_list(:pacbio_well, 2)
+      plate = build(:pacbio_plate, wells:)
+      run = create(:pacbio_generic_run, name: 'run1', plates: [plate])
       expect(run.name).to eq('run1')
     end
 
     it 'must be unique' do
-      run = create(:pacbio_revio_run, name: 'run1')
-      expect(build(:pacbio_revio_run, name: run.name)).not_to be_valid
+      wells = create_list(:pacbio_well, 2)
+      plate = build(:pacbio_plate, wells:)
+      run = create(:pacbio_generic_run, name: 'run1', plates: [plate])
+      expect(build(:pacbio_generic_run, name: run.name)).not_to be_valid
     end
 
     it 'is updateable' do

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -101,7 +101,11 @@ RSpec.describe Pacbio::Run, :pacbio do
       wells = create_list(:pacbio_well, 2)
       plate = build(:pacbio_plate, wells:)
       run = create(:pacbio_generic_run, plates: [plate], comments: nil)
-      expect(run.comments).to eq("#{wells.first.summary}:#{wells[1].summary}")
+      expect(run.comments).to eq(
+        wells.collect.with_index do |well|
+          "#{well.used_aliquots.first.source.tube.barcode} #{well.smrt_link_options['library_concentration']}pM"
+        end.join(' ')
+      )
     end
   end
 

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -94,12 +94,6 @@ RSpec.describe Pacbio::Run, :pacbio do
       expect(run.comments).to eq("A Run Comment#{comment}")
     end
 
-    it 'can have long run comments' do
-      comments = 'X' * 65535
-      run = create(:pacbio_sequel_run, comments:)
-      run.reload
-      expect(run.comments).to eq(comments)
-    end
 
     it 'can have the wells summary when no run comments exist' do
       wells = create_list(:pacbio_well, 2)

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -94,7 +94,6 @@ RSpec.describe Pacbio::Run, :pacbio do
       expect(run.comments).to eq("A Run Comment#{comment}")
     end
 
-
     it 'can have the wells summary when no run comments exist' do
       wells = create_list(:pacbio_well, 2)
       plate = build(:pacbio_plate, wells:)

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Pacbio::Run, :pacbio do
       plate = build(:pacbio_plate, wells:)
       run = create(:pacbio_generic_run, plates: [plate], comments: nil)
       expect(run.comments).to eq(
-        wells.collect.with_index do |well|
+        wells.collect do |well|
           "#{well.used_aliquots.first.source.tube.barcode} #{well.smrt_link_options['library_concentration']}pM"
         end.join(' ')
       )


### PR DESCRIPTION
Closes #627 

#### Changes proposed in this pull request

- When a run is created, the barcode will have the format: "BARCODE CONCENTRATION". The same will happen when a run is updated as long as the comment is empty.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
