### PR TITLE
Y25-344 - Adapter 2 includes oligo_reverse attribute on sample sheet

### DIFF
--- a/app/exchanges/run_csv/pacbio_sample_sheet.rb
+++ b/app/exchanges/run_csv/pacbio_sample_sheet.rb
@@ -91,7 +91,7 @@ module RunCsv
         bio_sample_name(sample),
         well.plate_well_position,
         sample.adapter, # left adapter
-        sample.adapter  # right adapter
+        sample.library&.tag&.oligo_reverse.presence || sample.adapter # right adapter
       ]
     end
 


### PR DESCRIPTION
Closes #1624 

#### Changes proposed in this pull request

- If the `oligo_reverse` attribute is present on the linked tag, it will be used as the value for the adapter 2 field on the sample sheet

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
