### PR TITLE
Y24-153 - Added volume check to PacBio pools

### DIFF
--- a/app/models/concerns/aliquotable.rb
+++ b/app/models/concerns/aliquotable.rb
@@ -83,6 +83,11 @@ module Aliquotable
       throw(:abort)
     end
 
+    # Method: used_aliquots_volume
+    #
+    # This method is used to validate the volume of used aliquots in a well.
+    # It is typically used as a validation method before updating a pool record.
+    # Returns false if the volume of any used aliquot is insufficient.
     def used_aliquots_volume
       # Get all the aliquots that are libraries or pools and have insufficient volume
       failed_aliquots = used_aliquots.select do |aliquot|

--- a/app/models/concerns/aliquotable.rb
+++ b/app/models/concerns/aliquotable.rb
@@ -82,24 +82,24 @@ module Aliquotable
       errors.add(:volume, 'Volume must be greater than the current used volume')
       throw(:abort)
     end
+  end
 
-    # Method: used_aliquots_volume
-    #
-    # This method is used to validate the volume of used aliquots in a well.
-    # It is typically used as a validation method before updating a pool record.
-    # Returns false if the volume of any used aliquot is insufficient.
-    def used_aliquots_volume
-      # Get all the aliquots that are libraries or pools and have insufficient volume
-      failed_aliquots = used_aliquots.select do |aliquot|
-        (aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool') &&
-          !aliquot.source.available_volume_sufficient
-      end
-      return if failed_aliquots.empty?
-
-      # If there are failed aliquots we want to collect the source barcodes add an error to the pool
-      failed_barcodes = failed_aliquots.map { |aliquot| aliquot.source.tube.barcode }.join(',')
-      errors.add(:base, "Insufficient volume available for #{failed_barcodes}")
-      false
+  # Method: used_aliquots_volume
+  #
+  # This method is used to validate the volume of used aliquots in a well.
+  # It is typically used as a validation method before updating a pool record.
+  # Returns false if the volume of any used aliquot is insufficient.
+  def used_aliquots_volume
+    # Get all the aliquots that are libraries or pools and have insufficient volume
+    failed_aliquots = used_aliquots.select do |aliquot|
+      (aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool') &&
+        !aliquot.source.available_volume_sufficient
     end
+    return if failed_aliquots.empty?
+
+    # If there are failed aliquots we want to collect the source barcodes add an error to the pool
+    failed_barcodes = failed_aliquots.map { |aliquot| aliquot.source.tube.barcode }.join(',')
+    errors.add(:base, "Insufficient volume available for #{failed_barcodes}")
+    false
   end
 end

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -24,7 +24,6 @@ module Pacbio
     validates :used_aliquots, presence: true
     validates :primary_aliquot, presence: true
     validate :used_aliquots_volume
-    before_update :primary_aliquot_volume_sufficient
 
     if Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
       before_update :primary_aliquot_volume_sufficient

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -25,9 +25,7 @@ module Pacbio
     validates :primary_aliquot, presence: true
     validate :used_aliquots_volume
 
-    if Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
-      before_update :primary_aliquot_volume_sufficient
-    end
+    before_update :primary_aliquot_volume_sufficient, if:  Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
 
     accepts_nested_attributes_for :primary_aliquot
 

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -25,7 +25,7 @@ module Pacbio
     validates :primary_aliquot, presence: true
     validate :used_aliquots_volume
     before_update :primary_aliquot_volume_sufficient,
-            if: -> { Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update) }
+                  if: -> { Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update) }
 
     accepts_nested_attributes_for :primary_aliquot
 

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -26,6 +26,9 @@ module Pacbio
     validate :used_aliquots_volume
     before_update :primary_aliquot_volume_sufficient
 
+    if Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+      before_update :primary_aliquot_volume_sufficient
+    end
 
     accepts_nested_attributes_for :primary_aliquot
 

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -30,12 +30,11 @@ module Pacbio
     accepts_nested_attributes_for :primary_aliquot
 
     def used_aliquots_volume
-      # Get all the aliquots that are libraries and have insufficient volume
+      # Get all the aliquots that are libraries or pools and have insufficient volume
       failed_aliquots = used_aliquots.select do |aliquot|
