### PR TITLE
misc: 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -68,5 +68,8 @@ module TractionService
 
     # Fix for Psych::DisallowedClass. Added the four top classes as this may guard against hidden errors.
     config.active_record.yaml_column_permitted_classes = [Symbol, Hash, Array, ActiveSupport::HashWithIndifferentAccess, BigDecimal]
+
+    # Ensure the rails console shows all attributes by default for ease of debugging
+    config.active_record.attributes_for_inspect = :all
   end
 end


### PR DESCRIPTION
Rails 7.2 changed default active record attributes inspection to just display id's with returned objects.
This is unhelpful for Neil when debugging issues and working on data fixes.

#### Changes proposed in this pull request

- Updates config to always show all attributes when inspecting elements.

