### PR TITLE
DPL-671 - Prevent hidden tag sets from being used

### DIFF
--- a/app/models/tag_set.rb
+++ b/app/models/tag_set.rb
@@ -9,5 +9,12 @@ class TagSet < ApplicationRecord
   enum sample_sheet_behaviour: { default: 0, hidden: 1 }, _suffix: true
 
   validates :name, presence: true
-  validates :pipeline, presence: true
+  
+  def set_active
+    update(active: true)
+  end
+  
+  def set_inactive
+    update(active: false)
+  end
 end

--- a/app/models/tag_set.rb
+++ b/app/models/tag_set.rb
@@ -10,11 +10,7 @@ class TagSet < ApplicationRecord
 
   validates :name, presence: true
   
-  def set_active
-    update(active: true)
-  end
-  
-  def set_inactive
-    update(active: false)
+  def set_active(active)
+    update(active:)
   end
 end

--- a/app/models/tag_set.rb
+++ b/app/models/tag_set.rb
@@ -9,8 +9,9 @@ class TagSet < ApplicationRecord
   enum sample_sheet_behaviour: { default: 0, hidden: 1 }, _suffix: true
 
   validates :name, presence: true
-  
-  def set_active(active)
+  validates :pipeline, presence: true
+
+  def update_active(active)
     update(active:)
   end
 end

--- a/app/resources/v1/tag_set_resource.rb
+++ b/app/resources/v1/tag_set_resource.rb
@@ -8,5 +8,9 @@ module V1
     has_many :tags
 
     filter :pipeline
+
+    def self.records(options = {})
+      super.where(active: true)
+    end
   end
 end

--- a/db/migrate/20240529124554_add_active_to_tag_sets.rb
+++ b/db/migrate/20240529124554_add_active_to_tag_sets.rb
@@ -1,0 +1,5 @@
+class AddActiveToTagSets < ActiveRecord::Migration[7.1]
+  def change
+    add_column :tag_sets, :active, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_18_145212) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_29_124554) do
   create_table "aliquots", charset: "utf8mb3", force: :cascade do |t|
     t.float "volume"
     t.float "concentration"
@@ -459,6 +459,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_18_145212) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "pipeline", null: false
     t.integer "sample_sheet_behaviour", default: 0, null: false
+    t.boolean "active", default: true, null: false
   end
 
   create_table "tag_taggables", charset: "utf8mb3", force: :cascade do |t|


### PR DESCRIPTION
Closes #920 

#### Changes proposed in this pull request

- Tag sets now have an `active` attribute that defaults to true, along with a method to set the value
- Only active tag sets are returned by the API

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
