### PR TITLE
Y24-412 - request end point filter update with multiple source identifiers

### DIFF
--- a/app/resources/v1/pacbio/request_resource.rb
+++ b/app/resources/v1/pacbio/request_resource.rb
@@ -61,17 +61,29 @@ module V1
       }
 
       filter :source_identifier, apply: lambda { |records, value, _options|
-        # First we check tubes to see if there are any given the source identifier
-        recs = records.joins(:tube).where(tube: { barcode: value })
-        return recs unless recs.empty?
+        # Initialize an empty result set
+        rec_ids = []
 
-        # If no tubes match the source identifier we check plates
-        # If source identifier specifies a well we need to match samples to well
-        # TODO: The below value[0] means we only take the first value passed in the filter
-        #       If we want to support multiple values in one filter we would need to update this
-        plate, well = value[0].split(':')
-        recs = records.joins(:plate).where(plate: { barcode: plate })
-        well ? recs.joins(:well).where(well: { position: well }) : recs
+        # Iterate over each value in the filter
+        value.each do |val|
+          if val.include?(':')
+            # If the value contains a colon, it's a plate and well identifier
+            plate, well = val.split(':')
+            filtered_recs = records.joins(:plate).where(plate: { barcode: plate })
+            filtered_recs = filtered_recs.joins(:well).where(well: { position: well }) if well
+          else
+            # Otherwise, it's a tube identifier
+            filtered_recs = records.joins(:tube).where(tube: { barcode: val })
+          end
+          # Collect the IDs of the filtered records
+          rec_ids.concat(filtered_recs.pluck(:id))
+        rescue StandardError => e
+          # Log the error and continue with the next value
+          Rails.logger.warn("Invalid source identifier: #{val}, error: #{e.message}")
+        end
+        # Perform a final query to fetch the records by their IDs
+        combined_recs = records.where(id: rec_ids)
+        combined_recs
       }
 
       def self.default_sort

--- a/app/resources/v1/pacbio/request_resource.rb
+++ b/app/resources/v1/pacbio/request_resource.rb
@@ -2,17 +2,45 @@
 
 module V1
   module Pacbio
-    # @todo This documentation does not yet include a detailed description of what this resource represents.
-    # @todo This documentation does not yet include detailed descriptions for relationships, attributes and filters.
-    # @todo This documentation does not yet include any example usage of the API via cURL or similar.
-    #
-    # @note Access this resource via the `/v1/pacbio/requests/` endpoint.
-    #
     # Provides a JSON:API representation of {Pacbio::Request}.
     #
     # For more information about JSON:API see the [JSON:API Specifications](https://jsonapi.org/format/)
     # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package
     # for the service implementation of the JSON:API standard.
+    # This resource represents a Pacbio Request and can return all requests, a single request or
+    # multiple requests along with their relationships.
+    #
+    # ## Filters:
+    #
+    # * sample_name
+    # * source_identifier
+    # * species
+    #
+    # ## Primary relationships:
+    #
+    # * well {V1::Pacbio::WellResource}
+    # * plate {V1::Pacbio::PlateResource}
+    # * tube {V1::Pacbio::TubeResource}
+    #
+    # ## Relationship trees:
+    #
+    # * well.plate
+    # * plate.wells
+    # * tube.requests
+    #
+    # @example
+    #   curl -X GET http://localhost:3000/v1/pacbio/requests/1
+    #   curl -X GET http://localhost:3000/v1/pacbio/requests/
+    #   curl -X GET http://localhost:3000/v1/pacbio/requests/1?include=well,plate,tube
+    #
+    #   https://localhost:3000/v1/pacbio/requests?filter[sample_name]=sample_name
+    #   https://localhost:3000/v1/pacbio/requests?filter[species]=species
+    #
+    #   https://localhost:3000/v1/pacbio/requests?filter[source_identifier]=TRAC-2-12068
+    #
+    #   https://localhost:3000/v1/pacbio/requests?filter[source_identifier]=TRAC-2-12068,TRAC-2-12066,TRAC-2-12067:A1
+    #
+    #   https://localhost:3000/v1/pacbio/requests?filter[source_identifier]=TRAC-2-12068,TRAC-2-12066,TRAC-2-12067&include=well.plate,plate.wells,tube.requests
     class RequestResource < JSONAPI::Resource
       model_name 'Pacbio::Request', add_model_hint: false
 

--- a/app/resources/v1/pacbio/request_resource.rb
+++ b/app/resources/v1/pacbio/request_resource.rb
@@ -69,8 +69,13 @@ module V1
           if val.include?(':')
             # If the value contains a colon, it's a plate and well identifier
             plate, well = val.split(':')
