### PR TITLE
fix: update adapter_1 method to use '_F' suffix and adjust related spec

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -18,10 +18,14 @@ class Tag < ApplicationRecord
                                      case_sensitive: false }
 
   def adapter_1
-    "#{group_id}#{'_L' if oligo_reverse.present?}"
+    "#{group_id}#{'_F' if oligo_reverse.present?}"
   end
 
   def adapter_2
     "#{group_id}#{'_R' if oligo_reverse.present?}"
+  end
+
+  def asymmetric?
+    oligo_reverse.present?
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Tag do
 
   it 'can have an adapter_1 and adapter_2' do
     tag = create(:tag, group_id: '1', oligo_reverse: 'CGATCGAATAT')
-    expect(tag.adapter_1).to eq('1_L')
+    expect(tag.adapter_1).to eq('1_F')
     expect(tag.adapter_2).to eq('1_R')
   end
 


### PR DESCRIPTION
Closes N/A

#### Changes proposed in this pull request

- Modified the adapter_1 field to use '_F' instead of '_L' (mistype)

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
