### PR TITLE
Y24 473 generalize multiple source identifier filtering logic

### DIFF
--- a/app/models/concerns/source_identifier_filterable.rb
+++ b/app/models/concerns/source_identifier_filterable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# app/models/concerns/barcode_filterable.rb
+module SourceIdentifierFilterable
+  extend ActiveSupport::Concern
+
+  class_methods do # rubocop:disable Metrics/BlockLength
+    def apply_source_identifier_filter(records, value, # rubocop:disable Metrics/MethodLength,Metrics/PerceivedComplexity
+                                       plate_join: :plate, tube_join: :tube, well_join: :well)
+      rec_ids = []
+      value.each do |val|
+        # byebug
+        if val.include?(':')
+          plate, well = val.split(':')
+          if plate.present?
+            filtered_recs = records.joins(plate_join).where(plate_join => { barcode: plate })
+            if well.present?
+              filtered_recs = filtered_recs.joins(well_join).where(well_join => { position: well })
+            end
+          else
+            Rails.logger.warn("Malformed source identifier: '#{val}'. Plate part is missing.")
+            next
+          end
+        else
+          filtered_recs = records.joins(plate_join).where(plate_join => { barcode: val })
+          if filtered_recs.empty?
+            filtered_recs = records.joins(tube_join).where(tube_join => { barcode: val })
+          end
+        end
+        rec_ids.concat(filtered_recs.pluck(:id))
+      rescue StandardError => e
+        Rails.logger.warn("Invalid source identifier: #{val}, error: #{e.message}")
+      end
+      records.where(id: rec_ids)
+    end
+  end
+end

--- a/app/resources/v1/pacbio/request_resource.rb
+++ b/app/resources/v1/pacbio/request_resource.rb
@@ -42,6 +42,8 @@ module V1
     #
     #   https://localhost:3000/v1/pacbio/requests?filter[source_identifier]=TRAC-2-12068,TRAC-2-12066,TRAC-2-12067&include=well.plate,plate.wells,tube.requests
     class RequestResource < JSONAPI::Resource
+      include SourceIdentifierFilterable
+
       model_name 'Pacbio::Request', add_model_hint: false
 
       # @!attribute [rw] library_type
@@ -89,40 +91,7 @@ module V1
       }
 
       filter :source_identifier, apply: lambda { |records, value, _options|
-        # Initialize an empty result set
-        rec_ids = []
-
-        # Iterate over each value in the filter
-        value.each do |val|
-          if val.include?(':')
-            # If the value contains a colon, it's a plate and well identifier
-            plate, well = val.split(':')
-            if plate.present?
-              filtered_recs = records.joins(:plate).where(plate: { barcode: plate })
-              if well.present?
-                filtered_recs = filtered_recs.joins(:well).where(well: { position: well })
-              end
-            else
-              Rails.logger.warn("Malformed source identifier: '#{val}'. Plate part is missing.")
-              next
-            end
-          else
-            #  If the value does not contain a colon, it's a tube or plate identifier
-            filtered_recs = records.joins(:plate).where(plate: { barcode: val })
-            # If no records are found by plate, try to find by tube
-            if filtered_recs.empty?
-              filtered_recs = records.joins(:tube).where(tube: { barcode: val })
-            end
-          end
-          # Collect the IDs of the filtered records
-          rec_ids.concat(filtered_recs.pluck(:id))
-        rescue StandardError => e
-          # Log the error and continue with the next value
-          Rails.logger.warn("Invalid source identifier: #{val}, error: #{e.message}")
-        end
-        # Perform a final query to fetch the records by their IDs
-        combined_recs = records.where(id: rec_ids)
-        combined_recs
+        apply_source_identifier_filter(records, value)
       }
 
       def self.default_sort

