### PR TITLE
Y24-518 - SMRTLink v25.1 Revio support

### DIFF
--- a/app/exchanges/run_csv/pacbio_sample_sheet.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet.rb
@@ -49,9 +49,10 @@ module RunCsv
         'Indexes'	=> well.barcode_set, # 244d96c6-f3b2-4997-5ae3-23ed33ab925f
         'Sample is indexed'	=> well.tagged?, # Set to True to Multiplex
         'Bio Sample Name' => well.tagged? ? nil : well.bio_sample_name,
-        'Use Adaptive Loading'	=> false, # this will likely be a well default in future
+        'Use Adaptive Loading'	=> well.use_adaptive_loading,
         'Consensus Mode'	=> 'molecule', # (default to molecule do we need a custom field)
-        'Same Barcodes on Both Ends of Sequence'	=> well.same_barcodes_on_both_ends_of_sequence
+        'Same Barcodes on Both Ends of Sequence'	=> well.same_barcodes_on_both_ends_of_sequence,
+        'Full Resolution Base Qual' => well.full_resolution_base_qual
       }
     end
 

--- a/app/exchanges/run_csv/pacbio_sample_sheet.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# A class spefically for SMRT-Link v13 Sample Sheets, based on the PacbioSampleSheet class
+# A class specifically for SMRT-Link v13 Sample Sheets, based on the PacbioSampleSheet class
 # See https://www.pacb.com/wp-content/uploads/SMRT-Link-User-Guide-v13.1.pdf (page 31) for details.
 
 module RunCsv

--- a/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# A class spefically for SMRT-Link v25 Sample Sheets, based on the PacbioSampleSheet class
+# A class specifically for SMRT-Link v25 Sample Sheets, based on the PacbioSampleSheet class
 # See https://www.pacb.com/wp-content/uploads/SMRT-Link-User-Guide-v25.1.pdf (page 28) for details.
 
 module RunCsv

--- a/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# A class spefically for SMRT-Link v25 Sample Sheets, based on the PacbioSampleSheet class
+# See https://www.pacb.com/wp-content/uploads/SMRT-Link-User-Guide-v25.1.pdf (page 28) for details.
+
+module RunCsv
+  # RunCsv::PacbioSampleSheet
+  class PacbioSampleSheetV25 < PacbioSampleSheet
+    # Generate a hash of settings for a single cell
+    # Overrides the method in the parent class
+    # Only difference is removal of 'Polymerase Kit' key
+    def generate_smrt_cell_settings(well) # rubocop:disable Metrics/MethodLength
+      {
+        'Well Name'	=> well.used_aliquots.first.source.tube.barcode, # TRAC-2-7242
+        'Library Type'	=> well.library_type, # Standard
+        'Movie Acquisition Time (hours)'	=> well.movie_acquisition_time, # 24
+        'Insert Size (bp)'	=> well.insert_size, # 500
+        'Assign Data To Project'	=> 1, # (maybe we need to assign a run a project in traction)?
+        'Library Concentration (pM)'	=> well.library_concentration, # 250
+        'Include Base Kinetics'	=> well.include_base_kinetics,
+        'Indexes'	=> well.barcode_set, # 244d96c6-f3b2-4997-5ae3-23ed33ab925f
+        'Sample is indexed'	=> well.tagged?, # Set to True to Multiplex
+        'Bio Sample Name' => well.tagged? ? nil : well.bio_sample_name,
+        'Use Adaptive Loading'	=> well.use_adaptive_loading,
+        'Consensus Mode'	=> 'molecule', # (default to molecule do we need a custom field)
+        'Same Barcodes on Both Ends of Sequence'	=> well.same_barcodes_on_both_ends_of_sequence,
+        'Full Resolution Base Qual' => well.full_resolution_base_qual
+      }
+    end
+  end
+end

--- a/app/models/pacbio/run.rb
+++ b/app/models/pacbio/run.rb
@@ -134,6 +134,16 @@ module Pacbio
       end
     end
 
+    # @return [Boolean] true if all wells have adaptive loading enabled
+    def adaptive_loading
+      wells.all? { |w| w.use_adaptive_loading == 'True' }
+    end
+
+    # @return [Array<String>] the barcodes of the sequencing kits
+    def sequencing_kit_box_barcodes
+      plates.map { |p| "Plate #{p.plate_number}: #{p.sequencing_kit_box_barcode}" }
+    end
+
     private
 
     # We now have SMRT Link versioning

--- a/app/resources/v1/pacbio/run_resource.rb
+++ b/app/resources/v1/pacbio/run_resource.rb
@@ -32,9 +32,14 @@ module V1
       #   @return [Integer] the ID of the PacBio SMRT Link version
       # @!attribute [rw] plates_attributes
       #   @return [Array<Hash>] the attributes of the plates
