### PR TITLE
Y24-274 fix to publish data to include aliquots from all libraries in a run

### DIFF
--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -332,13 +332,13 @@ RSpec.describe Pacbio::Run, :pacbio do
 
     it 'includes used_aliquots coming from library in a pool in the run and from the library directly added to run' do
       pool_library = create(:pacbio_library)
-      pool = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: pool_library, aliquot_type: :primary))
+      pool = create(:pacbio_pool, used_aliquots: [create(:aliquot, source: pool_library, aliquot_type: :primary)])
       run_library = create(:pacbio_library)
       wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [run_library]),
                build(:pacbio_well, row: 'B', column: '1', pools: [pool])]
       run = create(:pacbio_revio_run, plates: [build(:pacbio_plate, wells:)])
       library_aliquot_used_in_run = wells.flat_map(&:used_aliquots).find { |aliquot| aliquot.source_type == 'Pacbio::Library' && aliquot.source_id == run_library.id }
-      library_aliquot_from_pool = pool.used_aliquots.find { |aliquot| aliquot.source_type == 'Pacbio::Library' }
+      library_aliquot_from_pool = pool.used_aliquots.find { |aliquot| aliquot.source_type == 'Pacbio::Library' && aliquot.source_id == pool_library.id }
       expect(run.aliquots_to_publish_on_run).to include(library_aliquot_used_in_run, library_aliquot_from_pool)
     end
   end

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -301,17 +301,20 @@ RSpec.describe Pacbio::Run, :pacbio do
 
   describe 'aliquots_to_publish_on_run' do
     it 'returns all the aliquots used for a run of source type eq to library or pool' do
-      request_pool = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: build(:pacbio_request), aliquot_type: :primary))
-      pool = create(:pacbio_pool)
-      wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [create(:pacbio_library)]),
-               build(:pacbio_well, row: 'B', column: '1', pools: [request_pool, pool])]
+      request = build(:pacbio_request)
+      pool_library = create(:pacbio_library)
+      pool1 = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: request, aliquot_type: :primary))
+      pool2 = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: pool_library, aliquot_type: :primary))
+      run_library = create(:pacbio_library)
+      wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [run_library]),
+               build(:pacbio_well, row: 'B', column: '1', pools: [pool1, pool2])]
       run = create(:pacbio_revio_run, plates: [build(:pacbio_plate, wells:)])
       run.aliquots_to_publish_on_run do |aliquot|
         expect(aliquot.source_type).to eq('Pacbio::Library').or eq('Pacbio::Pool')
       end
     end
 
-    it 'includes only used_aliquots coming from pool with type source eq to pool' do
+    it 'includes used_aliquots coming from pool with type source eq to pool' do
       request_pool = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: build(:pacbio_request), aliquot_type: :primary))
       library_pool = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: build(:pacbio_pool), aliquot_type: :primary), used_aliquots: [create(:aliquot, source: build(:pacbio_library), aliquot_type: :derived)])
       wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [create(:pacbio_library)]),
@@ -325,6 +328,18 @@ RSpec.describe Pacbio::Run, :pacbio do
       request_pool.used_aliquots do |aliquot|
         expect(run.aliquots_to_publish_on_run).not_to include(aliquot)
       end
+    end
+
+    it 'includes used_aliquots coming from library in a pool in the run and from the library directly added to run' do
+      pool_library = create(:pacbio_library)
+      pool = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: pool_library, aliquot_type: :primary))
+      run_library = create(:pacbio_library)
+      wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [run_library]),
+               build(:pacbio_well, row: 'B', column: '1', pools: [pool])]
+      run = create(:pacbio_revio_run, plates: [build(:pacbio_plate, wells:)])
+      library_aliquot_used_in_run = wells.flat_map(&:used_aliquots).find { |aliquot| aliquot.source_type == 'Pacbio::Library' && aliquot.source_id == run_library.id }
+      library_aliquot_from_pool = pool.used_aliquots.find { |aliquot| aliquot.source_type == 'Pacbio::Library' }
+      expect(run.aliquots_to_publish_on_run).to include(library_aliquot_used_in_run, library_aliquot_from_pool)
     end
   end
 end

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -303,8 +303,8 @@ RSpec.describe Pacbio::Run, :pacbio do
     it 'returns all the aliquots used for a run of source type eq to library or pool' do
       request = build(:pacbio_request)
       pool_library = create(:pacbio_library)
-      pool1 = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: request, aliquot_type: :primary))
-      pool2 = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: pool_library, aliquot_type: :primary))
+      pool1 = create(:pacbio_pool, used_aliquots: [create(:aliquot, source: request, aliquot_type: :derived)])
+      pool2 = create(:pacbio_pool, used_aliquots: [create(:aliquot, source: pool_library, aliquot_type: :derived)])
       run_library = create(:pacbio_library)
       wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [run_library]),
                build(:pacbio_well, row: 'B', column: '1', pools: [pool1, pool2])]
@@ -315,8 +315,8 @@ RSpec.describe Pacbio::Run, :pacbio do
     end
 
     it 'includes used_aliquots coming from pool with type source eq to pool' do
-      request_pool = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: build(:pacbio_request), aliquot_type: :primary))
-      library_pool = create(:pacbio_pool, primary_aliquot: create(:aliquot, source: build(:pacbio_pool), aliquot_type: :primary), used_aliquots: [create(:aliquot, source: build(:pacbio_library), aliquot_type: :derived)])
+      request_pool = create(:pacbio_pool, used_aliquots: [create(:aliquot, source: build(:pacbio_request), aliquot_type: :derived)])
+      library_pool = create(:pacbio_pool, used_aliquots: [create(:aliquot, source: build(:pacbio_library), aliquot_type: :derived)])
       wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [create(:pacbio_library)]),
                build(:pacbio_well, row: 'B', column: '1', pools: [request_pool, library_pool])]
       run = create(:pacbio_revio_run, plates: [build(:pacbio_plate, wells:)])
@@ -332,7 +332,7 @@ RSpec.describe Pacbio::Run, :pacbio do
 
     it 'includes used_aliquots coming from library in a pool in the run and from the library directly added to run' do
       pool_library = create(:pacbio_library)
-      pool = create(:pacbio_pool, used_aliquots: [create(:aliquot, source: pool_library, aliquot_type: :primary)])
+      pool = create(:pacbio_pool, used_aliquots: [create(:aliquot, source: pool_library, aliquot_type: :derived)])
       run_library = create(:pacbio_library)
       wells = [build(:pacbio_well, row: 'A', column: '1', libraries: [run_library]),
                build(:pacbio_well, row: 'B', column: '1', pools: [pool])]


### PR DESCRIPTION
Closes https://github.com/sanger/traction-service/issues/1408

#### Changes proposed in this pull request
- The aliquots_to_publish_on_run method in the run model has been modified to include aliquots from all libraries directly added to all run wells.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
