### PR TITLE
Y25-175 retention instruction in request attributes

### DIFF
--- a/app/models/ont/request.rb
+++ b/app/models/ont/request.rb
@@ -15,6 +15,7 @@ module Ont
     has_one :request, class_name: '::Request', as: :requestable, dependent: :nullify
     has_one :sample, through: :request
     delegate :name, to: :sample, prefix: :sample
+    delegate :retention_instruction, to: :sample, prefix: :sample
 
     validates :cost_code, presence: true
     validates :number_of_flowcells, numericality: { only_integer: true, greater_than: 0 }

--- a/app/models/pacbio/request.rb
+++ b/app/models/pacbio/request.rb
@@ -18,6 +18,7 @@ module Pacbio
 
     delegate :name, to: :sample, prefix: :sample
     delegate :species, to: :sample, prefix: :sample
+    delegate :retention_instruction, to: :sample, prefix: :sample
 
     validates :external_study_id, uuid: true
 

--- a/app/resources/v1/ont/request_resource.rb
+++ b/app/resources/v1/ont/request_resource.rb
@@ -27,16 +27,18 @@ module V1
       #   @return [String] the external study identifier
       # @!attribute [rw] number_of_flowcells
       #   @return [Integer] the number of flowcells requested
-      # @!attribute [rw] sample_name
+      attributes(*::Ont.request_attributes)
+
+      # @!attribute [r] sample_name
       #   @return [String] the name of the sample
-      # @!attribute [rw] source_identifier
-      #   @return [String] the source identifier of the request
-      # @!attribute [rw] created_at
-      #   @return [String] the creation timestamp of the request
-      # @!attribute [rw] sample_retention_instruction
+      # @!attribute [r] sample_retention_instruction
       #   @return [String] the retention instruction for the sample
-      attributes(*::Ont.request_attributes, :sample_name, :source_identifier, :created_at,
-                 :sample_retention_instruction)
+      # @!attribute [r] source_identifier
+      #   @return [String] the source identifier of the request
+      # @!attribute [r] created_at
+      #   @return [String] the creation timestamp of the request
+      attributes :sample_name, :sample_retention_instruction, :source_identifier, :created_at,
+                 readonly: true
 
       paginator :paged
 

--- a/app/resources/v1/ont/request_resource.rb
+++ b/app/resources/v1/ont/request_resource.rb
@@ -33,7 +33,10 @@ module V1
       #   @return [String] the source identifier of the request
       # @!attribute [rw] created_at
       #   @return [String] the creation timestamp of the request
-      attributes(*::Ont.request_attributes, :sample_name, :source_identifier, :created_at)
+      # @!attribute [rw] sample_retention_instruction
+      #   @return [String] the retention instruction for the sample
+      attributes(*::Ont.request_attributes, :sample_name, :source_identifier, :created_at,
+                 :sample_retention_instruction)
 
       paginator :paged
 

--- a/app/resources/v1/pacbio/request_resource.rb
+++ b/app/resources/v1/pacbio/request_resource.rb
@@ -66,8 +66,10 @@ module V1
       #   @return [String] the creation time of the request
       # @!attribute [rw] source_identifier
       #   @return [String] the source identifier of the request
+      # @!attribute [rw] sample_retention_instrction
+      #   @return [String] the retention instruction of the request
       attributes(*::Pacbio.request_attributes, :sample_name, :barcode, :sample_species,
-                 :created_at, :source_identifier)
+                 :created_at, :source_identifier, :sample_retention_instruction)
 
       # If we don't specify the relation_name here, jsonapi-resources
       # attempts to use_related_resource_records_for_joins

--- a/app/resources/v1/pacbio/request_resource.rb
+++ b/app/resources/v1/pacbio/request_resource.rb
@@ -56,20 +56,23 @@ module V1
       #   @return [String] the cost code
       # @!attribute [rw] external_study_id
       #   @return [String] the external study ID
-      # @!attribute [rw] sample_name
+      attributes(*::Pacbio.request_attributes)
+
+      # @!attribute [r] sample_name
       #   @return [String] the name of the sample
-      # @!attribute [rw] barcode
+      # @!attribute [r] barcode
       #   @return [String] the barcode of the sample
-      # @!attribute [rw] sample_species
+      # @!attribute [r] sample_species
       #   @return [String] the species of the sample
-      # @!attribute [rw] created_at
+      # @!attribute [r] created_at
       #   @return [String] the creation time of the request
-      # @!attribute [rw] source_identifier
+      # @!attribute [r] source_identifier
       #   @return [String] the source identifier of the request
-      # @!attribute [rw] sample_retention_instrction
+      # @!attribute [r] sample_retention_instrction
       #   @return [String] the retention instruction of the request
-      attributes(*::Pacbio.request_attributes, :sample_name, :barcode, :sample_species,
-                 :created_at, :source_identifier, :sample_retention_instruction)
+      attributes :sample_name, :barcode, :sample_species,
+                 :created_at, :source_identifier, :sample_retention_instruction,
+                 readonly: true
 
       # If we don't specify the relation_name here, jsonapi-resources
       # attempts to use_related_resource_records_for_joins

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -115,7 +115,7 @@ module V1
     end
 
     def publish_message(message, config)
-       Messages.publish(message, config)
+      Messages.publish(message, config)
     end
   end
 end

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -115,7 +115,7 @@ module V1
     end
 
     def publish_message(message, config)
-      # Messages.publish(message, config)
+       Messages.publish(message, config)
     end
   end
 end