+      # @!attribute [r] adaptive_loading
+      #  @return [Boolean] whether adaptive loading is used
+      # @!attribute [r] sequencing_kit_box_barcodes
+      #  @return [Array<String>] the barcodes of the sequencing kits
       attributes :name, :dna_control_complex_box_barcode,
                  :system_name, :created_at, :state, :comments,
-                 :pacbio_smrt_link_version_id, :plates_attributes
+                 :pacbio_smrt_link_version_id, :plates_attributes,
+                 :adaptive_loading, :sequencing_kit_box_barcodes
 
       has_many :plates, foreign_key_on: :related, foreign_key: 'pacbio_run_id',
                         class_name: 'Runs::Plate'
@@ -84,6 +89,14 @@ module V1
         Messages.publish(@model, Pipelines.pacbio.message)
         Emq::Publisher.publish(@model.aliquots_to_publish_on_run, Pipelines.pacbio,
                                'volume_tracking')
+      end
+
+      def self.creatable_fields(context)
+        super - %i[adaptive_loading sequencing_kit_box_barcodes]
+      end
+
+      def self.updatable_fields(context)
+        super - %i[adaptive_loading sequencing_kit_box_barcodes]
       end
 
       private

--- a/app/resources/v1/pacbio/run_resource.rb
+++ b/app/resources/v1/pacbio/run_resource.rb
@@ -2,17 +2,39 @@
 
 module V1
   module Pacbio
-    # @todo This documentation does not yet include a detailed description of what this resource represents.
-    # @todo This documentation does not yet include detailed descriptions for relationships, attributes and filters.
-    # @todo This documentation does not yet include any example usage of the API via cURL or similar.
-    #
-    # @note Access this resource via the `/v1/pacbio/runs/` endpoint.
-    #
     # Provides a JSON:API representation of {Pacbio::Run}.
     #
     # For more information about JSON:API see the [JSON:API Specifications](https://jsonapi.org/format/)
     # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package
     # for the service implementation of the JSON:API standard.
+    # This resource represents a Pacbio Run and can return all runs, a single run or multiple
+    # runs along with their relationships.
+    # It can also create and update runs and their nested relationships
+    # via the plates_attributes parameter. These actions also publish run messages to the warehouse.
+    #
+    # ## Filters:
+    #
+    # * name
+    # * state
+    #
+    # ## Primary relationships:
+    #
+    # * plates {V1::Pacbio::PlateResource}
+    # * smrt_link_version {V1::Pacbio::SmrtLinkVersionResource}
+    #
+    # ## Relationship trees:
+    #
+    # * plates.wells.used_aliquots
+    # * smrt_link_version.smrt_link_option_versions
+    #
+    # @example
+    #   curl -X GET http://localhost:3000/v1/pacbio/runs/1
+    #   curl -X GET http://localhost:3000/v1/pacbio/runs/
+    #   curl -X GET http://localhost:3000/v1/pacbio/runs/1?include=plates.wells.used_aliquots,smrt_link_version
+    #
+    #   http://localhost:3000/v1/pacbio/runs?filter[name]=TRACTION-RUN-1
+    #   http://localhost:3000/v1/pacbio/runs?filter[state]=pending
+    #
     class RunResource < JSONAPI::Resource
       model_name 'Pacbio::Run'
 
@@ -33,9 +55,9 @@ module V1
       # @!attribute [rw] plates_attributes
       #   @return [Array<Hash>] the attributes of the plates
       # @!attribute [r] adaptive_loading
-      #  @return [Boolean] whether adaptive loading is used
+      #   @return [Boolean] whether adaptive loading is used
       # @!attribute [r] sequencing_kit_box_barcodes
-      #  @return [Array<String>] the barcodes of the sequencing kits
+      #   @return [Array<String>] the barcodes of the sequencing kits
       attributes :name, :dna_control_complex_box_barcode,
                  :system_name, :created_at, :state, :comments,
                  :pacbio_smrt_link_version_id, :plates_attributes,
@@ -50,13 +72,10 @@ module V1
 
       paginator :paged
 
-      #
-      # # A pain. It means we would need to turn this into a method to beat the cop.
-      # rubocop:disable Layout/LineLength
-      PERMITTED_WELL_PARAMETERS = %i[id
-                                     row column
-                                     comment].concat(Rails.configuration.pacbio_smrt_link_versions.options.keys).freeze
-      # rubocop:enable Layout/LineLength
+      # Well parameters that are permitted for the plates_attributes
+      PERMITTED_WELL_PARAMETERS = %i[
+        id row column comment
+      ].concat(Rails.configuration.pacbio_smrt_link_versions.options.keys).freeze
 
       after_save :publish_messages
 

