### PR TITLE
Y25-319 - [PR][Traction] Use sanger-jsonapi-resources version 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'puma' # Use Puma as the app server
 gem 'rack-cors' # Use Rack CORS for handling CORS, making cross-origin AJAX possible
 gem 'rack-session' # Use Rack Session for session management. Needed for flipper
 gem 'rails', '~> 8.0.2'
-gem 'sanger-jsonapi-resources', '~> 0.2.0'
+gem 'sanger-jsonapi-resources', '~> 0.2.1'
 gem 'syslog' # No longer part of the default gems in Ruby 3.4
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.9)
+    nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     parallel (1.27.0)
@@ -306,7 +306,7 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
-    sanger-jsonapi-resources (0.2.0)
+    sanger-jsonapi-resources (0.2.1)
       activerecord (>= 5.1)
       concurrent-ruby
       railties (>= 5.1)
@@ -376,7 +376,7 @@ DEPENDENCIES
   rubocop-factory_bot
   rubocop-rails
   rubocop-rspec
-  sanger-jsonapi-resources (~> 0.2.0)
+  sanger-jsonapi-resources (~> 0.2.1)
   shoulda-matchers
   spring
   spring-watcher-listen

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -24,12 +24,4 @@ class JSONAPI::ActiveRelationResource
     Arel.sql("#{concat_table_field(table, field, quoted)} AS #{alias_table_field(table, field, quoted)}")
   end
 end
-
-# TODO: This is a temporary fix to allow the use of 422 Unprocessable Entity status code
-# in JSONAPI::Resources. This should be removed once the issue is resolved in the
-# JSONAPI::Resources gem.
-# See:
-# https://github.com/cerebris/jsonapi-resources/issues/1456
-Rack::Utils::SYMBOL_TO_STATUS_CODE[:unprocessable_entity] = 422
-
 # rubocop:enable


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Use sanger-jsonapi-resources version 0.2.1 .
- Remove the patch for the missing Rack symbol.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
