### PR TITLE
Y24 318 modify message send to warehouse so that the id_sample_lims will be the sample name

### DIFF
--- a/config/pipelines/reception.yml
+++ b/config/pipelines/reception.yml
@@ -43,7 +43,7 @@ default: &default
           last_updated: *timestamp
           id_sample_lims:
             type: :model
-            value: id
+            value: name
           uuid_sample_lims:
             type: :model
             value: external_id

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'ReceptionsController' do
                             'lims' => 'Traction', 'sample' => {
                               'common_name' => 'human',
                               'last_updated' => /.*/,
-                              'id_sample_lims' => /\d/,
+                              'id_sample_lims' => /.*/,
                               'uuid_sample_lims' => /.*/,
                               'name' => /.*/,
                               'public_name' => 'PublicName',


### PR DESCRIPTION
Closes https://github.com/sanger/traction-service/issues/1430

#### Changes proposed in this pull request

- The id_sample_lims field in message send to warehouse is changed to sample name instead of traction sample ids


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