--- a/app/resources/v1/pacbio/runs/well_resource.rb
+++ b/app/resources/v1/pacbio/runs/well_resource.rb
@@ -59,6 +59,10 @@ module V1
         #   @return [String] the polymerase kit
         # @!attribute [rw] library_type
         #   @return [String] the library type
+        # @!attribute [rw] use_adaptive_loading
+        #   @return [Boolean] whether to use adaptive loading
+        # @!attribute [rw] full_resolution_base_qual
+        #   @return [Boolean] whether to apply full resolution base qual
         attributes :row, :column, :comment, :pacbio_plate_id, :position,
                    *Rails.configuration.pacbio_smrt_link_versions.options.keys
 

--- a/app/resources/v1/pacbio/smrt_link_version_resource.rb
+++ b/app/resources/v1/pacbio/smrt_link_version_resource.rb
@@ -2,18 +2,28 @@
 
 module V1
   module Pacbio
-    # @todo This documentation does not yet include a detailed description of what this resource represents.
-    # @todo This documentation does not yet include detailed descriptions for relationships, attributes and filters.
-    # @todo This documentation does not yet include any example usage of the API via cURL or similar.
-    #
-    # @note Access this resource via the `/v1/pacbio/smrt_link_versions/` endpoint.
-    #
-    # Provides a JSON:API representation of {Pacbio::SmrtLinkVersion}. Returns the SMRT Link
-    #  Versions.
-    #
+    # The JSON:API representation of a {Pacbio::SmrtLinkVersion}.
     # For more information about JSON:API see the [JSON:API Specifications](https://jsonapi.org/format/)
     # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package
     # for the service implementation of the JSON:API standard.
+    #
+    # @note Access this resource via the `/v1/pacbio/smrt_link_versions/` endpoint.
+    #
+    # This resource represents a Pacbio SmrtLinkVersion and can return all smrt_link_versions
+    # or a single smrt_link_version
+    #
+    # This resource has no filters.
+    #
+    # ## Primary relationships:
+    #
+    # * smrt_link_option_versions {V1::Pacbio::SmrtLinkOptionVersionResource}
+    #
+    # @example
+    #   curl -X GET http://localhost:3000/v1/pacbio/smrt_link_versions/1
+    #   curl -X GET http://localhost:3000/v1/pacbio/smrt_link_versions
+    #
+    #  https://localhost:3000/v1/pacbio/v1/smrt_link_versions/1?include=smrt_link_option_versions
+    #
     class SmrtLinkVersionResource < JSONAPI::Resource
       model_name 'Pacbio::SmrtLinkVersion'
 

--- a/app/resources/v1/pacbio/well_resource.rb
+++ b/app/resources/v1/pacbio/well_resource.rb
@@ -2,17 +2,36 @@
 
 module V1
   module Pacbio
-    # @todo This documentation does not yet include a detailed description of what this resource represents.
-    # @todo This documentation does not yet include detailed descriptions for relationships, attributes and filters.
-    # @todo This documentation does not yet include any example usage of the API via cURL or similar.
+    # Provides a JSON:API representation of {Pacbio::Well}.
     #
-    # @note Access this resource via the `/v1/pacbio/wells/` endpoint.
-    #
-    # Provides a JSON:API representation of {Well}. Returns the wells for a Pacbio plate.
+    # This resource is primarily accessed through {V1::Pacbio::RunResource}
+    # and {V1::Pacbio::PlateResource}.
+    # Wells are primarily created via a Run and Plate.
     #
     # For more information about JSON:API see the [JSON:API Specifications](https://jsonapi.org/format/)
     # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package
     # for the service implementation of the JSON:API standard.
+    #
+    # This resource represents a Pacbio Well and can return all wells or a single well
+    #
+    # This resource has no filters.
+    #
+    # ## Primary relationships:
+    #
+    # * materials {V1::Pacbio::MaterialResource}
+    # * requests {V1::Pacbio::RequestResource}
+    # * plate {V1::Pacbio::PlateResource}
+    #
+    # @note Access this resource via the `/v1/pacbio/wells/` endpoint.
+    #
+    # @example
+    #   curl -X GET http://localhost:3000/v1/pacbio/wells/1
+    #   curl -X GET http://localhost:3000/v1/pacbio/wells
+    #   curl -X GET http://localhost:3000/v1/pacbio/runs/1/wells
+    #   curl -X GET http://localhost:3000/v1/pacbio/runs/1/wells/1
+    #
+    #   https://localhost:3000/v1/pacbio/v1/wells/1?include=plate,materials
+    #
     class WellResource < JSONAPI::Resource
       model_name '::Well'
 

