### PR TITLE
DPL-1074 sent library volume to warehouse while creating or updating a sequencing run

### DIFF
--- a/app/exchanges/volume_tracking/message_builder.rb
+++ b/app/exchanges/volume_tracking/message_builder.rb
@@ -35,7 +35,8 @@ module VolumeTracking
       when 'Pacbio::Well'
         data[:used_by_type] = 'run'
         data[:used_by_barcode] =
-          "#{aliquot.used_by.plate.sequencing_kit_box_barcode}:#{aliquot.used_by.plate.plate_number}:#{aliquot.used_by.position}" # rubocop:disable Layout/LineLength
+          "#{aliquot.used_by.plate.sequencing_kit_box_barcode}:" \
+          "#{aliquot.used_by.plate.plate_number}:#{aliquot.used_by.position}"
       when 'Pacbio::Pool'
         data[:used_by_type] = 'pool'
         data[:used_by_barcode] = aliquot.used_by.tube.barcode

--- a/app/exchanges/volume_tracking/message_builder.rb
+++ b/app/exchanges/volume_tracking/message_builder.rb
@@ -33,7 +33,7 @@ module VolumeTracking
 
       case aliquot.used_by_type
       when 'Pacbio::Well'
-        data[:used_by_type] = 'well'
+        data[:used_by_type] = 'run'
         data[:used_by_barcode] =
           "#{aliquot.used_by.plate.sequencing_kit_box_barcode}:#{aliquot.used_by.plate.plate_number}:#{aliquot.used_by.position}" # rubocop:disable Layout/LineLength
       when 'Pacbio::Pool'

--- a/app/messages/emq/publishing_job.rb
+++ b/app/messages/emq/publishing_job.rb
@@ -44,7 +44,8 @@ module Emq
       # and create a message builder class from the configuration
       message_builder_config_obj = message_builder_config(message_config, schema_key, version)
       if message_builder_config_obj.nil?
-        Rails.logger.error("Message builder configuration not found for schema key: #{schema_key} and version: #{version}") # rubocop:disable Layout/LineLength
+        Rails.logger.error('Message builder configuration not found for ' \
+                           "schema key: #{schema_key} and version: #{version}")
         return
       end
       message_builder_class = message_builder_config_obj.message_class.to_s.constantize

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -97,6 +97,16 @@ module Pacbio
       wells.count
     end
 
+    # Returns all aliquots with source_type 'Pacbio::Library' from the wells of the plates.
+    # @return [Array<Aliquot>] an array of aliquots with source_type 'Pacbio::Library'
+    def all_library_aliquots
+      plates.flat_map do |plate|
+        plate.wells.flat_map do |well|
+          well.used_aliquots.select { |aliquot| aliquot.source_type == 'Pacbio::Library' }
+        end
+      end
+    end
+
     private
 
     # We now have SMRT Link versioning

--- a/app/resources/v1/pacbio/run_resource.rb
+++ b/app/resources/v1/pacbio/run_resource.rb
@@ -56,12 +56,7 @@ module V1
 
       def publish_messages
         Messages.publish(@model, Pipelines.pacbio.message)
-        all_library_aliquots = @model.plates.flat_map do |plate|
-          plate.wells.flat_map do |well|
-            well.used_aliquots.select { |aliquot| aliquot.source_type == 'Pacbio::Library' }
-          end
-        end
-        Emq::Publisher.publish(all_library_aliquots, Pipelines.pacbio, 'volume_tracking')
+        Emq::Publisher.publish(@model.all_library_aliquots, Pipelines.pacbio, 'volume_tracking')
       end
 
       private

--- a/app/resources/v1/pacbio/run_resource.rb
+++ b/app/resources/v1/pacbio/run_resource.rb
@@ -56,6 +56,12 @@ module V1
 
       def publish_messages
         Messages.publish(@model, Pipelines.pacbio.message)
+        all_library_aliquots = @model.plates.flat_map do |plate|
+          plate.wells.flat_map do |well|
+            well.used_aliquots.select { |aliquot| aliquot.source_type == 'Pacbio::Library' }
+          end
+        end
+        Emq::Publisher.publish(all_library_aliquots, Pipelines.pacbio, 'volume_tracking')
       end
 
       private

--- a/spec/exchanges/volume_tracking/message_builder_spec.rb
+++ b/spec/exchanges/volume_tracking/message_builder_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe VolumeTracking::MessageBuilder, type: :model do
                                                           source_type: 'library',
                                                           source_barcode: pacbio_library.tube.barcode,
                                                           sample_name: pacbio_library.sample_name,
-                                                          used_by_type: 'well',
+                                                          used_by_type: 'run',
                                                           used_by_barcode: "#{pacbio_well.plate.sequencing_kit_box_barcode}:#{pacbio_well.plate.plate_number}:#{pacbio_well.position}",
                                                           aliquot_uuid: aliquot.uuid
                                                         })

--- a/spec/messages/emq/publisher_spec.rb
+++ b/spec/messages/emq/publisher_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Emq::Publisher do
         allow(Rails.configuration).to receive(:bunny).and_return({ 'enabled' => true })
       end
 
+      after do
+        described_class.instance_variable_set(:@publish_job, nil)
+      end
+
       it 'is present' do
         described_class.publish(aliquots, configuration, schema_key)
         expect(described_class.instance_variable_get(:@publish_job)).not_to be_nil

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -298,4 +298,16 @@ RSpec.describe Pacbio::Run, :pacbio do
       expect(run.wells.last.library_type).to eq 'Standard'
     end
   end
