### PR TITLE
Y25-080 - rename comments to barcodes_and_concentrations in Pacbio run model and update related references

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,6 @@ inherit_from: .rubocop_todo.yml
 plugins:
   - rubocop-rspec
   - rubocop-rails
-
-require:
   - rubocop-factory_bot
 
 AllCops:

--- a/app/exchanges/run_csv/pacbio_sample_sheet.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet.rb
@@ -20,7 +20,7 @@ module RunCsv
       {
         'Instrument Type' => run.system_name,
         'Run Name' =>	run.name,
-        'Run Comments' =>	run.comments
+        'Run Comments' =>	run.barcodes_and_concentrations
       }.merge(plate_data).merge(
         { 'CSV Version' => 1 }
       )

--- a/app/resources/v1/pacbio/run_resource.rb
+++ b/app/resources/v1/pacbio/run_resource.rb
@@ -48,8 +48,7 @@ module V1
       #   @return [String] the creation time of the run
       # @!attribute [rw] state
       #   @return [String] the state of the run
-      # @!attribute [rw] comments
-      #   @return [String] the comments on the run
+
       # @!attribute [rw] pacbio_smrt_link_version_id
       #   @return [Integer] the ID of the PacBio SMRT Link version
       # @!attribute [rw] plates_attributes
@@ -59,9 +58,17 @@ module V1
       # @!attribute [r] sequencing_kit_box_barcodes
       #   @return [Array<String>] the barcodes of the sequencing kits
       attributes :name, :dna_control_complex_box_barcode,
-                 :system_name, :created_at, :state, :comments,
+                 :system_name, :created_at, :state,
                  :pacbio_smrt_link_version_id, :plates_attributes,
                  :adaptive_loading, :sequencing_kit_box_barcodes
+
+      # @!attribute [r] barcodes_and_concentrations
+      #   @return [String] the barcodes and concentrations of the run
+      attribute :barcodes_and_concentrations, readonly: true
+
+      # @!attribute [r] comments [DEPRECATED]
+      #   @return [String] the comments on the run
+      attribute :comments, readonly: true
 
       has_many :plates, foreign_key_on: :related, foreign_key: 'pacbio_run_id',
                         class_name: 'Runs::Plate'

--- a/config/pipelines/pacbio.yml
+++ b/config/pipelines/pacbio.yml
@@ -121,7 +121,7 @@ default: &default
               value: plate.run.system_name
             Run Comments:
               type: :model
-              value: plate.run.comments
+              value: plate.run.barcodes_and_concentrations
             Is Collection:
               type: :model
               value: collection?
@@ -242,7 +242,7 @@ default: &default
               value: plate.run.dna_control_complex_box_barcode
             Run Comments:
               type: :model
-              value: plate.run.comments
+              value: plate.run.barcodes_and_concentrations
             Sample is Barcoded:
               type: :model
               value: sample_is_barcoded

--- a/db/migrate/20250319151746_rename_pacbio_run_comments_to_barcodes_and_concentrations.rb
+++ b/db/migrate/20250319151746_rename_pacbio_run_comments_to_barcodes_and_concentrations.rb
@@ -1,0 +1,5 @@
+class RenamePacbioRunCommentsToBarcodesAndConcentrations < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :pacbio_runs, :comments, :barcodes_and_concentrations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_21_134136) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_19_151746) do
   create_table "aliquots", charset: "utf8mb3", force: :cascade do |t|
     t.float "volume"
     t.float "concentration"
@@ -238,7 +238,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_21_134136) do
   create_table "pacbio_runs", charset: "utf8mb3", force: :cascade do |t|
     t.string "name"
     t.string "dna_control_complex_box_barcode"
-    t.text "comments"
+    t.text "barcodes_and_concentrations"
     t.string "uuid"
     t.integer "system_name", default: 2
     t.datetime "created_at", precision: nil, null: false

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_legacy_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_legacy_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               nil, # plate 2: sequencing_kit_box_barcode
               well.plate.run.name,
               well.plate.run.system_name,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               'true', # well.collection?
               well.position_leading_zero,
               well.tube_barcode,
@@ -152,7 +152,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               nil, # plate 2: sequencing_kit_box_barcode
               well.plate.run.name,
               well.plate.run.system_name,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               'true', # well.collection?
               well.position_leading_zero,
               well.tube_barcode,
@@ -230,7 +230,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               well.plate.sequencing_kit_box_barcode,
               well.on_plate_loading_concentration.to_s,
               well.plate.run.dna_control_complex_box_barcode,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               well.show_row_per_sample?.to_s,
               nil, # barcode name - does not apply
               well.barcode_set,