--- a/app/validators/smrt_link_options_validator.rb
+++ b/app/validators/smrt_link_options_validator.rb
@@ -22,7 +22,7 @@
 # - Or you need to create your own validator as per
 # https://api.rubyonrails.org/classes/ActiveModel/Validator.html
 class SmrtLinkOptionsValidator < ActiveModel::Validator
-  def validate(record)
+  def validate(record) # rubocop:disable Metrics/MethodLength
     # If the version is not present no point validating
     return if record&.run&.smrt_link_version.blank?
 
@@ -38,7 +38,15 @@ class SmrtLinkOptionsValidator < ActiveModel::Validator
         # @example
         #  key = required
         #  validator => ActiveModel::Validations::RequiredValidator
-        validator = "ActiveModel::Validations::#{key.capitalize}Validator".constantize
+
+        # Check if there is a custom validator first
+        validator_class_name = "#{key.camelize}Validator"
+        validator = if Object.const_defined?(validator_class_name)
+                      validator_class_name.constantize
+                    else
+                      # If no custom validator then use an active model one
+                      "ActiveModel::Validations::#{key.camelize}Validator".constantize
+                    end
 
         # We then need to create a new instance of the validator
         # and pass the options along with the attribute name which is the key
@@ -52,5 +60,5 @@ class SmrtLinkOptionsValidator < ActiveModel::Validator
         instance.validate(record)
       end
     end
-  end
+  end # rubocop:enable Metrics/MethodLength
 end

--- a/app/validators/use_adaptive_loading_validator.rb
+++ b/app/validators/use_adaptive_loading_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Validator for ensuring use_adaptive_loading is consistent across all wells
+class UseAdaptiveLoadingValidator < ActiveModel::Validator
+  # @param [ActiveRecord::Base] record
+  def validate(record)
+    return if record.use_adaptive_loading == record.run.wells.first.use_adaptive_loading
+
+    record.errors.add(:base, "well #{record.position} has a differing 'Use Adaptive Loading' value")
+  end
+end

--- a/config/pacbio_smrt_link_versions.yml
+++ b/config/pacbio_smrt_link_versions.yml
@@ -261,7 +261,6 @@ default: &default
         - v12_revio
         - v13_revio
         - v13_1_revio
-        - v25_1_revio
     library_type:
       key: library_type
       label: "Library Type"

--- a/config/pacbio_smrt_link_versions.yml
+++ b/config/pacbio_smrt_link_versions.yml
@@ -277,6 +277,34 @@ default: &default
         - v13_revio
         - v13_1_revio
         - v25_1_revio
+    use_adaptive_loading:
+      key: use_adaptive_loading
+      label: "Use Adaptive Loading"
+      default_value: "False"
+      validations:
+        presence: {}
+        inclusion:
+          in: *true_false
+      data_type: list
+      select_options: *select_true_false
+      versions:
+        - v13_revio
+        - v13_1_revio
+        - v25_1_revio
+    full_resolution_base_qual:
+      key: full_resolution_base_qual
+      label: "Full Resolution Base Qual"
+      default_value: "False"
+      validations:
+        presence: {}
+        inclusion:
+          in: *true_false
+      data_type: list
+      select_options: *select_true_false
+      versions:
+        - v13_revio
+        - v13_1_revio
+        - v25_1_revio
 
 development: *default
 test: *default

--- a/config/pacbio_smrt_link_versions.yml
+++ b/config/pacbio_smrt_link_versions.yml
@@ -285,6 +285,7 @@ default: &default
         presence: {}
         inclusion:
           in: *true_false
+        use_adaptive_loading: {}
       data_type: list
       select_options: *select_true_false
       versions:

--- a/config/pacbio_smrt_link_versions.yml
+++ b/config/pacbio_smrt_link_versions.yml
@@ -44,6 +44,10 @@ default: &default
       name: v13_1_revio
       active: true
       default: false
+    v25_1_revio:
+      name: v25_1_revio
+      active: true
+      default: false
   options:
     ccs_analysis_output:
       key: ccs_analysis_output
@@ -218,6 +222,7 @@ default: &default
         - v12_revio
         - v13_revio
         - v13_1_revio
+        - v25_1_revio
     include_base_kinetics:
       key: include_base_kinetics
       label: "Include Base Kinetics"
@@ -232,6 +237,7 @@ default: &default
         - v12_revio
         - v13_revio
         - v13_1_revio
+        - v25_1_revio
     library_concentration:
       key: library_concentration
       label: "Library Concentration (pM)"
@@ -243,6 +249,7 @@ default: &default
         - v12_revio
         - v13_revio
         - v13_1_revio
+        - v25_1_revio
     polymerase_kit:
       key: polymerase_kit
       label: "Polymerase Kit"
@@ -254,6 +261,7 @@ default: &default
         - v12_revio
         - v13_revio
         - v13_1_revio
