### PR TITLE
Y25-097 replace colon with hyphen for sample upload csv for smart link v25

### DIFF
--- a/app/exchanges/run_csv/pacbio_sample_sheet.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet.rb
@@ -88,11 +88,15 @@ module RunCsv
 
     def sample_data(well, sample)
       [
-        sample.bio_sample_name,
+        bio_sample_name(sample),
         well.plate_well_position,
         sample.adapter, # left adapter
         sample.adapter  # right adapter
       ]
+    end
+
+    def bio_sample_name(sample)
+      sample.bio_sample_name
     end
 
     # Generate a CSV of samples

--- a/app/exchanges/run_csv/pacbio_sample_sheet.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet.rb
@@ -95,6 +95,8 @@ module RunCsv
       ]
     end
 
+    # Returns the bio sample name for the given sample.
+
     def bio_sample_name(sample)
       sample.bio_sample_name
     end

--- a/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
@@ -9,6 +9,11 @@ module RunCsv
     # Generate a hash of settings for a single cell
     # Overrides the method in the parent class
     # Only difference is removal of 'Polymerase Kit' key
+    #
+    def bio_sample_name(sample)
+      sample.formatted_bio_sample_name
+    end
+
     def generate_smrt_cell_settings(well) # rubocop:disable Metrics/MethodLength
       {
         'Well Name'	=> well.used_aliquots.first.source.tube.barcode, # TRAC-2-7242

--- a/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
@@ -6,14 +6,18 @@
 module RunCsv
   # RunCsv::PacbioSampleSheet
   class PacbioSampleSheetV25 < PacbioSampleSheet
-    # Generate a hash of settings for a single cell
-    # Overrides the method in the parent class
-    # Only difference is removal of 'Polymerase Kit' key
-    #
+    # Returns the formatted bio sample name for the given sample.
+    # This method overrides the bio_sample_name method in the parent class.
+    # It returns the sample names with colons replaced by hyphens.
+
     def bio_sample_name(sample)
       sample.formatted_bio_sample_name
     end
 
+    # Generate a hash of settings for a single cell
+    # Overrides the method in the parent class
+    # Only difference is removal of 'Polymerase Kit' key
+    #
     def generate_smrt_cell_settings(well) # rubocop:disable Metrics/MethodLength
       {
         'Well Name'	=> well.used_aliquots.first.source.tube.barcode, # TRAC-2-7242

--- a/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
@@ -20,7 +20,7 @@ module RunCsv
         'Include Base Kinetics'	=> well.include_base_kinetics,
         'Indexes'	=> well.barcode_set, # 244d96c6-f3b2-4997-5ae3-23ed33ab925f
         'Sample is indexed'	=> well.tagged?, # Set to True to Multiplex
-        'Bio Sample Name' => well.tagged? ? nil : well.bio_sample_name,
+        'Bio Sample Name' => well.tagged? ? nil :  well.formatted_bio_sample_name,
         'Use Adaptive Loading'	=> well.use_adaptive_loading,
         'Consensus Mode'	=> 'molecule', # (default to molecule do we need a custom field)
         'Same Barcodes on Both Ends of Sequence'	=> well.same_barcodes_on_both_ends_of_sequence,

--- a/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet_v25.rb
@@ -17,7 +17,6 @@ module RunCsv
     # Generate a hash of settings for a single cell
     # Overrides the method in the parent class
     # Only difference is removal of 'Polymerase Kit' key
-    #
     def generate_smrt_cell_settings(well) # rubocop:disable Metrics/MethodLength
       {
         'Well Name'	=> well.used_aliquots.first.source.tube.barcode, # TRAC-2-7242

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -108,6 +108,9 @@ class Aliquot < ApplicationRecord
     source.sample_name || ''
   end
 
+  # Returns the formatted bio sample name.
+  # Replaces all colons (:) in the bio sample name with hyphens (-).
+
   def formatted_bio_sample_name
     bio_sample_name.gsub(':', '-')
   end

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -108,6 +108,10 @@ class Aliquot < ApplicationRecord
     source.sample_name || ''
   end
 
+  def formatted_bio_sample_name
+    bio_sample_name.gsub(':', '-')
+  end
+
   # Barcode Name field
   # Deprecated as of SMRT-Link v13.0
   # See https://www.pacb.com/wp-content/uploads/SMRT-Link-Release-Notes-v13.0.pdf

--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -216,5 +216,12 @@ module Pacbio
     def bio_sample_name
       sample_is_barcoded ? nil : sample_names
     end
+
+    # Returns the formatted bio sample name.
+    # If the sample is barcoded, it returns nil.
+    # Otherwise, it returns the sample names with colons replaced by hyphens.
+    def formatted_bio_sample_name
+      bio_sample_name&.gsub(':', '-')
+    end
   end
 end

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RunCsv::PacbioSampleSheetV25, type: :model do
           sample_expectations.each do |sample_data, well|
             expect(sample_data).to eq(
               {
-                'Bio Sample Name' => well.base_used_aliquots.first.formatted_bio_sample_name,
+                'Bio Sample Name' => well.base_used_aliquots.first.bio_sample_name,
                 'Plate Well' => well.plate_well_position,
                 'Adapter' => well.base_used_aliquots.first.tag.group_id,
                 'Adapter2' => well.base_used_aliquots.first.tag.group_id

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RunCsv::PacbioSampleSheetV25, type: :model do
           sample_expectations.each do |sample_data, well|
             expect(sample_data).to eq(
               {
-                'Bio Sample Name' => well.base_used_aliquots.first.bio_sample_name,
+                'Bio Sample Name' => well.base_used_aliquots.first.formatted_bio_sample_name,
                 'Plate Well' => well.plate_well_position,
                 'Adapter' => well.base_used_aliquots.first.tag.group_id,
                 'Adapter2' => well.base_used_aliquots.first.tag.group_id

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RunCsv::PacbioSampleSheetV25, type: :model do
           sample_expectations.each do |sample_data, well|
             expect(sample_data).to eq(
               {
-                'Bio Sample Name' => well.base_used_aliquots.first.bio_sample_name,
+                'Bio Sample Name' => well.base_used_aliquots.first.formatted_bio_sample_name,
                 'Plate Well' => well.plate_well_position,
                 'Adapter' => well.base_used_aliquots.first.tag.group_id,
                 'Adapter2' => well.base_used_aliquots.first.tag.group_id
@@ -257,7 +257,7 @@ RSpec.describe RunCsv::PacbioSampleSheetV25, type: :model do
               'Full Resolution Base Qual' => well.full_resolution_base_qual == 'true',
 
               # specific to untagged wells
-              'Bio Sample Name' => well.bio_sample_name,
+              'Bio Sample Name' => well.formatted_bio_sample_name,
               'Sample is indexed' => false,
               'Indexes' => '', # well.barcode_set
               'Same Barcodes on Both Ends of Sequence' => '' # well.same_barcodes_on_both_ends_of_sequence.to_s

--- a/spec/models/aliquot_spec.rb
+++ b/spec/models/aliquot_spec.rb
@@ -275,5 +275,24 @@ RSpec.describe Aliquot do
         end
       end
     end
+
+    describe '#formatted_bio_sample_name' do
+      context 'when the sample sheet behaviour is default' do
+        it 'returns the source sample name for a aliquot from a library' do
+          request = create(:pacbio_request, sample: create(:sample, name: 'test:A1'))
+          library = create(:pacbio_library, request:)
+          aliquot = create(:aliquot, source: library)
+          expect(aliquot.formatted_bio_sample_name).to eq(library.sample_name.gsub(':', '-'))
+        end
+      end
+
+      context 'when the sample sheet behaviour is hidden' do
+        it 'returns an empty string' do
+          library = create(:pacbio_library)
+          aliquot = create(:aliquot, tag: create(:hidden_tag), source: library)
+          expect(aliquot.formatted_bio_sample_name).to eq('')
+        end
+      end
+    end
   end
 end

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -643,6 +643,24 @@ RSpec.describe Pacbio::Well, :pacbio do
       end
     end
 
+    describe '#formatted_bio_sample_name' do
+      context 'when tag set is :default type' do
+        it 'returns nothing if row type is well' do
+          expect(well.formatted_bio_sample_name).to be_nil
+        end
+      end
+
+      context 'when tag set is :hidden type (eg. IsoSeq)' do
+        let(:request) { create(:pacbio_request, sample: create(:sample, name: 'test:A1')) }
+        let(:library) { create(:pacbio_library, :hidden_tagged, request:) }
+
+        it 'returns dash separated sample_names if row type is well' do
+          well = create(:pacbio_well, libraries: [library])
+          expect(well.formatted_bio_sample_name).to eq well.sample_names.gsub(':', '-')
+        end
+      end
+    end
+
     context 'show_row_per_sample?' do
       it 'returns true if all well aliquots are tagged' do
         expect(well.show_row_per_sample?).to be true


### PR DESCRIPTION
Closes https://github.com/sanger/traction-service/issues/1544

#### Changes proposed in this pull request

- Update bio_sample_name by replacing colons with hyphens for CSV upload in SmrtLink V25.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