+
+  describe 'all_library_aliquots' do
+    it 'only returns aliquots with source_type Pacbio::Library' do
+      library = create(:pacbio_library)
+      pools = create_list(:pacbio_pool, 2)
+      wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [library]), build(:pacbio_well, row: 'B', column: '1', pools:)]
+      run = create(:pacbio_revio_run, plates: [build(:pacbio_plate, wells:)])
+      run.all_library_aliquots.each do |aliquot|
+        expect(aliquot.source_type).to eq('Pacbio::Library')
+      end
+    end
+  end
 end

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -320,10 +320,6 @@ RSpec.describe 'RunsController' do
         }.to_json
       end
 
-      before do
-        @expected_aliquots = library1.aliquots
-      end
-
       it 'has a created status' do
         post v1_pacbio_runs_path, params: body, headers: json_api_headers
         expect(response).to have_http_status(:created)

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -17,14 +17,9 @@ RSpec.describe 'RunsController' do
     end
 
     it 'publishes volume tracking message for each used aliquot' do
-      allow(Emq::Publisher).to receive(:publish)
-
+      expect(Emq::Publisher).to receive(:publish)
       post v1_pacbio_runs_path, params: body, headers: json_api_headers
-
       expect(response).to have_http_status(:success), response.body
-      run = Pacbio::Run.first
-      # Verify that the publish method was called with the expected arguments
-      expect(Emq::Publisher).to have_received(:publish).with(array_including(run.all_library_aliquots), instance_of(Pipelines::Configuration::Item), 'volume_tracking') # rubocop:disable RSpec/MessageSpies
     end
   end
 
@@ -36,13 +31,9 @@ RSpec.describe 'RunsController' do
     end
 
     it 'publishes volume tracking message for each used aliquot' do
-      allow(Emq::Publisher).to receive(:publish)
-
+      expect(Emq::Publisher).to receive(:publish)
       patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
       expect(response).to have_http_status(:success), response.parsed_body
-
-      run = Pacbio::Run.first
-      expect(Emq::Publisher).to have_received(:publish).with(array_including(run.all_library_aliquots), instance_of(Pipelines::Configuration::Item), 'volume_tracking') # rubocop:disable RSpec/MessageSpies
     end
   end
 

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe 'RunsController' do
         expect(run.pacbio_smrt_link_version_id).to eq(version11.id)
       end
 
-      it_behaves_like 'publish_messages_on_create', 0
+      it_behaves_like 'publish_messages_on_create'
     end
 
     context 'smrtlink v12_revio on success' do
@@ -367,7 +367,7 @@ RSpec.describe 'RunsController' do
         expect(run.plates.first.wells.first.pools.first).to eq(pool1)
       end
 
-      it_behaves_like 'publish_messages_on_create', 1
+      it_behaves_like 'publish_messages_on_create'
     end
 
     context 'smrtlink v13_revio on success' do
@@ -443,7 +443,7 @@ RSpec.describe 'RunsController' do
         expect(run.pacbio_smrt_link_version_id).to eq(version13.id)
       end
 
-      it_behaves_like 'publish_messages_on_create', 0
+      it_behaves_like 'publish_messages_on_create'
     end
 
     context 'on failure' do
@@ -1120,7 +1120,7 @@ RSpec.describe 'RunsController' do
         expect(run.pacbio_smrt_link_version_id).to eq(version.id)
       end
 
-      it_behaves_like 'publish_messages_on_create', 0
+      it_behaves_like 'publish_messages_on_create'
     end
   end
 
@@ -1175,7 +1175,7 @@ RSpec.describe 'RunsController' do
         expect(run.pacbio_smrt_link_version_id).to eq(version.id)
       end
 
-      it_behaves_like 'publish_messages_on_create', 0
+      it_behaves_like 'publish_messages_on_create'
     end
   end
 
@@ -1221,7 +1221,7 @@ RSpec.describe 'RunsController' do
           expect(run.plates.first.wells.map(&:pools)).to eq existing_pools
         end
 
-        it_behaves_like 'publish_messages_on_update', 0
+        it_behaves_like 'publish_messages_on_update'
       end
 
       context 'when run info is successful' do
@@ -1260,7 +1260,7 @@ RSpec.describe 'RunsController' do
           expect(run.state).to eq 'pending'
         end
 
-        it_behaves_like 'publish_messages_on_update', 0
+        it_behaves_like 'publish_messages_on_update'
       end
 
       context 'when well info is successful' do
@@ -1316,7 +1316,7 @@ RSpec.describe 'RunsController' do
           expect(well.binding_kit_box_barcode).to eq 'DM1117100862200111711_updated'
         end
 
-        it_behaves_like 'publish_messages_on_update', 0
+        it_behaves_like 'publish_messages_on_update'
       end
 
       context 'when well is added, removed and updated' do
@@ -1399,7 +1399,7 @@ RSpec.describe 'RunsController' do
           expect(run.wells[1].column).to eq '12'
         end
 
-        it_behaves_like 'publish_messages_on_update', 0
+        it_behaves_like 'publish_messages_on_update'
       end
 
       context 'when pool is added, removed and updated' do
@@ -1476,7 +1476,7 @@ RSpec.describe 'RunsController' do
           expect(updated_plate.wells.first.used_aliquots.length).to eq(well1.used_aliquots.length + 1)
         end
 
-        it_behaves_like 'publish_messages_on_update', 0
+        it_behaves_like 'publish_messages_on_update'
       end
 
       context 'when the pool is updated with aliquot using the same tag as the deleted ones' do
@@ -1530,7 +1530,7 @@ RSpec.describe 'RunsController' do
           end
         end
 
-        it_behaves_like 'publish_messages_on_update', 0
+        it_behaves_like 'publish_messages_on_update'
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/sanger/traction-service/issues/1206

#### Changes proposed in this pull request
- Publish message to EMQ for all library aliquots when a run is created or updated

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