+        - v25_1_revio
     library_type:
       key: library_type
       label: "Library Type"
@@ -268,6 +276,7 @@ default: &default
         - v12_revio
         - v13_revio
         - v13_1_revio
+        - v25_1_revio
 
 development: *default
 test: *default

--- a/config/pipelines/pacbio.yml
+++ b/config/pipelines/pacbio.yml
@@ -340,6 +340,8 @@ default: &default
 
       v13_1_revio: *v13_revio
 
+      v25_1_revio: *v13_revio
+
     # For any EMQ message creation, the section and key name must be same as schema subject in bunny.yml
     volume_tracking:
     # The number suffix '1' is used to identify the schema version of message (created by the

--- a/config/pipelines/pacbio.yml
+++ b/config/pipelines/pacbio.yml
@@ -340,7 +340,8 @@ default: &default
 
       v13_1_revio: *v13_revio
 
-      v25_1_revio: *v13_revio
+      v25_1_revio:
+        sample_sheet_class: PacbioSampleSheetV25
 
     # For any EMQ message creation, the section and key name must be same as schema subject in bunny.yml
     volume_tracking:

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
   before do
     # Create a default smrt link version
     create(:pacbio_smrt_link_version, name: 'v13_revio', default: true)
+    create(:pacbio_smrt_link_version, name: 'v25_1_revio')
   end
 
   describe '#payload' do
@@ -21,6 +22,261 @@ RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
     let(:parsed_sample_sheet) { Parsers::PacbioSampleSheetParser.new.parse(sample_sheet_string) }
 
     context 'v13_revio' do
