### PR TITLE
Y24-126-1 - Support automatic pool creation in reception

### DIFF
--- a/app/models/ont/pool.rb
+++ b/app/models/ont/pool.rb
@@ -5,7 +5,9 @@ module Ont
   class Pool < ApplicationRecord
     include Uuidable
 
-    belongs_to :tube, default: -> { Tube.new }
+    belongs_to :tube, default: -> { Tube.new(barcode:) }
+
+    attr_accessor :barcode
 
     # We have one-to-one association between pool and flowcell at the moment.
     # XXX: We set dependent option to nullify for the moment.

--- a/app/models/reception.rb
+++ b/app/models/reception.rb
@@ -14,7 +14,8 @@ class Reception < ApplicationRecord
   # external collaborators
   validates :source, presence: true, format: /\A[a-z0-9\-.]+\z/
 
-  delegate :construct_resources!, :plates_attributes=, :tubes_attributes=, to: :resource_factory
+  delegate :construct_resources!, :plates_attributes=, :tubes_attributes=,
+           :pool_attributes=, to: :resource_factory
   # We flatten the keys here as they map back directly to the correpsonding
   # attributes in Reception. We're merely using the ResourceFactory to
   # encapsulate the behaviour

--- a/app/models/reception/resource_factory.rb
+++ b/app/models/reception/resource_factory.rb
@@ -93,10 +93,13 @@ class Reception
 
     # Creates a pool from pool_attributes and uses the imported libraries
     def create_pool(pool_attributes)
+      return if pool_attributes.blank?
+
       # Currently only supports Ont
       @pool = Ont::Pool.new(pool_attributes)
       begin
         @pool.libraries = libraries
+        update_labware_status(pool_attributes['barcode'], 'success', nil)
       rescue StandardError => e
         update_labware_status(pool_attributes['barcode'], 'failed', e.message)
       end

--- a/app/models/reception/resource_factory.rb
+++ b/app/models/reception/resource_factory.rb
@@ -94,7 +94,12 @@ class Reception
     # Creates a pool from pool_attributes and uses the imported libraries
     def create_pool(pool_attributes)
       # Currently only supports Ont
-      @pool = Ont::Pool.new(pool_attributes.merge(libraries:))
+      @pool = Ont::Pool.new(pool_attributes)
+      begin
+        @pool.libraries = libraries
+      rescue StandardError => e
+        update_labware_status(pool_attributes['barcode'], 'failed', e.message)
+      end
     end
 
     def library_type_for(request_attributes)

--- a/app/models/reception/resource_factory.rb
+++ b/app/models/reception/resource_factory.rb
@@ -87,13 +87,15 @@ class Reception
       end
     end
 
+    # Creates a pool from pool_attributes and uses the imported libraries
     def create_pool(pool_attributes)
       # Creates a pool
       pipeline = pool_attributes[:pipeline]
-      pipeline.capitalize.constantize.new(pool_attributes, libraries)
-      update_labware_state(pool_attributes[:barcode], 'success', nil)
+      pipeline.capitalize.constantize::Pool.new(pool_attributes.slice(*::Ont.pool_attributes)
+              .merge(libraries:))
+      update_labware_status(pool_attributes[:barcode], 'success', nil)
     rescue StandardError
-      update_labware_state(pool_attributes[:barcode], 'failed', 'Failed to create pool')
+      update_labware_status(pool_attributes[:barcode], 'failed', 'Failed to create pool')
     end
 
     def library_type_for(request_attributes)

--- a/app/models/reception/unknown_library_type.rb
+++ b/app/models/reception/unknown_library_type.rb
@@ -12,5 +12,9 @@ class Reception
     def request_factory(_attributes)
       self
     end
+
+    def library_factory(_attributes)
+      self
+    end
   end
 end

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -31,9 +31,11 @@ module Ont
   end
 
   def self.library_factory(request:, library_attributes:)
