### PR TITLE
chore: Add new printers for plates

### DIFF
--- a/lib/tasks/create_printers.rake
+++ b/lib/tasks/create_printers.rake
@@ -8,7 +8,9 @@ namespace :printers do
       { name: 'ssrtubebc-sq1', labware_type: 'tube' },
       { name: 'aa309bc1', labware_type: 'tube' },
       { name: 'g311bc1', labware_type: 'tube' },
-      { name: 'aa309bc3', labware_type: 'tube' }
+      { name: 'aa309bc3', labware_type: 'tube' },
+      { name: 'aa309bc2', labware_type: 'plate96' },
+      { name: 'aa303bc', labware_type: 'plate96' }
     ].each do |options|
       Printer.create_with(options).find_or_create_by!(name: options[:name])
     end

--- a/spec/lib/tasks/create_printers.rake_spec.rb
+++ b/spec/lib/tasks/create_printers.rake_spec.rb
@@ -9,7 +9,7 @@ Rails.application.load_tasks if Rake::Task.tasks.empty?
 RSpec.describe 'RakeTasks' do
   describe 'printers' do
     it 'creates the printers' do
-      expect { Rake::Task['printers:create'].invoke }.to change(Printer, :count).by(6).and output(
+      expect { Rake::Task['printers:create'].invoke }.to change(Printer, :count).by(8).and output(
         <<~HEREDOC
           -> Printers succesfully updated
         HEREDOC


### PR DESCRIPTION
This commit adds new printers for tubes and plates in the `create_printers.rake` file. Two new printers, `aa309bc2` and `aa303bc`, are created with the labware types `plate96`. This change ensures that the printers are properly created and available for use.

Closes #

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
