### PR TITLE
Update Bundler version in Gemfile.lock to 2.6.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,4 +385,4 @@ RUBY VERSION
    ruby 3.4.2
 
 BUNDLED WITH
-   2.5.9
+   2.6.5


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- It looks like the old bundler version has issues with ruby platform and nokogiri. Updating to the latest version fixes this issue.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