--- a/spec/models/concerns/source_identifier_filterable_spec.rb
+++ b/spec/models/concerns/source_identifier_filterable_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SourceIdentifierFilterable do
+  let(:dummy_class) do
+    Class.new do
+      include SourceIdentifierFilterable
+
+      def apply_source_identifier_filter(records, value, plate_join: :plate, tube_join: :tube, well_join: :well)
+        self.class.apply_source_identifier_filter(records, value, plate_join: plate_join, tube_join: tube_join, well_join: well_join)
+      end
+    end
+  end
+
+  let(:dummy_instance) { dummy_class.new }
+
+  describe '#apply_source_identifier_filter' do
+    context 'when the source_identifier belongs to a plate' do
+      it 'returns the correct records' do
+        pacbio_plate = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
+        pacbio_plate_requests = pacbio_plate.wells.flat_map(&:pacbio_requests)
+        records = Pacbio::Request.all
+
+        filtered_records = dummy_instance.apply_source_identifier_filter(records, [pacbio_plate.barcode])
+
+        expect(filtered_records.count).to eq(pacbio_plate_requests.count)
+        expect(filtered_records.map(&:id)).to match_array(pacbio_plate_requests.map(&:id))
+      end
+    end
+
+    context 'when the source_identifier belongs to a tube' do
+      it 'returns the correct records' do
+        pacbio_tube = create(:tube_with_pacbio_request)
+        records = Pacbio::Request.all
+
+        filtered_records = dummy_instance.apply_source_identifier_filter(records, [pacbio_tube.barcode])
+
+        expect(filtered_records.count).to eq(pacbio_tube.pacbio_requests.count)
+        expect(filtered_records.map(&:id)).to match_array(pacbio_tube.pacbio_requests.map(&:id))
+      end
+    end
+
+    context 'when the source_identifier belongs to a plate and well separated by colon' do
+      it 'returns the correct records' do
+        pacbio_plate = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
+        pacbio_plate_requests = pacbio_plate.wells.first.pacbio_requests
+        records = Pacbio::Request.all
+
+        filtered_records = dummy_instance.apply_source_identifier_filter(records, ["#{pacbio_plate.barcode}:#{pacbio_plate.wells.first.position}"])
+
+        expect(filtered_records.count).to eq(pacbio_plate_requests.count)
+        expect(filtered_records.map(&:id)).to match_array(pacbio_plate_requests.map(&:id))
+      end
+    end
+
+    context 'when the source_identifier contains multiple tubes, plates and invalid values' do
+      it 'returns the correct records and logs warnings for invalid values' do
+        pacbio_tube1 = create(:tube_with_pacbio_request)
+        pacbio_tube2 = create(:tube_with_pacbio_request)
+        pacbio_plate1 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
+        pacbio_plate2 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
+        pacbio_plate1_requests = pacbio_plate1.wells.first.pacbio_requests
+        pacbio_plate2_requests = pacbio_plate2.wells.flat_map(&:pacbio_requests)
+
+        source_identifiers = [
+          pacbio_tube1.barcode,
+          pacbio_tube2.barcode,
+          "#{pacbio_plate1.barcode}:#{pacbio_plate1.wells.first.position}",
+          pacbio_plate2.barcode,
+          'INVALID_IDENTIFIER'
+        ]
+
+        records = Pacbio::Request.all
+
+        filtered_records = dummy_instance.apply_source_identifier_filter(records, source_identifiers)
+
+        total_requests = pacbio_tube1.pacbio_requests.length +
+                         pacbio_tube2.pacbio_requests.length +
+                         pacbio_plate1_requests.length +
+                         pacbio_plate2_requests.length
+
+        expect(filtered_records.count).to eq(total_requests)
+        expect(filtered_records.map(&:id)).to match_array(
+          pacbio_tube1.pacbio_requests.map(&:id) +
+          pacbio_tube2.pacbio_requests.map(&:id) +
+          pacbio_plate1_requests.map(&:id) +
+          pacbio_plate2_requests.map(&:id)
+        )
+      end
+    end
+
+    context 'when the source_identifier contains malformed strings' do
+      it 'logs warnings for malformed strings' do
+        source_identifiers = [':test']
+        records = Pacbio::Request.all
+
+        expect(Rails.logger).to receive(:warn).with("Malformed source identifier: ':test'. Plate part is missing.").at_least(:once)
+
+        filtered_records = dummy_instance.apply_source_identifier_filter(records, source_identifiers)
+
+        expect(filtered_records.count).to eq(0)
+      end
+    end
+
+    context 'when the source_identifer contains colon which includes plate barcode without well' do
+      it 'returns the correct records for plate' do
+        pacbio_plate1 = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
+        pacbio_plate_requests = pacbio_plate1.wells.flat_map(&:pacbio_requests)
+        source_identifiers = ["#{pacbio_plate1.barcode}:"]
+        records = Pacbio::Request.all
+        filtered_records = dummy_instance.apply_source_identifier_filter(records, source_identifiers)
+        expect(filtered_records.count).to eq(pacbio_plate_requests.count)
+      end
+    end
+
+    context 'when using custom join conditions' do
+      it 'returns the correct records for source_plate and source_tube' do
+        pacbio_tube = create(:tube_with_pacbio_request)
+        create(:pacbio_library, request: pacbio_tube.pacbio_requests[0])
+        pacbio_plate = create(:plate_with_wells_and_requests, pipeline: 'pacbio')
+        pacbio_plate.wells.first.pacbio_requests[0]
+        create(:pacbio_library, request: pacbio_plate.wells.first.pacbio_requests[0])
+        source_identifiers = [
+          pacbio_tube.barcode,
+          "#{pacbio_plate.barcode}:#{pacbio_plate.wells.first.position}"
+        ]
+        records = Pacbio::Library.all
+        filtered_records = dummy_instance.apply_source_identifier_filter(records, source_identifiers, plate_join: :source_plate,
+                                                                                                      tube_join: :source_tube,
+                                                                                                      well_join: :source_well)
+
+        expect(filtered_records.count).to eq(records.count)
+        expect(filtered_records.map(&:id)).to match_array(records.map(&:id))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/sanger/traction-service/issues/1490

#### Changes proposed in this pull request

Added the SourceIdentifierFilterable concern, thereby generalizing the code to apply multiple source_identifiers, which can be called from both Pacbio::LibraryResource and Pacbio::RequestResource.
https://github.com/sanger/traction-service/pull/1488#pullrequestreview-2454409961

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
