### PR TITLE
deps: bump pry to 0.15.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.4.0)
-    pry (0.14.2)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-rails (0.3.11)


### PR DESCRIPTION
#### Changes proposed in this pull request

- Bumps pry from 0.14.2 to 0.15.2 

#### Additional context
Solves ostruct warnings 
```
/Users/xxx/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/pry-0.14.2/lib/pry/command_state.rb:3: warning: /Users/xxx/.rbenv/versions/3.4.5/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of pry-0.14.2 to request adding ostruct into its gemspec.
/Users/xxx/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/pry-0.14.2/lib/pry/command_state.rb:3: warning: /Users/xxx/.rbenv/versions/3.4.5/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of pry-0.14.2 to request adding ostruct into its gemspec.
```
See https://github.com/pry/pry/issues/2328