@@ -335,7 +335,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               well.plate.sequencing_kit_box_barcode,
               well.on_plate_loading_concentration.to_s,
               well.plate.run.dna_control_complex_box_barcode,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               well.sample_is_barcoded.to_s,
               nil, # barcode name - does not apply
               well.barcode_set,
@@ -403,7 +403,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               well.plate.sequencing_kit_box_barcode,
               well.on_plate_loading_concentration.to_s,
               well.plate.run.dna_control_complex_box_barcode,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               well.sample_is_barcoded.to_s,
               nil, # barcode name - does not apply
               well.barcode_set,
@@ -468,7 +468,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               well.plate.sequencing_kit_box_barcode,
               well.on_plate_loading_concentration.to_s,
               well.plate.run.dna_control_complex_box_barcode,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               well.sample_is_barcoded.to_s,
               nil, # barcode name - does not apply
               well.barcode_set,
@@ -604,7 +604,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               well.plate.sequencing_kit_box_barcode,
               well.on_plate_loading_concentration.to_s,
               well.plate.run.dna_control_complex_box_barcode,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               well.show_row_per_sample?.to_s,
               nil, # barcode name - does not apply
               well.barcode_set,
@@ -713,7 +713,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               well.plate.sequencing_kit_box_barcode,
               well.on_plate_loading_concentration.to_s,
               well.plate.run.dna_control_complex_box_barcode,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               well.sample_is_barcoded.to_s,
               nil, # barcode name - does not apply
               well.barcode_set,
@@ -783,7 +783,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               well.plate.sequencing_kit_box_barcode,
               well.on_plate_loading_concentration.to_s,
               well.plate.run.dna_control_complex_box_barcode,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               well.sample_is_barcoded.to_s,
               nil, # barcode name - does not apply
               well.barcode_set,
@@ -850,7 +850,7 @@ RSpec.describe RunCsv::PacbioSampleSheetLegacy, type: :model do
               well.plate.sequencing_kit_box_barcode,
               well.on_plate_loading_concentration.to_s,
               well.plate.run.dna_control_complex_box_barcode,
