### PR TITLE
Removing retention instruction from warehouse message

### DIFF
--- a/config/pipelines/reception.yml
+++ b/config/pipelines/reception.yml
@@ -80,9 +80,6 @@ default: &default
           date_of_sample_collection:
             type: :model
             value: date_of_sample_collection
-          retention_instruction:
-            type: :model
-            value: retention_instruction
           
 
 

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -74,8 +74,7 @@ RSpec.describe 'ReceptionsController' do
                               'name' => /.*/,
                               'public_name' => 'PublicName',
                               'priority_level' => 'Medium',
-                              'country_of_origin' => 'United Kingdom',
-                              'retention_instruction' => 'return_to_customer_after_2_years'
+                              'country_of_origin' => 'United Kingdom'
                             }
                           })
 


### PR DESCRIPTION
Closes #1349 

#### Changes proposed in this pull request

- Stop sending the retention instruction to warehouse

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
