### PR TITLE
Y25-451 - Fixed validation when sequencing kit box barcode is reused in the same run

### DIFF
--- a/app/validators/sequencing_kit_box_barcode_validator.rb
+++ b/app/validators/sequencing_kit_box_barcode_validator.rb
@@ -48,10 +48,15 @@ class SequencingKitBoxBarcodeValidator < ActiveModel::Validator
   # @param [Array<Plate>] existing_plates
   # For a given sequencing kit box barcode, check if the positions have already been used
   def validate_sequencing_kit_box_barcode_positions(record, existing_plates)
+    relevant_plates = existing_plates.reject do |plate|
+      plate.pacbio_run_id == record.pacbio_run_id
+    end
+
     # filter wells based on exclusions
     record_wells = filtered(record.wells)
+
     # Get the common positions between the existing plates and the record wells
-    common_positions = existing_plates.map(&:wells).flatten.map(&:position) &
+    common_positions = relevant_plates.map(&:wells).flatten.map(&:position) &
                        record_wells.map(&:position)
     return unless common_positions.any?
 

--- a/spec/validators/sequencing_kit_box_barcode_validator_spec.rb
+++ b/spec/validators/sequencing_kit_box_barcode_validator_spec.rb
@@ -43,4 +43,16 @@ RSpec.describe SequencingKitBoxBarcodeValidator do
     new_pacbio_run = create(:pacbio_generic_run, system_name: 'Sequel IIe', plates: [build(:pacbio_plate, plate_number: 1, sequencing_kit_box_barcode: '1234', wells: [build(:pacbio_well, row: 'A', column: '1')])])
     expect(new_pacbio_run.plates.first).to be_valid
   end
+
+  it 'no errors when plates in the same run have the same sequencing_kit_box_barcode' do
+    run = create(:pacbio_generic_run, system_name: 'Revio', plates: [
+      build(:pacbio_plate, plate_number: 1, sequencing_kit_box_barcode: '1234', wells: [build(:pacbio_well, row: 'A', column: '1')]),
+      build(:pacbio_plate, plate_number: 2, sequencing_kit_box_barcode: '1234', wells: [build(:pacbio_well, row: 'A', column: '1')])
+    ])
+    run.plates.first.update(sequencing_kit_box_barcode: '1234')
+    run.plates.second.update(sequencing_kit_box_barcode: '1234')
+    run.save
+
+    expect(run.errors).to be_empty
+  end
 end


### PR DESCRIPTION
Closes https://github.com/sanger/traction-ui/issues/2397

#### Changes proposed in this pull request

- The validator will exclude plates within the same run when validating the `sequencing_kit_box_barcode` when updating the run
- Added a test for checking that the validator allows for having the same `sequencing_kit_box_barcode` for plates within the same run

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