--- a/app/resources/v1/reception_resource.rb
+++ b/app/resources/v1/reception_resource.rb
@@ -115,7 +115,7 @@ module V1
     end
 
     def publish_message(message, config)
-      Messages.publish(message, config)
+      # Messages.publish(message, config)
     end
   end
 end

--- a/spec/requests/v1/ont/requests_spec.rb
+++ b/spec/requests/v1/ont/requests_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe 'Ont::RequestsController', :ont do
               'data_type' => request.data_type.name,
               'created_at' => request.created_at.to_fs(:us),
               'sample_name' => request.sample_name,
-              'source_identifier' => request.source_identifier
+              'source_identifier' => request.source_identifier,
+              'sample_retention_instruction' => request.sample_retention_instruction
             )
           end
         end
@@ -116,7 +117,8 @@ RSpec.describe 'Ont::RequestsController', :ont do
               'data_type' => request.data_type.name,
               'created_at' => request.created_at.to_fs(:us),
               'sample_name' => request.sample_name,
-              'source_identifier' => request.source_identifier
+              'source_identifier' => request.source_identifier,
+              'sample_retention_instruction' => request.sample_retention_instruction
             )
           end
         end
@@ -138,7 +140,8 @@ RSpec.describe 'Ont::RequestsController', :ont do
               'data_type' => request.data_type.name,
               'created_at' => request.created_at.to_fs(:us),
               'sample_name' => request.sample_name,
-              'source_identifier' => request.source_identifier
+              'source_identifier' => request.source_identifier,
+              'sample_retention_instruction' => request.sample.retention_instruction
             )
           end
         end
@@ -166,7 +169,8 @@ RSpec.describe 'Ont::RequestsController', :ont do
               'data_type' => request.data_type.name,
               'created_at' => request.created_at.to_fs(:us),
               'sample_name' => request.sample_name,
-              'source_identifier' => request.source_identifier
+              'source_identifier' => request.source_identifier,
+              'sample_retention_instruction' => request.sample_retention_instruction
             )
           end
         end

--- a/spec/requests/v1/pacbio/plates_spec.rb
+++ b/spec/requests/v1/pacbio/plates_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe 'PlatesController' do
         expect(request_data['attributes']['external_study_id']).to eq(request.external_study_id)
         expect(request_data['attributes']['sample_name']).to eq(request.sample_name)
         expect(request_data['attributes']['sample_species']).to eq(request.sample_species)
+        expect(request_data['attributes']['sample_retention_instruction']).to eq(request.sample_retention_instruction)
       end
     end
 

--- a/spec/requests/v1/pacbio/requests_spec.rb
+++ b/spec/requests/v1/pacbio/requests_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe 'RequestsController', :pacbio do
           'sample_name' => request.sample.name,
           'sample_species' => request.sample.species,
           'source_identifier' => request.source_identifier,
-          'created_at' => request.created_at.to_fs(:us)
+          'created_at' => request.created_at.to_fs(:us),
+          'sample_retention_instruction' => request.sample.retention_instruction
         )
       end
     end
@@ -68,7 +69,8 @@ RSpec.describe 'RequestsController', :pacbio do
               'sample_name' => request.sample.name,
               'sample_species' => request.sample.species,
               'source_identifier' => request.source_identifier,
-              'created_at' => request.created_at.to_fs(:us)
+              'created_at' => request.created_at.to_fs(:us),
+              'sample_retention_instruction' => request.sample.retention_instruction
             )
           end
         end
@@ -94,7 +96,8 @@ RSpec.describe 'RequestsController', :pacbio do
               'sample_name' => request.sample.name,
               'sample_species' => request.sample.species,
               'source_identifier' => request.source_identifier,
-              'created_at' => request.created_at.to_fs(:us)
+              'created_at' => request.created_at.to_fs(:us),
+              'sample_retention_instruction' => request.sample.retention_instruction
             )
           end
         end
@@ -117,7 +120,8 @@ RSpec.describe 'RequestsController', :pacbio do
               'sample_name' => request.sample.name,
               'sample_species' => request.sample.species,
               'source_identifier' => request.source_identifier,
-              'created_at' => request.created_at.to_fs(:us)
+              'created_at' => request.created_at.to_fs(:us),
+              'sample_retention_instruction' => request.sample.retention_instruction
             )
           end
         end
@@ -141,7 +145,8 @@ RSpec.describe 'RequestsController', :pacbio do
               'sample_name' => request.sample.name,
               'sample_species' => request.sample.species,
               'source_identifier' => request.source_identifier,
-              'created_at' => request.created_at.to_fs(:us)
+              'created_at' => request.created_at.to_fs(:us),
+              'sample_retention_instruction' => request.sample.retention_instruction
             )
           end
         end
@@ -185,7 +190,8 @@ RSpec.describe 'RequestsController', :pacbio do
               'sample_name' => request.sample.name,
               'sample_species' => request.sample.species,
               'source_identifier' => request.source_identifier,
-              'created_at' => request.created_at.to_fs(:us)
+              'created_at' => request.created_at.to_fs(:us),
+              'sample_retention_instruction' => request.sample.retention_instruction
             )
           end
         end


### PR DESCRIPTION
Closes https://github.com/sanger/traction-ui/issues/2234

#### Changes proposed in this pull request

This pull request introduces support for handling the `sample_retention_instruction` attribute across both ONT and PacBio requests. The changes include updates to models, API resources, and test cases to ensure the new attribute is properly integrated and validated

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