-    # We need to find the tag_id from the tag_sequence provided
-    # TODO: We should take a tag_set here as well as there are duplicate oligos across tagsets
-    library_attributes[:tag_id] = Tag.find_by(oligo: library_attributes[:tag_sequence]).id
+    # Get the tag_set from the kit_barcode
+    ont_tag_set = TagSet.find_by(name: library_attributes[:kit_barcode])
+    # Find the tag_id from the tag_set based on the tag_sequence/oligo
+    library_attributes[:tag_id] =
+      ont_tag_set.tags.find_by(oligo: library_attributes[:tag_sequence])&.id
     filtered_attributes = library_attributes.slice(*self.library_attributes)
 
     Ont::Library.new(

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -7,7 +7,9 @@ module Ont
   end
 
   def self.library_attributes
-    raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
+    %i[
+      volume concenetration kit_barcode insert_size tag_id
+    ]
   end
 
   def self.request_attributes
@@ -24,9 +26,17 @@ module Ont
     request_attributes - associated_request_attributes
   end
 
-  # Parameters would be request: and library_attributes: if this was supported.
-  def self.library_factory(*)
-    raise StandardError, 'Unsupported' # Only Pacbio is supported at the moment
+  def self.library_factory(request:, library_attributes:)
+    # We need to find the tag_id from the tag_sequence provided
+    # TODO: We should take a tag_set here as well as there are duplicate oligos across tagsets
+    #
+    library_attributes[:tag_id] = Tag.find_by(oligo: library_attributes[:tag_sequence])
+    filtered_attributes = library_attributes.slice(*self.library_attributes)
+
+    Ont::Library.new(
+      request: request.requestable,
+      **filtered_attributes
+    )
   end
 
   def self.request_factory(sample:, container:, request_attributes:, resource_factory:, reception:)

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -35,7 +35,7 @@ module Ont
     ont_tag_set = TagSet.find_by(name: library_attributes[:kit_barcode])
     # Find the tag_id from the tag_set based on the tag_sequence/oligo
     library_attributes[:tag_id] =
-      ont_tag_set.tags.find_by(oligo: library_attributes[:tag_sequence])&.id
+      ont_tag_set&.tags&.find_by(oligo: library_attributes[:tag_sequence])&.id
     filtered_attributes = library_attributes.slice(*self.library_attributes)
 
     Ont::Library.new(

--- a/app/ont/ont.rb
+++ b/app/ont/ont.rb
@@ -6,9 +6,13 @@ module Ont
     'ont_'
   end
 
+  def self.pool_attributes
+    %i[barcode volume concentration kit_barcode insert_size]
+  end
+
   def self.library_attributes
     %i[
-      volume concenetration kit_barcode insert_size tag_id
+      volume concentration kit_barcode insert_size tag_id
     ]
   end
 
@@ -29,8 +33,7 @@ module Ont
   def self.library_factory(request:, library_attributes:)
     # We need to find the tag_id from the tag_sequence provided
     # TODO: We should take a tag_set here as well as there are duplicate oligos across tagsets
-    #
-    library_attributes[:tag_id] = Tag.find_by(oligo: library_attributes[:tag_sequence])
+    library_attributes[:tag_id] = Tag.find_by(oligo: library_attributes[:tag_sequence]).id
     filtered_attributes = library_attributes.slice(*self.library_attributes)
 
     Ont::Library.new(

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -3,7 +3,7 @@
 module V1
   # A Reception handles the import of resources into traction
   class ReceptionResource < JSONAPI::Resource
-    attributes :source, :labware, :plates_attributes, :tubes_attributes
+    attributes :source, :labware, :plates_attributes, :tubes_attributes, :pool_attributes
 
     after_create :publish_messages, :construct_resources!
 
@@ -63,11 +63,11 @@ module V1
     end
 
     def permitted_pool_attributes
-      [*::Ont.pool_attributes]
+      [*::Ont.pool_attributes, :pipeline]
     end
 
     def permitted_library_attributes
-      [*::Pacbio.library_attributes, *::Ont.library_attributes].uniq
+      [*::Pacbio.library_attributes, *::Ont.library_attributes, :tag_sequence].uniq
     end
 
     def permitted_request_attributes

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -63,7 +63,7 @@ module V1
     end
 
     def permitted_pool_attributes
-      [*::Ont.pool_attributes, :pipeline]
+      [*::Ont.pool_attributes, :barcode]
     end
 
     def permitted_library_attributes

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -49,13 +49,25 @@ module V1
       end
     end
 
+    def pool_attributes=(pool_parameters)
+      raise ArgumentError unless pool_parameters.is_a?(Object)
+
+      @model.pool_attributes = pool_parameters.permit(
+        *permitted_pool_attributes
+      ).to_h.with_indifferent_access
+    end
+
     def construct_resources!
       # Use context to cache the labware to be used in the response
       context[:labware] = @model.construct_resources!
     end
 
+    def permitted_pool_attributes
+      [*::Ont.pool_attributes]
+    end
+
     def permitted_library_attributes
-      [*::Pacbio.library_attributes].uniq
+      [*::Pacbio.library_attributes, *::Ont.request_attributes].uniq
     end
 
     def permitted_request_attributes

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -67,7 +67,7 @@ module V1
     end
 
     def permitted_library_attributes
-      [*::Pacbio.library_attributes, *::Ont.request_attributes].uniq
+      [*::Pacbio.library_attributes, *::Ont.library_attributes].uniq
     end
 
     def permitted_request_attributes

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,6 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true

--- a/spec/lib/tasks/volume_tracking.rake_spec.rb
+++ b/spec/lib/tasks/volume_tracking.rake_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'RakeTasks' do
   end
 
   describe 'volume_tracking:clear_well_aliquot_volume' do
+    define_negated_matcher :not_change, :change
+
     it 'sets the volume and concentration of all well aliquots to 0' do
       # Create some other aliquots to check they are not affected
       pool_aliquots = create_list(:aliquot, 5, used_by: create(:pacbio_pool), volume: 10, concentration: 10)
@@ -22,7 +24,7 @@ RSpec.describe 'RakeTasks' do
       well_aliquots = create_list(:aliquot, 10, used_by: create(:pacbio_well), volume: 10, concentration: 10)
 
       # We shouldnt change the amount of aliquots
-      expect { Rake::Task['volume_tracking:clear_well_aliquot_volume'].invoke }.not_to change(Aliquot, :count) and output(
+      expect { Rake::Task['volume_tracking:clear_well_aliquot_volume'].invoke }.to not_change(Aliquot, :count).and output(
         <<~HEREDOC
           -> Clearing volume of all well aliquots
         HEREDOC

--- a/spec/models/ont/pool_spec.rb
+++ b/spec/models/ont/pool_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Ont::Pool, :ont do
     expect(pool.tube).to be_a(Tube)
   end
 
+  it 'can set the tube barcode if given' do
+    pool = create(:ont_pool, barcode: '123456')
+    expect(pool.tube.barcode).to eq('123456')
+  end
+
   it 'can have many libraries' do
     pool = build(:ont_pool, libraries:)
     expect(pool.libraries).to eq(libraries)

--- a/spec/models/reception/resource_factory_spec.rb
+++ b/spec/models/reception/resource_factory_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Reception::ResourceFactory do
-  subject(:resource_factory) { build(:reception_resource_factory, tubes_attributes:, plates_attributes:) }
+  subject(:resource_factory) { build(:reception_resource_factory, tubes_attributes:, plates_attributes:, pool_attributes:) }
 
   let(:tubes_attributes) { [] }
   let(:plates_attributes) { [] }
+  let(:pool_attributes) { nil }
   let(:library_type) { create(:library_type, :ont) }
   let(:data_type) { create(:data_type, :ont) }
 
@@ -87,6 +88,31 @@ RSpec.describe Reception::ResourceFactory do
           ),
           sample: attributes_for(:sample)
         }]
+      end
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'with an invalid pool' do
+      let(:tubes_attributes) do
+        [{
+          type: 'tubes',
+          barcode: 'NT1',
+          request: attributes_for(:ont_request).merge(
+            library_type: library_type.name,
+            data_type: data_type.name
+          ),
+          sample: attributes_for(:sample)
+        }]
+      end
+
+      let(:pool_attributes) do
+        {
+          barcode: 'test-barcode',
+          volume: 1,
+          concentration: -1,
+          insert_size: 1
+        }
       end
 
       it { is_expected.not_to be_valid }

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -337,7 +337,8 @@ RSpec.describe 'ReceptionsController' do
                   volume: 1,
                   concentration: 2,
                   insert_size: 3,
-                  kit_barcode: 'barcode'
+                  kit_barcode: 'barcode',
+                  barcode: 'NT123'
                 }
               }
             }