+      it 'must return a string' do
+        expect(sample_sheet_string.class).to eq String
+      end
+
+      it 'must have the three required sections' do
+        expect(sample_sheet_string).to include('[Run Settings]')
+        expect(sample_sheet_string).to include('[SMRT Cell Settings]')
+        expect(sample_sheet_string).to include('[Samples]')
+      end
+
+      it 'must have the three required sections in the correct order' do
+        run_settings_index = sample_sheet_string.index('[Run Settings]')
+        cell_settings_index = sample_sheet_string.index('[SMRT Cell Settings]')
+        samples_index = sample_sheet_string.index('[Samples]')
+
+        expect(run_settings_index).to be < cell_settings_index
+        expect(cell_settings_index).to be < samples_index
+      end
+
+      it 'must have the correct run settings' do
+        expect(parsed_sample_sheet['Run Settings']).to eq(
+          {
+            'Instrument Type' => 'Revio',
+            'Run Name' => run.name,
+            'Run Comments' => run.comments,
+            'Plate 1' => run.plates[0].sequencing_kit_box_barcode,
+            'Plate 2' => run.plates[1].sequencing_kit_box_barcode,
+            'CSV Version' => '1'
+          }
+        )
+      end
+
+      it 'must have the cells used listed on the same line as the section header' do
+        # get the line from sample_sheet_string containing [SMRT Cell Settings]
+        smrt_cell_settings_line = sample_sheet_string.lines.find { |line| line.include?('[SMRT Cell Settings]') }.strip
+        expect(smrt_cell_settings_line).to eq('[SMRT Cell Settings],1_A01,1_B01,2_A01')
+      end
+
+      it 'must have the correct SMRT cell settings' do
+        smrt_cell_settings = parsed_sample_sheet['SMRT Cell Settings']
+
+        # create a hash of plate_well_name => well for easy comparison
+        plate_wells = run.plates.flat_map(&:wells).each_with_object({}) do |well, hash|
+          plate_well_name = "#{well.plate.plate_number}_#{well.position_leading_zero}"
+          hash[plate_well_name] = well
+        end
+
+        # confirm that the wells are as expected
+        plate_well_names = plate_wells.keys
+        expect(plate_well_names).to contain_exactly('1_A01', '1_B01', '2_A01')
+        expect(smrt_cell_settings.keys).to match_array(plate_well_names)
+
+        plate_well_names.each do |plate_well_name|
+          well = plate_wells[plate_well_name]
+          expected_settings = {
+            # for all wells
+            'Well Name' => well.used_aliquots.first.source.tube.barcode,
+            'Library Type' => 'Standard',
+            'Movie Acquisition Time (hours)' => well.movie_acquisition_time.to_s,
+            'Insert Size (bp)' => well.insert_size.to_s,
+            'Assign Data To Project' => '1',
+            'Library Concentration (pM)' => well.library_concentration.to_s,
+            'Include Base Kinetics' => well.include_base_kinetics.downcase == 'true', # is a string
+            'Polymerase Kit' => well.polymerase_kit,
+            'Use Adaptive Loading' => false,
+            'Consensus Mode' => 'molecule',
+
+            # specific to tagged wells
+            'Bio Sample Name' => '',
+            'Sample is indexed' => true,
+            'Indexes' => well.barcode_set,
+            'Same Barcodes on Both Ends of Sequence' => true
+          }
+
+          expect(smrt_cell_settings[plate_well_name]).to eq(expected_settings)
+        end
+      end
+
+      context 'when the libraries are tagged' do
+        let(:well1) do
+          create(
+            :pacbio_well,
+            pre_extension_time: 2,
+            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output: 'Yes',
+            row: 'A',
+            column: 1
+          )
+        end
+        let(:well2) do
+          create(
+            :pacbio_well,
+            pre_extension_time: 2,
+            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output: 'No',
+            row: 'A',
+            column: 1
+          )
+        end
+        let(:well3) do
+          create(
+            :pacbio_well,
+            pre_extension_time: 2,
+            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output: 'No',
+            row: 'B',
+            column: 1
+          )
+        end
+        let(:plate1_wells)   { [well1] }
+        let(:plate2_wells)   { [well2, well3] }
+        let(:plate1)  { build(:pacbio_plate, wells: plate1_wells, plate_number: 1) }
+        let(:plate2)  { build(:pacbio_plate, wells: plate2_wells, plate_number: 2) }
+        let(:run)     { create(:pacbio_revio_run, plates: [plate1, plate2]) }
+
+        it 'must have the correct headers' do
+          # get the line from sample_sheet_string after the one containing [Samples]
+          sample_sheet_lines = sample_sheet_string.lines
+          samples_section_index = sample_sheet_lines.find_index { |line| line.include?('[Samples]') }
+          headers_line = sample_sheet_lines[samples_section_index + 1]
+          headers = headers_line.strip.split(',')
+          expected_headers = ['Bio Sample Name', 'Plate Well', 'Adapter', 'Adapter2']
+          expect(headers).to eq(expected_headers)
+        end
+
+        it 'must have the correct sample rows' do
+          # 5 pools per well
+          sample_data_1 = parsed_sample_sheet['Samples'][0]
+          sample_data_2 = parsed_sample_sheet['Samples'][1 * 5]
+          sample_data_3 = parsed_sample_sheet['Samples'][2 * 5]
+
+          #  iterate through the samples under test
+          sample_expectations = [
+            [sample_data_1, well1],
+            [sample_data_2, well2],
+            [sample_data_3, well3]
+          ]
+          sample_expectations.each do |sample_data, well|
+            expect(sample_data).to eq(
+              {
+                'Bio Sample Name' => well.base_used_aliquots.first.bio_sample_name,
+                'Plate Well' => well.plate_well_position,
+                'Adapter' => well.base_used_aliquots.first.tag.group_id,
+                'Adapter2' => well.base_used_aliquots.first.tag.group_id
+              }
+            )
+          end
+        end
+      end
+
+      context 'when the libraries are untagged' do
+        let(:pool1)   { create_list(:pacbio_pool, 1, :untagged) }
+        let(:pool2)   { create_list(:pacbio_pool, 1, :untagged) }
+        let(:pool3)   { create_list(:pacbio_pool, 1, :untagged) }
+        let(:well1) do
+          create(
+            :pacbio_well,
+            pre_extension_time: 2,
+            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output: 'Yes',
+            pools: pool1, # untagged pool
+            row: 'A',
+            column: 1
+          )
+        end
+        let(:well2) do
+          create(
+            :pacbio_well,
+            pre_extension_time: 2,
+            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output: 'No',
+            pools: pool2, # untagged pool
+            row: 'A',
+            column: 1
+          )
+        end
+        let(:well3) do
+          create(
+            :pacbio_well,
+            pre_extension_time: 2,
+            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output: 'No',
+            pools: pool3, # untagged pool
+            row: 'B',
+            column: 1
+          )
+        end
+        let(:plate1_wells)   { [well1] }
+        let(:plate2_wells)   { [well2, well3] }
+        let(:plate1)  { build(:pacbio_plate, wells: plate1_wells, plate_number: 1) }
+        let(:plate2)  { build(:pacbio_plate, wells: plate2_wells, plate_number: 2) }
+        let(:run)     { create(:pacbio_revio_run, plates: [plate1, plate2]) }
+
+        it 'must have the correct headers' do
+          # get the line from sample_sheet_string after the one containing [Samples]
+          sample_sheet_lines = sample_sheet_string.lines
+          samples_section_index = sample_sheet_lines.find_index { |line| line.include?('[Samples]') }
+          headers_line = sample_sheet_lines[samples_section_index + 1]
+          headers = headers_line.strip.split(',')
+          expected_headers = ['Bio Sample Name', 'Plate Well', 'Adapter', 'Adapter2']
+          expect(headers).to eq(expected_headers)
+        end
+
+        it 'must have the wells added to the SMRT Cell Settings section' do
+          smrt_cell_settings = parsed_sample_sheet['SMRT Cell Settings']
+
+          # create a hash of plate_well_name => well for easy comparison
+          plate_wells = run.plates.flat_map(&:wells).each_with_object({}) do |well, hash|
+            plate_well_name = "#{well.plate.plate_number}_#{well.position_leading_zero}"
+            hash[plate_well_name] = well
+          end
+
+          # confirm that the wells are as expected
+          plate_well_names = plate_wells.keys
+          expect(plate_well_names).to contain_exactly('1_A01', '2_A01', '2_B01')
+          expect(smrt_cell_settings.keys).to match_array(plate_well_names)
+
+          #  iterate through the wells under test
+          plate_well_names.each do |plate_well_name|
+            well_data = smrt_cell_settings[plate_well_name]
+            well = plate_wells[plate_well_name]
+
+            expect(well_data).to eq(
+              # for all wells
+              'Well Name' => well.used_aliquots.first.source.tube.barcode,
+              'Library Type' => 'Standard',
+              'Movie Acquisition Time (hours)' => well.movie_acquisition_time.to_s,
+              'Insert Size (bp)' => well.insert_size.to_s,
+              'Assign Data To Project' => '1',
+              'Library Concentration (pM)' => well.library_concentration.to_s,
+              'Include Base Kinetics' => well.include_base_kinetics.downcase == 'true', # is a string
+              'Polymerase Kit' => well.polymerase_kit,
+              'Use Adaptive Loading' => false,
+              'Consensus Mode' => 'molecule',
+
+              # specific to untagged wells
+              'Bio Sample Name' => well.bio_sample_name,
+              'Sample is indexed' => false,
+              'Indexes' => '', # well.barcode_set
+              'Same Barcodes on Both Ends of Sequence' => '' # well.same_barcodes_on_both_ends_of_sequence.to_s
+            )
+          end
+        end
+
+        it 'must not have sample rows' do
+          expect(parsed_sample_sheet['Samples']).to be_empty
+        end
+      end
+    end
+
+    context 'v25_1_revio' do
+      before do
+        run.smrt_link_version = Pacbio::SmrtLinkVersion.find_by(name: 'v25_1_revio')
+      end
+
       it 'must return a string' do
         expect(sample_sheet_string.class).to eq String
       end

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
   before do
     # Create a default smrt link version
     create(:pacbio_smrt_link_version, name: 'v13_revio', default: true)
