### PR TITLE
fix(primary-aliquot): fixes bug where pool and library primary aliquots without ids caused the aliquots to be remade

### DIFF
--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -42,7 +42,9 @@ module Pacbio
     has_one :source_plate, through: :source_well, source: :plate, class_name: '::Plate'
 
     validates :primary_aliquot, presence: true
-    accepts_nested_attributes_for :primary_aliquot
+
+    # Update only so that we don't recreate the primary aliquot if the ID is missing.
+    accepts_nested_attributes_for :primary_aliquot, update_only: true
 
     after_create :create_used_aliquot
 

--- a/app/models/pacbio/pool.rb
+++ b/app/models/pacbio/pool.rb
@@ -26,7 +26,8 @@ module Pacbio
     validate :used_aliquots_volume
     before_update :primary_aliquot_volume_sufficient
 
-    accepts_nested_attributes_for :primary_aliquot
+    # Update only so that we don't recreate the primary aliquot if the ID is missing.
+    accepts_nested_attributes_for :primary_aliquot, update_only: true
 
     def used_aliquots_attributes=(used_aliquot_options)
       self.used_aliquots = used_aliquot_options.map do |attributes|

--- a/config/bunny.yml.example
+++ b/config/bunny.yml.example
@@ -21,7 +21,7 @@ default: &default
       subjects:
         volume_tracking:
           subject: 'create-aliquot-in-mlwh'
-          version: 3
+          version: 2
 
 development:
   <<: *default

--- a/spec/requests/v1/pacbio/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/libraries_spec.rb
@@ -419,6 +419,7 @@ RSpec.describe 'LibrariesController', :pacbio do
   describe '#updating' do
     let!(:library) { create(:pacbio_library) }
     let!(:tag) { create(:tag) }
+    let!(:primary_aliquot) { library.primary_aliquot }
 
     before do
       patch v1_pacbio_library_path(library), params: body, headers: json_api_headers
@@ -461,6 +462,9 @@ RSpec.describe 'LibrariesController', :pacbio do
 
       it 'updates the library primary aliquot' do
         library.reload
+
+        primary_aliquot.reload
+        expect(library.primary_aliquot).to eq(primary_aliquot)
         expect(library.primary_aliquot.template_prep_kit_box_barcode).to eq('100')
       end
     end

--- a/spec/requests/v1/pacbio/pools_spec.rb
+++ b/spec/requests/v1/pacbio/pools_spec.rb
@@ -503,7 +503,6 @@ RSpec.describe 'PoolsController', :pacbio do
                 }
               ],
               primary_aliquot_attributes: {
-                id: pool.primary_aliquot.id.to_s,
                 volume: '200',
                 concentration: '22',
                 template_prep_kit_box_barcode: '100',
@@ -531,7 +530,10 @@ RSpec.describe 'PoolsController', :pacbio do
 
       it 'updates the primary aliquot' do
         pool.reload
-        expect(pool.primary_aliquot.template_prep_kit_box_barcode).to eq('100')
+
+        primary_aliquot.reload
+        expect(pool.primary_aliquot).to eq(primary_aliquot)
+        expect(primary_aliquot.template_prep_kit_box_barcode).to eq('100')
       end
 
       it 'updates used_aliquots accordingly' do


### PR DESCRIPTION
#### Changes proposed in this pull request

- The UI can send primary aliquots of existing pools/libraries without their ids. This change prevents the aliquot being deleted and recreated in that case.