@@ -365,13 +366,13 @@ RSpec.describe 'ReceptionsController' do
             .to(3)
 
           new_pool = Ont::Pool.last
+          expect(new_pool.tube.barcode).to eq('NT123')
           expect(new_pool.volume).to eq(1)
           expect(new_pool.concentration).to eq(2)
           expect(new_pool.insert_size).to eq(3)
           expect(new_pool.kit_barcode).to eq('barcode')
           expect(new_pool.libraries.count).to eq(3)
           new_pool.libraries.each do |library|
-            expect(library.pool.id).to be(new_pool.id)
             expect(library.volume).to eq(1)
             expect(library.concentration).to eq(2)
             expect(library.insert_size).to eq(3)
@@ -411,7 +412,8 @@ RSpec.describe 'ReceptionsController' do
                   kit_barcode: nil,
                   volume: nil,
                   concentration: -1,
-                  insert_size: nil
+                  insert_size: nil,
+                  barcode: 'NT123'
                 }
               }
             }
@@ -447,7 +449,8 @@ RSpec.describe 'ReceptionsController' do
                   kit_barcode: nil,
                   volume: 1,
                   concentration: 1,
-                  insert_size: nil
+                  insert_size: nil,
+                  barcode: 'NT123'
                 }
               }
             }
@@ -704,7 +707,7 @@ RSpec.describe 'ReceptionsController' do
       it 'has a unprocessable_entity status' do
         # This errors because of a type mismatch when attempting to create the pool as its trying to
         # puts PacBio libraries into an ONT pool