-            filtered_recs = records.joins(:plate).where(plate: { barcode: plate })
-            filtered_recs = filtered_recs.joins(:well).where(well: { position: well }) if well
+            if plate.present? && well.present?
+              filtered_recs = records.joins(:plate).where(plate: { barcode: plate })
+              filtered_recs = filtered_recs.joins(:well).where(well: { position: well })
+            else
+              Rails.logger.warn("Invalid plate or well identifier: #{val}")
+              next
+            end
           else
             # Otherwise, it's a tube identifier
             filtered_recs = records.joins(:tube).where(tube: { barcode: val })

--- a/app/resources/v1/pacbio/tag_set_resource.rb
+++ b/app/resources/v1/pacbio/tag_set_resource.rb
@@ -21,6 +21,8 @@ module V1
       def self.create_model
         _model_class.pacbio_pipeline.new
       end
+
+      filter :name
     end
   end
 end

--- a/spec/requests/v1/pacbio/requests_spec.rb
+++ b/spec/requests/v1/pacbio/requests_spec.rb
@@ -170,6 +170,8 @@ RSpec.describe 'RequestsController', :pacbio do
           pacbio_plate1 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
           source_identifiers = ["#{pacbio_plate1.barcode}:",
                                 ":#{pacbio_plate1.wells.first.position}"]
+          expect(Rails.logger).to receive(:warn).with("Invalid plate or well identifier: #{pacbio_plate1.barcode}:").at_least(:once)
+          expect(Rails.logger).to receive(:warn).with("Invalid plate or well identifier: :#{pacbio_plate1.wells.first.position}").at_least(:once)
           get "#{v1_pacbio_requests_path}?filter[source_identifier]=#{source_identifiers.join(',')}",
               headers: json_api_headers
           expect(response).to have_http_status(:success)

--- a/spec/requests/v1/pacbio/requests_spec.rb
+++ b/spec/requests/v1/pacbio/requests_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'RequestsController', :pacbio do
           end
         end
 
-        it 'when the source_identifier cotains multiple tubes, plates and invalid values' do
+        it 'when the source_identifier contains multiple tubes, plates and invalid values' do
           pacbio_tube1 = create(:tube_with_pacbio_request)
           pacbio_tube2 = create(:tube_with_pacbio_request)
           pacbio_plate1 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')

--- a/spec/requests/v1/pacbio/requests_spec.rb
+++ b/spec/requests/v1/pacbio/requests_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'RequestsController', :pacbio do
           end
         end
 
-        it 'when the source_identifier belongs to multiple tubes and plates' do
+        it 'when the source_identifier cotains multiple tubes, plates and invalid values' do
           pacbio_tube1 = create(:tube_with_pacbio_request)
           pacbio_tube2 = create(:tube_with_pacbio_request)
           pacbio_plate1 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
@@ -164,6 +164,16 @@ RSpec.describe 'RequestsController', :pacbio do
               'created_at' => request.created_at.to_fs(:us)
             )
           end
+        end
+
+        it 'when the source_identifer contains malformed strings' do
+          pacbio_plate1 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
+          source_identifiers = ["#{pacbio_plate1.barcode}:",
+                                ":#{pacbio_plate1.wells.first.position}"]
+          get "#{v1_pacbio_requests_path}?filter[source_identifier]=#{source_identifiers.join(',')}",
+              headers: json_api_headers
+          expect(response).to have_http_status(:success)
+          expect(json['data'].length).to eq(0)
         end
       end
     end

--- a/spec/requests/v1/pacbio/requests_spec.rb
+++ b/spec/requests/v1/pacbio/requests_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe 'RequestsController', :pacbio do
       context 'filters - source_identifier' do
         it 'when the source_identifier belongs to a plate' do
           pacbio_plate = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
-          pacbio_plate_requests = pacbio_plate.wells.first.pacbio_requests
-          get "#{v1_pacbio_requests_path}?filter[source_identifier]=#{pacbio_plate.barcode}:#{pacbio_plate.wells.first.position}",
+          pacbio_plate_requests = pacbio_plate.wells.flat_map(&:pacbio_requests)
+          get "#{v1_pacbio_requests_path}?filter[source_identifier]=#{pacbio_plate.barcode}",
               headers: json_api_headers
 
           expect(response).to have_http_status(:success)
@@ -122,19 +122,43 @@ RSpec.describe 'RequestsController', :pacbio do
           end
         end
 
