### PR TITLE
Y24-403 - Send run name with well library aliquots

### DIFF
--- a/app/exchanges/volume_tracking/message_builder.rb
+++ b/app/exchanges/volume_tracking/message_builder.rb
@@ -80,7 +80,7 @@ module VolumeTracking
     end
 
     def used_by_well_barcode
-      "#{object.used_by.run.name}:#{object.used_by.position}"
+      "#{object.used_by.run.name}:#{object.used_by.plate.plate_number}:#{object.used_by.position}"
     end
 
     def pacbio_library_sample_names

--- a/app/exchanges/volume_tracking/message_builder.rb
+++ b/app/exchanges/volume_tracking/message_builder.rb
@@ -80,8 +80,7 @@ module VolumeTracking
     end
 
     def used_by_well_barcode
-      "#{object.used_by.plate.sequencing_kit_box_barcode}:" \
-        "#{object.used_by.plate.plate_number}:#{object.used_by.position}"
+      "#{object.used_by.run.name}:#{object.used_by.position}"
     end
 
     def pacbio_library_sample_names

--- a/spec/exchanges/volume_tracking/message_builder_spec.rb
+++ b/spec/exchanges/volume_tracking/message_builder_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe VolumeTracking::MessageBuilder, type: :model do
                                                           source_barcode: pacbio_pool.tube.barcode,
                                                           sample_name: expected_sample_names,
                                                           used_by_type: 'run',
-                                                          used_by_barcode: "#{pacbio_well.plate.sequencing_kit_box_barcode}:#{pacbio_well.plate.plate_number}:#{pacbio_well.position}",
+                                                          used_by_barcode: "#{pacbio_well.run.name}:#{pacbio_well.position}",
                                                           aliquot_uuid: aliquot.uuid
                                                         })
       end
@@ -135,7 +135,7 @@ RSpec.describe VolumeTracking::MessageBuilder, type: :model do
                                                           source_barcode: pacbio_library.tube.barcode,
                                                           sample_name: pacbio_library.sample_name,
                                                           used_by_type: 'run',
-                                                          used_by_barcode: "#{pacbio_well.plate.sequencing_kit_box_barcode}:#{pacbio_well.plate.plate_number}:#{pacbio_well.position}",
+                                                          used_by_barcode: "#{pacbio_well.run.name}:#{pacbio_well.position}",
                                                           aliquot_uuid: aliquot.uuid
                                                         })
       end

--- a/spec/exchanges/volume_tracking/message_builder_spec.rb
+++ b/spec/exchanges/volume_tracking/message_builder_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe VolumeTracking::MessageBuilder, type: :model do
                                                           source_barcode: pacbio_pool.tube.barcode,
                                                           sample_name: expected_sample_names,
                                                           used_by_type: 'run',
-                                                          used_by_barcode: "#{pacbio_well.run.name}:#{pacbio_well.position}",
+                                                          used_by_barcode: "#{pacbio_well.run.name}:#{pacbio_well.plate.plate_number}:#{pacbio_well.position}",
                                                           aliquot_uuid: aliquot.uuid
                                                         })
       end
@@ -135,7 +135,7 @@ RSpec.describe VolumeTracking::MessageBuilder, type: :model do
                                                           source_barcode: pacbio_library.tube.barcode,
                                                           sample_name: pacbio_library.sample_name,
                                                           used_by_type: 'run',
-                                                          used_by_barcode: "#{pacbio_well.run.name}:#{pacbio_well.position}",
+                                                          used_by_barcode: "#{pacbio_well.run.name}:#{pacbio_well.plate.plate_number}:#{pacbio_well.position}",
                                                           aliquot_uuid: aliquot.uuid
                                                         })
       end


### PR DESCRIPTION
Closes #1457

#### Changes proposed in this pull request

- Updates volume tracking message builder to send used_by_well_barcode in the format <run_name>:<well_position>

#### Instructions for Reviewers

Wondering if the plate number is still useful?