-        # This is fine as its unsupported, we should not be creating pools for pacbio
+        # This is fine as its unsupported, we should not be creating pools for pacbio this way
         post v1_receptions_path, params: body, headers: json_api_headers
         expect(response).to have_http_status(:internal_server_error)
       end

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -380,6 +380,15 @@ RSpec.describe 'ReceptionsController' do
             # Check the library has a tag
             expect(library.tag).to eq(ont_tag_set.tags.find_by(id: library.tag_id))
           end
+
+          labware = JSON.parse(response.parsed_body)['data']['attributes']['labware']
+          expected_labware = {
+            'NT1' => { 'imported' => 'success', 'errors' => [] },
+            'NT2' => { 'imported' => 'success', 'errors' => [] },
+            'NT3' => { 'imported' => 'success', 'errors' => [] },
+            'NT123' => { 'imported' => 'success', 'errors' => [] }
+          }
+          expect(labware).to eq(expected_labware)
         end
       end
 

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -435,44 +435,6 @@ RSpec.describe 'ReceptionsController' do
         expect(json['errors'][0]['detail']).to eq('requests - there are no new samples to import')
       end
     end
-
-    context 'with unwanted library attributes' do
-      let(:object_body) do
-        {
-          data: {
-            type: 'receptions',
-            attributes: {
-              source: 'traction-ui.sequencescape',
-              tubes_attributes: [
-                {
-                  type: 'tubes',
-                  barcode: 'NT1',
-                  library: {},
-                  request: attributes_for(:ont_request).merge(
-                    library_type: library_type.name,
-                    data_type: data_type.name
-                  ),
-                  sample: attributes_for(:sample)
-                }
-              ]
-            }
-          }
-        }
-      end
-      let(:body) do
-        object_body.to_json
-      end
-
-      it 'has a server error status' do
-        post v1_receptions_path, params: body, headers: json_api_headers
-        expect(response).to have_http_status(:server_error), response.body
-      end
-
-      it 'indicates the unsupported state in the response body' do
-        post v1_receptions_path, params: body, headers: json_api_headers
-        expect(response.body).to include('Unsupported')
-      end
-    end
   end
 
   describe '#post with pacbio data' do


### PR DESCRIPTION
Closes #1339

#### Changes proposed in this pull request

- Adds pool_attributes to reception api
- Enables ONT pool tube barcode to be overridden
- Enables ONT pools to be created via the reception

#### Instructions for Reviewers

This PR's code can be reviewed but it is reliant on [Y24-126-2](https://github.com/sanger/traction-ui/issues/1747) being completed for manual end to end testing.