### PR TITLE
As a long read user I would like the volume to be sent to the warehouse so I can track library volumes and enable top-up management

### DIFF
--- a/app/exchanges/volume_tracking/message_builder.rb
+++ b/app/exchanges/volume_tracking/message_builder.rb
@@ -29,6 +29,8 @@ module VolumeTracking
         data[:source_type] = 'library'
         data[:source_barcode] = aliquot.source.tube.barcode
         data[:sample_name] = aliquot.source.sample_name
+        data[:used_by_barcode] = 'none'
+        data[:used_by_type] = 'none'
       end
 
       case aliquot.used_by_type

--- a/app/exchanges/volume_tracking/message_builder.rb
+++ b/app/exchanges/volume_tracking/message_builder.rb
@@ -20,7 +20,7 @@ module VolumeTracking
 
       aliquot = object
       data = { source_type: '', source_barcode: '', sample_name: '',
-               used_by_type: 'nil', used_by_barcode: '',
+               used_by_type: 'none', used_by_barcode: '',
                aliquot_uuid: aliquot.uuid,
                message_uuid: SecureRandom.uuid }
 
@@ -29,8 +29,6 @@ module VolumeTracking
         data[:source_type] = 'library'
         data[:source_barcode] = aliquot.source.tube.barcode
         data[:sample_name] = aliquot.source.sample_name
-        data[:used_by_barcode] = 'none'
-        data[:used_by_type] = 'none'
       end
 
       case aliquot.used_by_type

--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -38,6 +38,8 @@ module V1
       # to republish the messages for the run
       after_update :publish_messages
 
+      after_create :push_volume_tracking_message
+
       filter :sample_name, apply: lambda { |records, value, _options|
         # We have to join requests and samples here in order to find by sample name
         records.joins(:sample).where(sample: { name: value })
@@ -91,6 +93,10 @@ module V1
 
       def publish_messages
         Messages.publish(@model.sequencing_runs, Pipelines.pacbio.message)
+        push_volume_tracking_message
+      end
+
+      def push_volume_tracking_message
         Emq::Publisher.publish(@model.primary_aliquot, Pipelines.pacbio, 'volume_tracking')
       end
     end

--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -91,7 +91,7 @@ module V1
 
       def publish_messages
         Messages.publish(@model.sequencing_runs, Pipelines.pacbio.message)
-        Emq::Publisher.publish(@model.used_aliquots, Pipelines.pacbio, 'volume_tracking')
+        Emq::Publisher.publish(@model.primary_aliquot, Pipelines.pacbio, 'volume_tracking')
       end
     end
   end

--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -38,7 +38,7 @@ module V1
       # to republish the messages for the run
       after_update :publish_messages
 
-      after_create :push_volume_tracking_message
+      after_create :publish_volume_tracking_message
 
       filter :sample_name, apply: lambda { |records, value, _options|
         # We have to join requests and samples here in order to find by sample name
@@ -93,10 +93,10 @@ module V1
 
       def publish_messages
         Messages.publish(@model.sequencing_runs, Pipelines.pacbio.message)
-        push_volume_tracking_message
+        publish_volume_tracking_message
       end
 
-      def push_volume_tracking_message
+      def publish_volume_tracking_message
         Emq::Publisher.publish(@model.primary_aliquot, Pipelines.pacbio, 'volume_tracking')
       end
     end

--- a/app/resources/v1/pacbio/library_resource.rb
+++ b/app/resources/v1/pacbio/library_resource.rb
@@ -91,6 +91,7 @@ module V1
 
       def publish_messages
         Messages.publish(@model.sequencing_runs, Pipelines.pacbio.message)
+        Emq::Publisher.publish(@model.used_aliquots, Pipelines.pacbio, 'volume_tracking')
       end
     end
   end

--- a/spec/exchanges/volume_tracking/message_builder_spec.rb
+++ b/spec/exchanges/volume_tracking/message_builder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe VolumeTracking::MessageBuilder, type: :model do
                                                           source_type: 'library',
                                                           source_barcode: pacbio_library.tube.barcode,
                                                           sample_name: pacbio_library.sample_name,
-                                                          used_by_type: 'nil',
+                                                          used_by_type: 'none',
                                                           used_by_barcode: '',
                                                           aliquot_uuid: aliquot.uuid
                                                         })

--- a/spec/messages/emq/publisher_spec.rb
+++ b/spec/messages/emq/publisher_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Emq::Publisher do
       allow(publish_job_mock).to receive(:publish).with(aliquots, configuration, schema_key)
     end
 
+    after do
+      described_class.instance_variable_set(:@publish_job, nil)
+    end
+
     context 'when bunny is disabled' do
       before do
         allow(Rails.configuration).to receive(:bunny).and_return({ 'enabled' => false })

--- a/spec/messages/emq/publisher_spec.rb
+++ b/spec/messages/emq/publisher_spec.rb
@@ -15,10 +15,6 @@ RSpec.describe Emq::Publisher do
       allow(publish_job_mock).to receive(:publish).with(aliquots, configuration, schema_key)
     end
 
-    after do
-      described_class.instance_variable_set(:@publish_job, nil)
-    end
-
     context 'when bunny is disabled' do
       before do
         allow(Rails.configuration).to receive(:bunny).and_return({ 'enabled' => false })

--- a/spec/requests/v1/pacbio/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/libraries_spec.rb
@@ -586,6 +586,8 @@ RSpec.describe 'LibrariesController', :pacbio do
 
       it 'publishes a message' do
         expect(Messages).to receive(:publish).with(library.sequencing_runs, having_attributes(pipeline: 'pacbio'))
+        expect(Emq::Publisher).to receive(:publish).with(library.primary_aliquot,
+                                                         having_attributes(pipeline: 'pacbio'), 'volume_tracking')
         patch v1_pacbio_library_path(library), params: body, headers: json_api_headers
         expect(response).to have_http_status(:success), response.body
       end

--- a/spec/requests/v1/pacbio/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/libraries_spec.rb
@@ -592,8 +592,7 @@ RSpec.describe 'LibrariesController', :pacbio do
 
       it 'publishes a message' do
         expect(Messages).to receive(:publish).with(library.sequencing_runs, having_attributes(pipeline: 'pacbio'))
-        expect(Emq::Publisher).to receive(:publish).with(library.primary_aliquot,
-                                                         having_attributes(pipeline: 'pacbio'), 'volume_tracking')
+        expect(Emq::Publisher).to receive(:publish)
         patch v1_pacbio_library_path(library), params: body, headers: json_api_headers
         expect(response).to have_http_status(:success), response.body
       end

--- a/spec/requests/v1/pacbio/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/libraries_spec.rb
@@ -316,6 +316,12 @@ RSpec.describe 'LibrariesController', :pacbio do
           expect(response).to have_http_status(:created), response.body
         end
 
+        it 'publishes volume tracking message for the aliquot' do
+          expect(Emq::Publisher).to receive(:publish)
+          post v1_pacbio_libraries_path, params: body, headers: json_api_headers
+          expect(response).to have_http_status(:success), response.body
+        end
+
         it 'creates a library and aliquots' do
           expect { post v1_pacbio_libraries_path, params: body, headers: json_api_headers }
             .to change(Pacbio::Library, :count).by(1)


### PR DESCRIPTION
Closes #1202

#### Changes proposed in this pull request

- Sending volume tracking message when libraries are created and/or updated.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