-        aliquot.source_type == 'Pacbio::Library' &&
+        (aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool') &&
           !aliquot.source.available_volume_sufficient
       end
-      # Return if there are no aliquots that failed the volume check
       return if failed_aliquots.empty?
 
       # If there are failed aliquots we want to collect the source barcodes add an error to the pool

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -29,20 +29,6 @@ module Pacbio
 
     accepts_nested_attributes_for :primary_aliquot
 
-    def used_aliquots_volume
-      # Get all the aliquots that are libraries or pools and have insufficient volume
-      failed_aliquots = used_aliquots.select do |aliquot|
-        (aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool') &&
-          !aliquot.source.available_volume_sufficient
-      end
-      return if failed_aliquots.empty?
-
-      # If there are failed aliquots we want to collect the source barcodes add an error to the pool
-      failed_barcodes = failed_aliquots.map { |aliquot| aliquot.source.tube.barcode }.join(',')
-      errors.add(:base, "Insufficient volume available for #{failed_barcodes}")
-      false
-    end
-
     def used_aliquots_attributes=(used_aliquot_options)
       self.used_aliquots = used_aliquot_options.map do |attributes|
         if attributes['id']

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -25,7 +25,8 @@ module Pacbio
     validates :primary_aliquot, presence: true
     validate :used_aliquots_volume
 
-    before_update :primary_aliquot_volume_sufficient, if:  Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+    before_update :primary_aliquot_volume_sufficient,
+                  if: Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
 
     accepts_nested_attributes_for :primary_aliquot
 

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -24,9 +24,8 @@ module Pacbio
     validates :used_aliquots, presence: true
     validates :primary_aliquot, presence: true
     validate :used_aliquots_volume
-
     before_update :primary_aliquot_volume_sufficient,
-                  if: Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+            if: -> { Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update) }
 
     accepts_nested_attributes_for :primary_aliquot
 

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -24,6 +24,8 @@ module Pacbio
     validates :used_aliquots, presence: true
     validates :primary_aliquot, presence: true
     validate :used_aliquots_volume
+    before_update :primary_aliquot_volume_sufficient
+
 
     accepts_nested_attributes_for :primary_aliquot
 

--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -114,7 +114,7 @@ module Pacbio
     def adaptive_loading_check
       loading_target_p1_plus_p2.present?
     end
-    
+
     # This method is used to update the smrt_link_options for a well
     # It takes a hash of options and updates the smrt_link_options store field
     # with the new values

--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -114,20 +114,7 @@ module Pacbio
     def adaptive_loading_check
       loading_target_p1_plus_p2.present?
     end
-
-    def used_aliquots_volume
-      # Get all the aliquots that are libraries or pools and have insufficient volume
-      failed_aliquots = used_aliquots.select do |aliquot|
-        (aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool') &&
-          !aliquot.source.available_volume_sufficient
-      end
-      return if failed_aliquots.empty?
-
-      # If there are failed aliquots we want to collect the source barcodes add an error to the well
-      failed_barcodes = failed_aliquots.map { |aliquot| aliquot.source.tube.barcode }.join(',')
-      errors.add(:base, "Insufficient volume available for #{failed_barcodes}")
-    end
-
+    
     # This method is used to update the smrt_link_options for a well
     # It takes a hash of options and updates the smrt_link_options store field
     # with the new values

--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -118,7 +118,7 @@ module Pacbio
     def used_aliquots_volume
       # Get all the aliquots that are libraries or pools and have insufficient volume
       failed_aliquots = used_aliquots.select do |aliquot|
-        (aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool') &&
+        (aliquot.source_type == 'Pacbio::Library') &&
           !aliquot.source.available_volume_sufficient
       end
       return if failed_aliquots.empty?

--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -118,7 +118,7 @@ module Pacbio
     def used_aliquots_volume
       # Get all the aliquots that are libraries or pools and have insufficient volume
       failed_aliquots = used_aliquots.select do |aliquot|
-        (aliquot.source_type == 'Pacbio::Library') &&
+        (aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool') &&
           !aliquot.source.available_volume_sufficient
       end
       return if failed_aliquots.empty?

--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -116,9 +116,9 @@ module Pacbio
     end
 
     def used_aliquots_volume
-      # Get all the aliquots that are libraries and have insufficient volume
+      # Get all the aliquots that are libraries or pools and have insufficient volume
       failed_aliquots = used_aliquots.select do |aliquot|
-        aliquot.source_type == 'Pacbio::Library' &&
+        (aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool') &&
           !aliquot.source.available_volume_sufficient
       end
       return if failed_aliquots.empty?

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -78,7 +78,7 @@ module V1
       end
 
       def volume_tracking_attributes
-        return unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+        return unless Flipper.enabled?(:y24_153__expose_volume_tracking_attributes_on_pool_resource)
 
         attributes :used_volume, :available_volume
       end

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -19,11 +19,10 @@ module V1
       has_many :libraries
 
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
-             :insert_size, :created_at, :updated_at,
-             :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
+                 :insert_size, :created_at, :updated_at,
+                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
+                 :used_volume, :available_volume
 
-             :used_volume, :available_volume
-  
       attribute :source_identifier, readonly: true
 
       ALIQUOT_ATTRIBUTES = %w[id volume concentration template_prep_kit_box_barcode insert_size

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -20,7 +20,8 @@ module V1
 
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
                  :insert_size, :created_at, :updated_at,
-                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
+                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
+                 :used_volume, :available_volume
 
       attribute :source_identifier, readonly: true
 

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -19,10 +19,11 @@ module V1
       has_many :libraries
 
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
-                 :insert_size, :created_at, :updated_at,
-                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
-                 :used_volume, :available_volume
+             :insert_size, :created_at, :updated_at,
+             :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
 
+             :used_volume, :available_volume if Flipper.enabled?(:y24_153__enable_volume_check_adding_pacbio_pool_to_run)
+  
       attribute :source_identifier, readonly: true
 
       ALIQUOT_ATTRIBUTES = %w[id volume concentration template_prep_kit_box_barcode insert_size

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -22,10 +22,10 @@ module V1
                  :insert_size, :created_at, :updated_at,
                  :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
 
-      # if Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
-      #   attribute :used_volume
-      #   attribute :available_volume
-      # end
+      if Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
+        attribute :used_volume
+        attribute :available_volume
+      end
       # Awaiting UI implementation before enabling this
 
       attribute :source_identifier, readonly: true

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -20,13 +20,8 @@ module V1
 
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
                  :insert_size, :created_at, :updated_at,
-                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
-
-      if Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
-        attribute :used_volume
-        attribute :available_volume
-      end
-      # Awaiting UI implementation before enabling this
+                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
+                 :used_volume, :available_volume
 
       attribute :source_identifier, readonly: true
 

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -22,7 +22,7 @@ module V1
              :insert_size, :created_at, :updated_at,
              :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
 
-             :used_volume, :available_volume if Flipper.enabled?(:y24_153__enable_volume_check_adding_pacbio_pool_to_run)
+             :used_volume, :available_volume
   
       attribute :source_identifier, readonly: true
 

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -19,8 +19,8 @@ module V1
       has_many :libraries
 
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
-             :insert_size, :created_at, :updated_at,
-             :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
+                 :insert_size, :created_at, :updated_at,
+                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
 
       if Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
         attribute :used_volume

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -20,8 +20,7 @@ module V1
 
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
                  :insert_size, :created_at, :updated_at,
-                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
-                 :used_volume, :available_volume
+                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
 
       attribute :source_identifier, readonly: true
 

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -21,7 +21,7 @@ module V1
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
                  :insert_size, :created_at, :updated_at,
                  :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
-                 :used_volume, :available_volume
+                 :volume_tracking_attributes
 
       attribute :source_identifier, readonly: true
 
@@ -75,6 +75,12 @@ module V1
 
       def publish_messages
         Messages.publish(@model.sequencing_runs, Pipelines.pacbio.message)
+      end
+
+      def volume_tracking_attributes
+        return unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+
+        attributes :used_volume, :available_volume
       end
     end
   end

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -21,7 +21,7 @@ module V1
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
                  :insert_size, :created_at, :updated_at,
                  :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes,
-                 :volume_tracking_attributes
+                 :used_volume, :available_volume
 
       attribute :source_identifier, readonly: true
 
@@ -75,12 +75,6 @@ module V1
 
       def publish_messages
         Messages.publish(@model.sequencing_runs, Pipelines.pacbio.message)
-      end
-
-      def volume_tracking_attributes
-        return unless Flipper.enabled?(:y24_153__expose_volume_tracking_attributes_on_pool_resource)
-
-        attributes :used_volume, :available_volume
       end
     end
   end

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -19,8 +19,13 @@ module V1
       has_many :libraries
 
       attributes :volume, :concentration, :template_prep_kit_box_barcode,
-                 :insert_size, :created_at, :updated_at,
-                 :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
+             :insert_size, :created_at, :updated_at,
+             :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
+
+      if Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
+        attribute :used_volume
+        attribute :available_volume
+      end
 
       attribute :source_identifier, readonly: true
 

--- a/app/resources/v1/pacbio/pool_resource.rb
+++ b/app/resources/v1/pacbio/pool_resource.rb
@@ -22,10 +22,11 @@ module V1
                  :insert_size, :created_at, :updated_at,
                  :library_attributes, :used_aliquots_attributes, :primary_aliquot_attributes
 
-      if Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
-        attribute :used_volume
-        attribute :available_volume
-      end
+      # if Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
+      #   attribute :used_volume
+      #   attribute :available_volume
+      # end
+      # Awaiting UI implementation before enabling this
 
       attribute :source_identifier, readonly: true
 

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -3,3 +3,4 @@
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
 
 y24_153__enable_volume_check_pacbio_pool_on_update: When enabled, used volume will be validated against available volume when updating a pool
+y24_153__expose_volume_tracking_attributes_on_pool_resource: When enabled, two attributes for volume tracking will be exposed on the pool resource for validating volume

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -3,4 +3,3 @@
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
 
 y24_153__enable_volume_check_pacbio_pool_on_update: When enabled, used volume will be validated against available volume when updating a pool
-y24_153__enable_volume_check_when_adding_pacbio_pool_to_run: When enabled, "used_volume" and "available_volune" will be exposed to the pool resource to allow for validation

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -3,3 +3,4 @@
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
 
 y24_153__enable_volume_check_pacbio_pool_on_update: When enabled, used volume will be validated against available volume when updating a pool
+y24_153__enable_volume_check_adding_pacbio_pool_to_run: When enabled, used volume will be validated against available volume when updating a pool

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -3,4 +3,3 @@
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
 
 y24_153__enable_volume_check_pacbio_pool_on_update: When enabled, used volume will be validated against available volume when updating a pool
-y24_153__enable_volume_check_adding_pacbio_pool_to_run: When enabled, used volume will be validated against available volume when updating a pool

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,3 +1,5 @@
 # Add feature flags to this file, example:
 # dpl202_enable_angry_cat_feature: When enabled this will add an angry cat to all pages that will try to catch the mouse pointer
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
+
+y24_153__enable_volume_check_pacbio_pool_on_update: When enabled, used volume will be validated against available volume when updating a pool

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -3,3 +3,4 @@
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
 
 y24_153__enable_volume_check_pacbio_pool_on_update: When enabled, used volume will be validated against available volume when updating a pool
+y24_153__enable_volume_check_when_adding_pacbio_pool_to_run: When enabled, "used_volume" and "available_volune" will be exposed to the pool resource to allow for validation

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -3,4 +3,3 @@
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
 
 y24_153__enable_volume_check_pacbio_pool_on_update: When enabled, used volume will be validated against available volume when updating a pool
-y24_153__expose_volume_tracking_attributes_on_pool_resource: When enabled, two attributes for volume tracking will be exposed on the pool resource for validating volume

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -54,7 +54,7 @@ namespace :pacbio_data do
           insert_size: library.insert_size, tag_id: library.tag_id, source_id: library.pacbio_request_id, source_type: 'Pacbio::Request', aliquot_type: :derived
         )
       end
-      Pacbio::Pool.create!(tube: Tube.create, used_aliquots:, volume: 200, concentration: 1, insert_size: 600, template_prep_kit_box_barcode: '029979102141700063023',
+      Pacbio::Pool.create!(tube: Tube.create, used_aliquots:, volume: 20, concentration: 1, insert_size: 600, template_prep_kit_box_barcode: '029979102141700063023',
                            primary_aliquot: Aliquot.new(volume: 20, concentration: 1, template_prep_kit_box_barcode: '029979102141700063023', insert_size: 500))
     end
 

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -54,8 +54,8 @@ namespace :pacbio_data do
           insert_size: library.insert_size, tag_id: library.tag_id, source_id: library.pacbio_request_id, source_type: 'Pacbio::Request', aliquot_type: :derived
         )
       end
-      Pacbio::Pool.create!(tube: Tube.create, used_aliquots:, volume: 1, concentration: 1, insert_size: 600, template_prep_kit_box_barcode: '029979102141700063023',
-                           primary_aliquot: Aliquot.new(volume: 1, concentration: 1, template_prep_kit_box_barcode: '029979102141700063023', insert_size: 500))
+      Pacbio::Pool.create!(tube: Tube.create, used_aliquots:, volume: 200, concentration: 1, insert_size: 600, template_prep_kit_box_barcode: '029979102141700063023',
+                           primary_aliquot: Aliquot.new(volume: 20, concentration: 1, template_prep_kit_box_barcode: '029979102141700063023', insert_size: 500))
     end
 
     # pools

--- a/spec/factories/pacbio/pool.rb
+++ b/spec/factories/pacbio/pool.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       library_factory { :pacbio_library }
     end
 
-    primary_aliquot { association :aliquot, source: instance, aliquot_type: :primary }
+    primary_aliquot { association :aliquot, source: instance, aliquot_type: :primary, volume: 10 }
     template_prep_kit_box_barcode { 'ABC1' }
     concentration { 10 }
     volume { 10 }
@@ -16,7 +16,7 @@ FactoryBot.define do
     used_aliquots do
       library_count.times.map do
         library = build(library_factory)
-        build(:aliquot, source: library, tag: library.tag, aliquot_type: :derived, used_by: instance)
+        build(:aliquot, source: library, tag: library.tag, aliquot_type: :derived, used_by: instance, volume: 10)
       end
     end
 

--- a/spec/factories/pacbio/pool.rb
+++ b/spec/factories/pacbio/pool.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       library_factory { :pacbio_library }
     end
 
-    primary_aliquot { association :aliquot, source: instance, aliquot_type: :primary, volume: 10 }
+    primary_aliquot { association :aliquot, source: instance, aliquot_type: :primary, volume: }
     template_prep_kit_box_barcode { 'ABC1' }
     concentration { 10 }
     volume { 10 }

--- a/spec/factories/pacbio/pool.rb
+++ b/spec/factories/pacbio/pool.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     used_aliquots do
       library_count.times.map do
         library = build(library_factory)
-        build(:aliquot, source: library, tag: library.tag, aliquot_type: :derived, used_by: instance, volume: 10)
+        build(:aliquot, source: library, tag: library.tag, aliquot_type: :derived, used_by: instance)
       end
     end
 

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -6,6 +6,12 @@ require 'rails_helper'
 # Revio Multiplexing work is complete
 
 RSpec.describe Aliquotable do
+
+  before do
+    Flipper.enable(:y24_153__enable_volume_check_pacbio_pool_on_update)
+    Flipper.enable(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
+  end
+
   describe '#primary_aliquot' do
     it 'returns the primary aliquot' do
       pacbio_pool = create(:pacbio_pool)

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -123,16 +123,13 @@ RSpec.describe Aliquotable do
 
     context 'when primary aliquot volume for pools is less than used volume' do
       it 'adds an error' do
-      if not Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
-        pass
-      end
-      
-      pool = create(:pacbio_pool, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
-      create_list(:aliquot, 5, aliquot_type: :derived, source: pool, volume: 2)
-      pool.primary_aliquot.volume = 5
-      expect { pool.primary_aliquot_volume_sufficient }.to throw_symbol(:abort)
-      expect(pool.errors[:volume]).to include('Volume must be greater than the current used volume')
+        pass unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
 
+        pool = create(:pacbio_pool, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
+        create_list(:aliquot, 5, aliquot_type: :derived, source: pool, volume: 2)
+        pool.primary_aliquot.volume = 5
+        expect { pool.primary_aliquot_volume_sufficient }.to throw_symbol(:abort)
+        expect(pool.errors[:volume]).to include('Volume must be greater than the current used volume')
       end
     end
 

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -127,8 +127,6 @@ RSpec.describe Aliquotable do
 
     context 'when primary aliquot volume for pools is less than used volume' do
       it 'adds an error' do
-        skip unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
-
         pool = create(:pacbio_pool, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         create_list(:aliquot, 5, aliquot_type: :derived, source: pool, volume: 2)
         pool.primary_aliquot.volume = 5

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -123,11 +123,16 @@ RSpec.describe Aliquotable do
 
     context 'when primary aliquot volume for pools is less than used volume' do
       it 'adds an error' do
-        pool = create(:pacbio_pool, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
-        create_list(:aliquot, 5, aliquot_type: :derived, source: pool, volume: 2)
-        pool.primary_aliquot.volume = 5
-        expect { pool.primary_aliquot_volume_sufficient }.to throw_symbol(:abort)
-        expect(pool.errors[:volume]).to include('Volume must be greater than the current used volume')
+      if not Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+        pass
+      end
+      
+      pool = create(:pacbio_pool, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
+      create_list(:aliquot, 5, aliquot_type: :derived, source: pool, volume: 2)
+      pool.primary_aliquot.volume = 5
+      expect { pool.primary_aliquot_volume_sufficient }.to throw_symbol(:abort)
+      expect(pool.errors[:volume]).to include('Volume must be greater than the current used volume')
+
       end
     end
 

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe Aliquotable do
       end
     end
 
+    context 'when primary aliquot volume is less than used volume' do
+      it 'adds an error' do
+        pool = create(:pacbio_pool, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
+        create_list(:aliquot, 5, aliquot_type: :derived, source: pool, volume: 2)
+        pool.primary_aliquot.volume = 5
+        expect { pool.primary_aliquot_volume_sufficient }.to throw_symbol(:abort)
+        expect(pool.errors[:volume]).to include('Volume must be greater than the current used volume')
+      end
+    end
     context 'when primary_aliquot volume has not changed' do
       it 'returns without checking volume' do
         library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Aliquotable do
       end
     end
 
-    context 'when primary aliquot volume is less than used volume' do
+    context 'when primary aliquot volume for libraries is less than used volume' do
       it 'adds an error' do
         library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         create_list(:aliquot, 5, aliquot_type: :derived, source: library, volume: 2)
@@ -121,7 +121,7 @@ RSpec.describe Aliquotable do
       end
     end
 
-    context 'when primary aliquot volume is less than used volume' do
+    context 'when primary aliquot volume for pools is less than used volume' do
       it 'adds an error' do
         pool = create(:pacbio_pool, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         create_list(:aliquot, 5, aliquot_type: :derived, source: pool, volume: 2)
@@ -130,6 +130,7 @@ RSpec.describe Aliquotable do
         expect(pool.errors[:volume]).to include('Volume must be greater than the current used volume')
       end
     end
+
     context 'when primary_aliquot volume has not changed' do
       it 'returns without checking volume' do
         library = create(:pacbio_library, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -6,7 +6,6 @@ require 'rails_helper'
 # Revio Multiplexing work is complete
 
 RSpec.describe Aliquotable do
-
   before do
     Flipper.enable(:y24_153__enable_volume_check_pacbio_pool_on_update)
     Flipper.enable(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Aliquotable do
 
     context 'when primary aliquot volume for pools is less than used volume' do
       it 'adds an error' do
-        pass unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+        skip unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
 
         pool = create(:pacbio_pool, volume: 100, primary_aliquot: build(:aliquot, aliquot_type: :primary, volume: 10))
         create_list(:aliquot, 5, aliquot_type: :derived, source: pool, volume: 2)

--- a/spec/models/concerns/aliquotable_spec.rb
+++ b/spec/models/concerns/aliquotable_spec.rb
@@ -8,7 +8,6 @@ require 'rails_helper'
 RSpec.describe Aliquotable do
   before do
     Flipper.enable(:y24_153__enable_volume_check_pacbio_pool_on_update)
-    Flipper.enable(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
   end
 
   describe '#primary_aliquot' do

--- a/spec/models/pacbio/pool_spec.rb
+++ b/spec/models/pacbio/pool_spec.rb
@@ -312,4 +312,13 @@ RSpec.describe Pacbio::Pool, :pacbio do
       expect(pool.sequencing_runs).to eq([plate1.run, plate2.run])
     end
   end
+
+  context 'before_update' do
+    it 'calls primary_aliquot_volume_sufficient method' do
+      pool = create(:pacbio_pool)
+      expect(pool).to receive(:primary_aliquot_volume_sufficient)
+      pool.primary_aliquot.update(volume: 100)
+      pool.save
+    end
+  end
 end

--- a/spec/models/pacbio/pool_spec.rb
+++ b/spec/models/pacbio/pool_spec.rb
@@ -316,7 +316,6 @@ RSpec.describe Pacbio::Pool, :pacbio do
 
   context 'before_update' do
     it 'calls primary_aliquot_volume_sufficient method' do
-      skip unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
       pool = create(:pacbio_pool)
       expect(pool).to receive(:primary_aliquot_volume_sufficient)
       pool.primary_aliquot.update(volume: 100)

--- a/spec/models/pacbio/pool_spec.rb
+++ b/spec/models/pacbio/pool_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Pacbio::Pool, :pacbio do
 
   context 'before_update' do
     it 'calls primary_aliquot_volume_sufficient method' do
-      skip if !Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+      skip unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
       pool = create(:pacbio_pool)
       expect(pool).to receive(:primary_aliquot_volume_sufficient)
       pool.primary_aliquot.update(volume: 100)

--- a/spec/models/pacbio/pool_spec.rb
+++ b/spec/models/pacbio/pool_spec.rb
@@ -134,7 +134,8 @@ RSpec.describe Pacbio::Pool, :pacbio do
   context 'when volume is nil' do
     let(:params) { { volume: nil } }
 
-    it { is_expected.to be_valid }
+    # Validation should fail on the primary aliquot which requires a volume
+    it { is_expected.not_to be_valid }
   end
 
   context 'when volume is positive' do

--- a/spec/models/pacbio/pool_spec.rb
+++ b/spec/models/pacbio/pool_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Pacbio::Pool, :pacbio do
   before do
     # Create a default pacbio smrt link version for pacbio runs.
     create(:pacbio_smrt_link_version, name: 'v10', default: true)
+    Flipper.enable(:y24_153__enable_volume_check_pacbio_pool_on_update)
   end
 
   let(:used_aliquots) { create_list(:aliquot, 5, source: build(:pacbio_library), aliquot_type: :derived) }
@@ -315,6 +316,7 @@ RSpec.describe Pacbio::Pool, :pacbio do
 
   context 'before_update' do
     it 'calls primary_aliquot_volume_sufficient method' do
+      skip if !Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
       pool = create(:pacbio_pool)
       expect(pool).to receive(:primary_aliquot_volume_sufficient)
       pool.primary_aliquot.update(volume: 100)

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Pacbio::Well, :pacbio do
         skip 'Volume check on pool update and run creation is not enabled'
       end
 
-      pools = create_list(:pacbio_pool, 3, volume: 1)
+      pools = create_list(:pacbio_pool, 3, volume: 10)
 
       # Pool with 3 pools: 2 invalid ones and one valid
       well = build(:pacbio_well, used_aliquots: [

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Pacbio::Well, :pacbio do
 
   before do
     Flipper.enable(:y24_153__enable_volume_check_pacbio_pool_on_update)
+    Flipper.enable(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
   end
 
   context 'uuidable' do
@@ -158,18 +159,15 @@ RSpec.describe Pacbio::Well, :pacbio do
       expect(well).to be_valid
     end
 
-
     it 'is not valid when using an invalid amount of volume from a pool' do
-      pools = create_list(:pacbio_pool, 3, volume: 10)
-
+      pools = create_list(:pacbio_pool, 3, volume: 1)
+      
       # Pool with 3 pools: 2 invalid ones and one valid
       well = build(:pacbio_well, used_aliquots: [
         create(:aliquot, source: pools[0], volume: 11, aliquot_type: :derived),
         create(:aliquot, source: pools[1], volume: 11, aliquot_type: :derived),
         create(:aliquot, source: pools[2], volume: 9, aliquot_type: :derived)
       ])
-
-      well.save
 
       expect(well).not_to be_valid
       expect(well.errors[:base][0]).to eq("Insufficient volume available for #{pools[0].tube.barcode},#{pools[1].tube.barcode}")

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Pacbio::Well, :pacbio do
 
   before do
     Flipper.enable(:y24_153__enable_volume_check_pacbio_pool_on_update)
-    Flipper.enable(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
   end
 
   context 'uuidable' do

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -160,6 +160,10 @@ RSpec.describe Pacbio::Well, :pacbio do
     end
 
     it 'is not valid when using an invalid amount of volume from a pool' do
+      if !Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update) || !Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
+        skip 'Volume check on pool update and run creation is not enabled'
+      end
+
       pools = create_list(:pacbio_pool, 3, volume: 1)
 
       # Pool with 3 pools: 2 invalid ones and one valid

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Pacbio::Well, :pacbio do
 
     it 'is not valid when using an invalid amount of volume from a pool' do
       pools = create_list(:pacbio_pool, 3, volume: 1)
-      
+
       # Pool with 3 pools: 2 invalid ones and one valid
       well = build(:pacbio_well, used_aliquots: [
         create(:aliquot, source: pools[0], volume: 11, aliquot_type: :derived),

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Pacbio::Well, :pacbio do
     end
 
     it 'is not valid when using an invalid amount of volume from a pool' do
-      if !Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
+      unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
         skip 'Volume check on pool update and run creation is not enabled'
       end
 

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Pacbio::Well, :pacbio do
     end
 
     it 'is not valid when using an invalid amount of volume from a pool' do
-      if !Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update) || !Flipper.enabled?(:y24_153__enable_volume_check_when_adding_pacbio_pool_to_run)
+      if !Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
         skip 'Volume check on pool update and run creation is not enabled'
       end
 

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Pacbio::Well, :pacbio do
   let!(:version11) { create(:pacbio_smrt_link_version, name: 'v11', default: true) }
   let!(:version12_revio) { create(:pacbio_smrt_link_version, name: 'v12_revio') }
 
+  before do
+    Flipper.enable(:y24_153__enable_volume_check_pacbio_pool_on_update)
+  end
+
   context 'uuidable' do
     let(:uuidable_model) { :pacbio_well }
 
@@ -151,6 +155,29 @@ RSpec.describe Pacbio::Well, :pacbio do
     it 'is valid when using a valid amount of volume from a library' do
       library = create(:pacbio_library, volume: 100)
       well = build(:pacbio_well, used_aliquots: [build(:aliquot, source: library, volume: 100, aliquot_type: :derived)])
+      expect(well).to be_valid
+    end
+
+
+    it 'is not valid when using an invalid amount of volume from a pool' do
+      pools = create_list(:pacbio_pool, 3, volume: 10)
+
+      # Pool with 3 pools: 2 invalid ones and one valid
+      well = build(:pacbio_well, used_aliquots: [
+        create(:aliquot, source: pools[0], volume: 11, aliquot_type: :derived),
+        create(:aliquot, source: pools[1], volume: 11, aliquot_type: :derived),
+        create(:aliquot, source: pools[2], volume: 9, aliquot_type: :derived)
+      ])
+
+      well.save
+
+      expect(well).not_to be_valid
+      expect(well.errors[:base][0]).to eq("Insufficient volume available for #{pools[0].tube.barcode},#{pools[1].tube.barcode}")
+    end
+
+    it 'is valid when using a valid amount of volume from a pool' do
+      pool = create(:pacbio_pool, volume: 100)
+      well = build(:pacbio_well, used_aliquots: [build(:aliquot, source: pool, volume: 100, aliquot_type: :derived)])
       expect(well).to be_valid
     end
   end

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -159,10 +159,6 @@ RSpec.describe Pacbio::Well, :pacbio do
     end
 
     it 'is not valid when using an invalid amount of volume from a pool' do
-      unless Flipper.enabled?(:y24_153__enable_volume_check_pacbio_pool_on_update)
-        skip 'Volume check on pool update and run creation is not enabled'
-      end
-
       pools = create_list(:pacbio_pool, 3, volume: 10)
 
       # Pool with 3 pools: 2 invalid ones and one valid


### PR DESCRIPTION
Closes #1348 

#### Changes proposed in this pull request

- A feature flagged change that validates `available_volume` when updating PacBio pools
    - The validation of available volume when editing a PacBio pool is feature flagged here

#### Additional Context

This PR leaves out adding attributes to the pool resource. When working on https://github.com/sanger/traction-ui/issues/1784, these will need to be added so that validation on the UI happens when adding a pool to a run (from what I can see, that validation already partially exists)


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