-              well.plate.run.comments,
+              well.plate.run.barcodes_and_concentrations,
               well.sample_is_barcoded.to_s,
               nil, # barcode name - does not apply
               well.barcode_set,

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
           {
             'Instrument Type' => 'Revio',
             'Run Name' => run.name,
-            'Run Comments' => run.comments,
+            'Run Comments' => run.barcodes_and_concentrations,
             'Plate 1' => run.plates[0].sequencing_kit_box_barcode,
             'Plate 2' => run.plates[1].sequencing_kit_box_barcode,
             'CSV Version' => '1'

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_v25_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RunCsv::PacbioSampleSheetV25, type: :model do
           {
             'Instrument Type' => 'Revio',
             'Run Name' => run.name,
-            'Run Comments' => run.comments,
+            'Run Comments' => run.barcodes_and_concentrations,
             'Plate 1' => run.plates[0].sequencing_kit_box_barcode,
             'Plate 2' => run.plates[1].sequencing_kit_box_barcode,
             'CSV Version' => '1'

--- a/spec/factories/pacbio/runs.rb
+++ b/spec/factories/pacbio/runs.rb
@@ -15,7 +15,6 @@ end
 FactoryBot.define do
   factory :pacbio_generic_run, class: 'Pacbio::Run' do
     sequence(:dna_control_complex_box_barcode) { |n| "Lxxxxx10171760012319#{n}" }
-    comments { 'A Run Comment' }
 
     factory :pacbio_revio_run do
       transient do

--- a/spec/models/pacbio/run_spec.rb
+++ b/spec/models/pacbio/run_spec.rb
@@ -80,27 +80,20 @@ RSpec.describe Pacbio::Run, :pacbio do
     end
   end
 
-  describe '#comments' do
-    it 'can have run comments' do
-      run = create(:pacbio_sequel_run)
+  describe '#barcodes_and_concentration' do
+    let(:well1) { create(:pacbio_well, library_concentration: 100) }
+    let(:well2) { create(:pacbio_well, library_concentration: nil, on_plate_loading_concentration: 200) }
+    let(:plate) { build(:pacbio_plate, wells: [well1, well2]) }
+    let(:run) { create(:pacbio_generic_run, plates: [plate]) }
+    let(:barcodes_and_concentrations) { "#{well1.used_aliquots.first.source.tube.barcode} 100pM #{well2.used_aliquots.first.source.tube.barcode} 200pM" }
 
-      comment = run.wells.collect do |well|
-        concentration = well.library_concentration || well.on_plate_loading_concentration
-        " #{well.used_aliquots.first.source.tube.barcode} #{concentration}pM"
-      end.join(' ')
-      expect(run.comments).to eq("A Run Comment#{comment}")
+    it 'has the barcodes and concentration' do
+      expect(run.barcodes_and_concentrations).to eq(barcodes_and_concentrations)
     end
 
-    it 'can have the wells summary when no run comments exist' do
-      wells = create_list(:pacbio_well, 2)
-      plate = build(:pacbio_plate, wells:)
-      run = create(:pacbio_generic_run, plates: [plate], comments: nil)
-
-      comment = run.wells.collect do |well|
-        concentration = well.library_concentration || well.on_plate_loading_concentration
-        " #{well.used_aliquots.first.source.tube.barcode} #{concentration}pM"
-      end.join(' ')
-      expect(run.comments).to eq(comment)
+    # This is a deprecated method
+    it 'comments will be the same as barcodes_and_concentration' do
+      expect(run.comments).to eq(barcodes_and_concentrations)
     end
   end
 

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'RunsController' do
             'dna_control_complex_box_barcode' => run.dna_control_complex_box_barcode,
             'system_name' => run.system_name,
             'state' => run.state,
-            'comments' => run.comments,
+            'barcodes_and_concentrations' => run.barcodes_and_concentrations,
             'pacbio_smrt_link_version_id' => run.pacbio_smrt_link_version_id,
             'created_at' => run.created_at.to_fs(:us),
             'adaptive_loading' => run.adaptive_loading,
@@ -157,7 +157,7 @@ RSpec.describe 'RunsController' do
             'dna_control_complex_box_barcode' => run1.dna_control_complex_box_barcode,
             'system_name' => run1.system_name,
             'state' => run1.state,
-            'comments' => run1.comments,
+            'barcodes_and_concentrations' => run1.barcodes_and_concentrations,
             'pacbio_smrt_link_version_id' => run1.pacbio_smrt_link_version_id,
             'created_at' => run1.created_at.to_fs(:us),
             'adaptive_loading' => run1.adaptive_loading,
@@ -189,7 +189,7 @@ RSpec.describe 'RunsController' do
             'dna_control_complex_box_barcode' => run1.dna_control_complex_box_barcode,
             'system_name' => run1.system_name,
             'state' => run1.state,
-            'comments' => run1.comments,
+            'barcodes_and_concentrations' => run1.barcodes_and_concentrations,
             'pacbio_smrt_link_version_id' => run1.pacbio_smrt_link_version_id,
             'created_at' => run1.created_at.to_fs(:us),
             'adaptive_loading' => run1.adaptive_loading,
@@ -211,7 +211,6 @@ RSpec.describe 'RunsController' do
             attributes: {
               dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
               system_name: 'Sequel II',
-              comments: 'A Run Comment',
               pacbio_smrt_link_version_id: version11.id,
               plates_attributes: [{
                 sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -272,7 +271,7 @@ RSpec.describe 'RunsController' do
         expect(run.state).to be_present
         expect(run.dna_control_complex_box_barcode).to be_present
         expect(run.system_name).to be_present
-        expect(run.comments).to be_present
+        expect(run.barcodes_and_concentrations).to be_present
         expect(run.smrt_link_version).to be_present
         expect(run.smrt_link_version).to eq(version11)
         expect(run.pacbio_smrt_link_version_id).to eq(version11.id)
@@ -292,7 +291,6 @@ RSpec.describe 'RunsController' do
             attributes: {
               dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
               system_name: 'Sequel II',
-              comments: 'A Run Comment',
               pacbio_smrt_link_version_id: version12.id,
               plates_attributes: [{
                 sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -352,7 +350,7 @@ RSpec.describe 'RunsController' do
         expect(run.state).to be_present
         expect(run.dna_control_complex_box_barcode).to be_present
         expect(run.system_name).to be_present
-        expect(run.comments).to be_present
+        expect(run.barcodes_and_concentrations).to be_present
         expect(run.smrt_link_version).to be_present
         expect(run.smrt_link_version).to eq(version12)
         expect(run.pacbio_smrt_link_version_id).to eq(version12.id)
@@ -373,7 +371,6 @@ RSpec.describe 'RunsController' do
             attributes: {
               dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
               system_name: 'Sequel II',
-              comments: 'A Run Comment',
               pacbio_smrt_link_version_id: version13.id,
               plates_attributes: [{
                 sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -430,7 +427,7 @@ RSpec.describe 'RunsController' do
         expect(run.state).to be_present
         expect(run.dna_control_complex_box_barcode).to be_present
         expect(run.system_name).to be_present
-        expect(run.comments).to be_present
+        expect(run.barcodes_and_concentrations).to be_present
         expect(run.smrt_link_version).to be_present
         expect(run.smrt_link_version).to eq(version13)
         expect(run.pacbio_smrt_link_version_id).to eq(version13.id)
@@ -544,7 +541,6 @@ RSpec.describe 'RunsController' do
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
                 system_name: 'Sequel IIe',
-                comments: 'A Run Comment',
                 pacbio_smrt_link_version_id: version11.id,
                 plates_attributes: [{ wells_attributes: [] }]
               }
@@ -590,7 +586,6 @@ RSpec.describe 'RunsController' do
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
                 system_name: 'Sequel II',
-                comments: 'A Run Comment',
                 pacbio_smrt_link_version_id: version11.id,
                 plates_attributes: [{
                   sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -653,7 +648,6 @@ RSpec.describe 'RunsController' do
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
                 system_name: 'Sequel II',
-                comments: 'A Run Comment',
                 pacbio_smrt_link_version_id: version11.id,
                 plates_attributes: [{
                   sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -723,7 +717,6 @@ RSpec.describe 'RunsController' do
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
                 system_name: 'Sequel II',
-                comments: 'A Run Comment',
                 pacbio_smrt_link_version_id: version11.id,
                 plates_attributes: [{
                   sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -794,7 +787,6 @@ RSpec.describe 'RunsController' do
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
                 system_name: 'Sequel II',
-                comments: 'A Run Comment',
                 pacbio_smrt_link_version_id: version11.id,
                 plates_attributes: [{
                   sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -870,7 +862,6 @@ RSpec.describe 'RunsController' do
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
                 system_name: 'Sequel II',
-                comments: 'A Run Comment',
                 pacbio_smrt_link_version_id: version11.id,
                 plates_attributes: [{
                   sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -945,7 +936,6 @@ RSpec.describe 'RunsController' do
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
                 system_name: 'Sequel II',
-                comments: 'A Run Comment',
                 pacbio_smrt_link_version_id: version11.id,
                 plates_attributes: [{
                   sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -1027,7 +1017,6 @@ RSpec.describe 'RunsController' do
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
                 system_name: 'Sequel II',
-                comments: 'A Run Comment',
                 pacbio_smrt_link_version_id: version11.id,
                 plates_attributes: [{
                   sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -1106,7 +1095,6 @@ RSpec.describe 'RunsController' do
           attributes: {
             dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
             system_name: 'Sequel II',
-            comments: 'A Run Comment',
             plates_attributes: [{
               sequencing_kit_box_barcode: 'DM0001100861800123121',
               plate_number: 1,
@@ -1161,7 +1149,6 @@ RSpec.describe 'RunsController' do
           attributes: {
             dna_control_complex_box_barcode: 'Lxxxxx101717600123191',
             system_name: 'Sequel II',
-            comments: 'A Run Comment',
             pacbio_smrt_link_version_id: version10.id,
             plates_attributes: [{
               sequencing_kit_box_barcode: 'DM0001100861800123121',
@@ -1258,8 +1245,7 @@ RSpec.describe 'RunsController' do
               type: 'runs',
               attributes: {
                 dna_control_complex_box_barcode: 'Lxxxxx101717600123191_updated',
-                system_name: 'Sequel I',
-                comments: 'A Run Comment updated'
+                system_name: 'Sequel I'
               }
             }
           }.to_json
@@ -1282,7 +1268,6 @@ RSpec.describe 'RunsController' do
           run.reload
           expect(run.dna_control_complex_box_barcode).to eq 'Lxxxxx101717600123191_updated'
           expect(run.system_name).to eq 'Sequel I'
-          expect(run.comments).to eq 'A Run Comment updated'
           expect(run.state).to eq 'pending'
         end
 

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -1269,6 +1269,7 @@ RSpec.describe 'RunsController' do
           expect(run.dna_control_complex_box_barcode).to eq 'Lxxxxx101717600123191_updated'
           expect(run.system_name).to eq 'Sequel I'
           expect(run.state).to eq 'pending'
+          expect(run.barcodes_and_concentrations).to be_present
         end
 
         it_behaves_like 'publish_messages_on_update'


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

Previously we were inserting a space at the start of the barcodes and concentrations. I see no need to continue doing this but at the same time see no need to modify existing records.