-    create(:pacbio_smrt_link_version, name: 'v25_1_revio')
   end
 
   describe '#payload' do

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
@@ -6,11 +6,10 @@ require 'rails_helper'
 # huh? what is this? If we need a parser to parse the sample sheet probably needs a refactor
 require_relative '../../support/parsers/pacbio_sample_sheet_parser'
 
-RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
+RSpec.describe RunCsv::PacbioSampleSheetV25, type: :model do
   before do
     # Create a default smrt link version
-    create(:pacbio_smrt_link_version, name: 'v13_revio', default: true)
-    create(:pacbio_smrt_link_version, name: 'v25_1_revio')
+    create(:pacbio_smrt_link_version, name: 'v25_1_revio', default: true)
   end
 
   describe '#payload' do
@@ -21,7 +20,7 @@ RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
     let(:configuration) { Pipelines.pacbio.sample_sheet.by_version(run.smrt_link_version.name) }
     let(:parsed_sample_sheet) { Parsers::PacbioSampleSheetParser.new.parse(sample_sheet_string) }
 
-    context 'v13_revio' do
+    context 'v25_1_revio' do
       it 'must return a string' do
         expect(sample_sheet_string.class).to eq String
       end
@@ -85,8 +84,7 @@ RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
             'Assign Data To Project' => '1',
             'Library Concentration (pM)' => well.library_concentration.to_s,
             'Include Base Kinetics' => well.include_base_kinetics.downcase == 'true', # is a string
-            'Polymerase Kit' => well.polymerase_kit,
-            'Use Adaptive Loading' => well.use_adaptive_loading == 'true',
+            'Use Adaptive Loading' => well.use_adaptive_loading.downcase == 'true',
             'Consensus Mode' => 'molecule',
             'Full Resolution Base Qual' => well.full_resolution_base_qual == 'true',
 
@@ -254,8 +252,7 @@ RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
               'Assign Data To Project' => '1',
               'Library Concentration (pM)' => well.library_concentration.to_s,
               'Include Base Kinetics' => well.include_base_kinetics.downcase == 'true', # is a string
-              'Polymerase Kit' => well.polymerase_kit,
-              'Use Adaptive Loading' => well.use_adaptive_loading == 'true',
+              'Use Adaptive Loading' => well.use_adaptive_loading.downcase == 'true',
               'Consensus Mode' => 'molecule',
               'Full Resolution Base Qual' => well.full_resolution_base_qual == 'true',
 

