### PR TITLE
refactor: modified the behaviour of "same barcodes on both ends of sequence"

### DIFF
--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -205,7 +205,7 @@ module Pacbio
     # Returns True if tagged, nil otherwise
     # See Aliquot#adapter field method below and adapter and adapter2 fields in pacbio.yml
     def same_barcodes_on_both_ends_of_sequence
-      tagged? || nil
+      tags.empty? || base_used_aliquots.first&.tag&.oligo_reverse.nil?
     end
 
     # Set the automation parameters

--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -205,7 +205,9 @@ module Pacbio
     # Returns True if tagged, nil otherwise
     # See Aliquot#adapter field method below and adapter and adapter2 fields in pacbio.yml
     def same_barcodes_on_both_ends_of_sequence
-      tags.empty? || base_used_aliquots.first&.tag&.oligo_reverse.nil?
+      return nil unless tagged?
+
+      base_used_aliquots.first&.tag&.oligo_reverse.nil?
     end
 
     # Set the automation parameters

--- a/app/models/pacbio/well.rb
+++ b/app/models/pacbio/well.rb
@@ -202,7 +202,7 @@ module Pacbio
     end
 
     # Are the left and right adapters the same?
-    # Returns True if tagged, nil otherwise
+    # Returns true if tagged, false if tagged with an asymmetric tag, nil otherwise
     # See Aliquot#adapter field method below and adapter and adapter2 fields in pacbio.yml
     def same_barcodes_on_both_ends_of_sequence
       return nil unless tagged?

--- a/spec/exchanges/run_csv/pacbio_sample_sheet_spec.rb
+++ b/spec/exchanges/run_csv/pacbio_sample_sheet_spec.rb
@@ -298,6 +298,13 @@ RSpec.describe RunCsv::PacbioSampleSheet, type: :model do
           expect(sample_row[2]).to end_with('_F') # Adapter
           expect(sample_row[3]).to end_with('_R') # Adapter2
         end
+
+        it 'the "Same Barcodes on Both Ends of Sequence" field is false' do
+          smrt_cell_settings = parsed_sample_sheet['SMRT Cell Settings']
+          smrt_cell_settings.each_value do |well_settings|
+            expect(well_settings['Same Barcodes on Both Ends of Sequence']).to be(false)
+          end
+        end
       end
     end
   end

--- a/spec/models/pacbio/well_spec.rb
+++ b/spec/models/pacbio/well_spec.rb
@@ -711,6 +711,27 @@ RSpec.describe Pacbio::Well, :pacbio do
           expect(well.same_barcodes_on_both_ends_of_sequence).to be_nil
         end
       end
+
+      context 'when the well contains a tag from an asymmetric tag set' do
+        let(:oligo_reverse) { 'ACGTACGT' }
+        let(:tag) { create(:tag, oligo_reverse: oligo_reverse) }
+        let(:library) { create(:pacbio_library, tag: tag) }
+        let(:well) do
+          create(
+            :pacbio_well,
+            pre_extension_time: 2,
+            generate_hifi: 'In SMRT Link',
+            ccs_analysis_output: 'Yes',
+            row: 'A',
+            column: 1,
+            libraries: [library]
+          )
+        end
+
+        it 'returns false' do
+          expect(well.same_barcodes_on_both_ends_of_sequence).to be false
+        end
+      end
     end
 
     context 'position_leading_zero' do


### PR DESCRIPTION
Closes N/A

#### Changes proposed in this pull request

- Instead of returning true or false depending on whether or not aliquots are tagged, the method will now return nil if not tagged, or true or false depending on whether or not the tag set linked in asymmetric.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
