### PR TITLE
[dev] Add ostruct gem to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'bunny'
 gem 'csv'
 gem 'exception_notification'
 gem 'mysql2'
+gem 'ostruct' # No longer part of the default gems in Ruby 3.5. Needed for pry
 gem 'puma' # Use Puma as the app server
 gem 'rack-cors' # Use Rack CORS for handling CORS, making cross-origin AJAX possible
 gem 'rack-session' # Use Rack Session for session management. Needed for flipper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
     nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -365,6 +366,7 @@ DEPENDENCIES
   flipper-ui
   listen
   mysql2
+  ostruct
   pry-rails
   puma
   rack-cors


### PR DESCRIPTION
Handles this warning on `bundle install`:

```
/Users/xxx/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/pry-0.14.2/lib/pry/command_state.rb:3: warning: /Users/xxx/.rbenv/versions/3.4.5/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of pry-0.14.2 to request adding ostruct into its gemspec.
/Users/xxx/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/pry-0.14.2/lib/pry/command_state.rb:3: warning: /Users/xxx/.rbenv/versions/3.4.5/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of pry-0.14.2 to request adding ostruct into its gemspec.
```

#### Changes proposed in this pull request

- Add `ostruct` gem to gemfile

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