+        it 'when the source_identifier belongs to a plate and well separated by colon' do
+          pacbio_plate = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
+          pacbio_plate_requests = pacbio_plate.wells.first.pacbio_requests
+          get "#{v1_pacbio_requests_path}?filter[source_identifier]=#{pacbio_plate.barcode}:#{pacbio_plate.wells.first.position}",
+              headers: json_api_headers
+
+          expect(response).to have_http_status(:success)
+          expect(json['data'].length).to eq(pacbio_plate_requests.length)
+          pacbio_plate_requests.each do |request|
+            request_attributes = find_resource(type: 'requests', id: request.id)['attributes']
+            expect(request_attributes).to include(
+              'cost_code' => request.cost_code,
+              'number_of_smrt_cells' => request.number_of_smrt_cells,
+              'external_study_id' => request.external_study_id,
+              'library_type' => request.library_type,
+              'estimate_of_gb_required' => request.estimate_of_gb_required,
+              'sample_name' => request.sample.name,
+              'sample_species' => request.sample.species,
+              'source_identifier' => request.source_identifier,
+              'created_at' => request.created_at.to_fs(:us)
+            )
+          end
+        end
+
         it 'when the source_identifier contains multiple tubes, plates and invalid values' do
           pacbio_tube1 = create(:tube_with_pacbio_request)
           pacbio_tube2 = create(:tube_with_pacbio_request)
           pacbio_plate1 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
           pacbio_plate2 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
           pacbio_plate1_renquests = pacbio_plate1.wells.first.pacbio_requests
-          pacbio_plate2_requests = pacbio_plate2.wells.first.pacbio_requests
+          pacbio_plate2_requests = pacbio_plate2.wells.flat_map(&:pacbio_requests)
 
           source_identifiers = [
             pacbio_tube1.barcode,
             pacbio_tube2.barcode,
             "#{pacbio_plate1.barcode}:#{pacbio_plate1.wells.first.position}",
-            "#{pacbio_plate2.barcode}:#{pacbio_plate2.wells.first.position}",
+            pacbio_plate2.barcode,
             'INVALID_IDENTIFIER'
           ]
 
@@ -166,12 +190,19 @@ RSpec.describe 'RequestsController', :pacbio do
           end
         end
 
-        it 'when the source_identifer contains malformed strings' do
+        it 'when the source_identifer contains colon which includes plate barcode without well' do
           pacbio_plate1 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
-          source_identifiers = ["#{pacbio_plate1.barcode}:",
-                                ":#{pacbio_plate1.wells.first.position}"]
-          expect(Rails.logger).to receive(:warn).with("Invalid plate or well identifier: #{pacbio_plate1.barcode}:").at_least(:once)
-          expect(Rails.logger).to receive(:warn).with("Invalid plate or well identifier: :#{pacbio_plate1.wells.first.position}").at_least(:once)
+          pacbio_plate_requests = pacbio_plate1.wells.flat_map(&:pacbio_requests)
+          source_identifiers = ["#{pacbio_plate1.barcode}:"]
+          get "#{v1_pacbio_requests_path}?filter[source_identifier]=#{source_identifiers.join(',')}",
+              headers: json_api_headers
+          expect(response).to have_http_status(:success)
+          expect(json['data'].length).to eq(pacbio_plate_requests.length)
+        end
+
+        it 'when the source_identifer contains malformed strings' do
+          source_identifiers = [':test']
+          expect(Rails.logger).to receive(:warn).with("Malformed source identifier: ':test'. Plate part is missing.").at_least(:once)
           get "#{v1_pacbio_requests_path}?filter[source_identifier]=#{source_identifiers.join(',')}",
               headers: json_api_headers
           expect(response).to have_http_status(:success)

--- a/spec/requests/v1/pacbio/tag_sets_spec.rb
+++ b/spec/requests/v1/pacbio/tag_sets_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe 'Pacbio::TagSetsController' do
     ActiveSupport::JSON.decode(response.body)
   end
 
-  describe '#get' do
-    let!(:tag_set) { create(:tag_set, pipeline: :pacbio) }
+  let!(:tag_set) { create(:tag_set, pipeline: :pacbio) }
 
+  describe '#get' do
     before do
       create(:tag_set, pipeline: :ont)
       get v1_pacbio_tag_sets_path, headers: json_api_headers
@@ -26,6 +26,15 @@ RSpec.describe 'Pacbio::TagSetsController' do
     it 'returns the correct attributes' do
       expect(json['data'][0]['attributes']['name']).to eq(tag_set.name)
     end
+  end
+
+  it 'filters by name' do
+    get v1_pacbio_tag_sets_path(filter: { name: tag_set.name }), headers: json_api_headers
+    expect(response).to have_http_status(:success)
+    json = ActiveSupport::JSON.decode(response.body)
+    expect(json['data'].length).to eq(1)
+
+    expect(json['data'][0]['attributes']['name']).to eq(tag_set.name)
   end
 
   describe '#create' do


### PR DESCRIPTION
Closes https://github.com/sanger/traction-service/issues/1489

#### Changes proposed in this pull request
-Enhanced the `filter :source_identifier` in request_resource to support multiple source identifiers instead of just one.
-Added filter by name option to pacbio tagsets resource


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