--- a/spec/factories/pacbio/wells.rb
+++ b/spec/factories/pacbio/wells.rb
@@ -66,5 +66,9 @@ FactoryBot.define do
     sequence(:library_concentration) { |n| "10.#{n}".to_f }
     sequence(:polymerase_kit) { |n| "DM111710086220011171#{n}" }
     library_type { 'Standard' }
+
+    # v13_1_revio
+    use_adaptive_loading { 'False' }
+    full_resolution_base_qual { 'False' }
   end
 end

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -233,6 +233,40 @@ RSpec.describe Pacbio::Run, :pacbio do
     end
   end
 
+  context 'adaptive_loading' do
+    it 'is false if the wells do not have use_adaptive_loading' do
+      # Sequel run wells do not have use_adaptive_loading
+      run = create(:pacbio_sequel_run)
+      expect(run.adaptive_loading).to be false
+    end
+
+    it 'is false if the wells have use_adaptive_loading set to false' do
+      # Revio run wells have use_adaptive_loading set to false
+      run = create(:pacbio_revio_run)
+      expect(run.adaptive_loading).to be false
+    end
+
+    it 'is true if the wells have use_adaptive_loading set to true' do
+      # Revio run wells have use_adaptive_loading set to true
+      run = create(:pacbio_revio_run)
+      run.wells.each do |w|
+        w.use_adaptive_loading = 'True'
+        w.save
+      end
+      expect(run.adaptive_loading).to be true
+    end
+  end
+
+  context 'sequencing_kit_box_barcodes' do
+    it 'returns the barcodes of the sequencing kits' do
+      run = create(:pacbio_revio_run)
+      expect(run.sequencing_kit_box_barcodes).to eq([
+        "Plate 1: #{run.plates.first.sequencing_kit_box_barcode}",
+        "Plate 2: #{run.plates.second.sequencing_kit_box_barcode}"
+      ])
+    end
+  end
+
   describe '#create with nested attributes' do
     let!(:pools) { create_list(:pacbio_pool, 2) }
 

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -273,6 +273,8 @@ RSpec.describe Pacbio::Well, :pacbio do
         library_concentration
         polymerase_kit
         library_type
+        use_adaptive_loading
+        full_resolution_base_qual
       ])
     end
 

--- a/spec/validators/smrt_link_options_validator_spec.rb
+++ b/spec/validators/smrt_link_options_validator_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SmrtLinkOptionsValidator do
       end
     end
 
-    it 'onlies mark the record as invalid for the correct version' do
+    it 'only marks the record as invalid for the correct version' do
       run = create(:pacbio_sequel_run, smrt_link_version: versions.first)
       well = build(:pacbio_well, plate: run.plates.first, movie_time: nil)
       described_class.new.validate(well)

--- a/spec/validators/use_adaptive_loading_validator_spec.rb
+++ b/spec/validators/use_adaptive_loading_validator_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UseAdaptiveLoadingValidator do
+  before do
+    create(:pacbio_smrt_link_version, name: 'v13_1_revio', default: true)
+  end
+
+  let(:run) { create(:pacbio_revio_run) }
+  let(:validator) { described_class.new(run:, exclude_marked_for_destruction: true) }
+
+  it 'is valid when all wells have the same use_adaptive_loading value' do
+    # Factory defaults to false for use_adaptive_loading for all wells
+    well = run.wells.first
+    validator.validate(well)
+    expect(well.errors).to be_empty
+  end
+
+  it 'is invalid when all wells do not have the same use_adaptive_loading value' do
+    well = run.wells.last
+    well.use_adaptive_loading = true
+
+    validator.validate(well)
+    expect(well.errors[:base]).to include("well #{run.wells.last.position} has a differing 'Use Adaptive Loading' value")
+  end
+end


### PR DESCRIPTION
Closes #1510 

#### Changes proposed in this pull request

- Adds v25_1_revio SMRTLink option.
- Adds pacbio_sample_sheet_v25 to handle well settings uniquely for the v25_1_revio sample sheets.
- Adds use_adaptive_loading and full_resolution_base_qual smrt link options.
- Adds custom smrt link option validator to handle use_adaptive_loading constraint to be the same for all wells in a run.
- Adds and exposes 'adaptive_loading' and 'sequencing_kit_box_barcodes' PacBio Run helper methods to the API.

#### Reviewer notes
Not sure if the custom smrt link option validator is the best option or not. The requirement is to ensure all v13 > revio runs using use_adaptive_loading have a consistent value across the run - all True or all False. So this validation is a mix of instrument type, smrt link option, run and well validation.
