### PR TITLE
Y25-570 - adds ONT SQK-RPB tag set

### DIFF
--- a/lib/tasks/create_tags.rake
+++ b/lib/tasks/create_tags.rake
@@ -31,6 +31,7 @@ namespace :tags do
       Rake::Task['tags:create:SQK-NBD114.96'].invoke
       Rake::Task['tags:create:SQK-RBK114.96'].invoke
       Rake::Task['tags:create:SQK-PCB114.24'].invoke
+      Rake::Task['tags:create:SQK-RPB114.24'].invoke
     end
 
     desc 'Create pacbio sequel tags'
@@ -1427,6 +1428,42 @@ namespace :tags do
         set.tags.find_or_create_by!(tag_attributes)
       end
       puts '-> SQK-PCB114.24 tags successfully created'
+    end
+
+    task 'SQK-RPB114.24': :environment do
+      puts '-> Creating SQK-RPB114.24 tag set and tags'
+      set = TagSet.ont_pipeline
+                  .find_or_create_by!(name: 'SQK-RPB114.24')
+      puts '-> Tag Set successfully created'
+      [
+        { group_id: 'RLB01', oligo: 'AAGAAAGTTGTCGGTGTCTTTGTG' },
+        { group_id: 'RLB02', oligo: 'TCGATTCCGTTTGTAGTCGTCTGT' },
+        { group_id: 'RLB03', oligo: 'GAGTCTTGTGTCCCAGTTACCAGG' },
+        { group_id: 'RLB04', oligo: 'TTCGGATTCTATCGTGTTTCCCTA' },
+        { group_id: 'RLB05', oligo: 'CTTGTCCAGGGTTTGTGTAACCTT' },
+        { group_id: 'RLB06', oligo: 'TTCTCGCAAAGGCAGAAAGTAGTC' },
+        { group_id: 'RLB07', oligo: 'GTGTTACCGTGGGAATGAATCCTT' },
+        { group_id: 'RLB08', oligo: 'TTCAGGGAACAAACCAAGTTACGT' },
+        { group_id: 'RLB09', oligo: 'AACTAGGCACAGCGAGTCTTGGTT' },
+        { group_id: 'RLB10', oligo: 'AAGCGTTGAAACCTTTGTCCTCTC' },
+        { group_id: 'RLB11', oligo: 'GTTTCATCTATCGGAGGGAATGGA' },
+        { group_id: 'RLB12A', oligo: 'GTTGAGTTACAAAGCACCGATCAG' },
+        { group_id: 'RLB13', oligo: 'AGAACGACTTCCATACTCGTGTGA' },
+        { group_id: 'RLB14', oligo: 'AACGAGTCTCTTGGGACCCATAGA' },
+        { group_id: 'RLB15', oligo: 'AGGTCTACCTCGCTAACACCACTG' },
+        { group_id: 'RLB16', oligo: 'CGTCAACTGACAGTGGTTCGTACT' },
+        { group_id: 'RLB17', oligo: 'ACCCTCCAGGAAAGTACCTCTGAT' },
+        { group_id: 'RLB18', oligo: 'CCAAACCCAACAACCTAGATAGGC' },
+        { group_id: 'RLB19', oligo: 'GTTCCTCGTGCAGTGTCAAGAGAT' },
+        { group_id: 'RLB20', oligo: 'TTGCGTCCTGTTACGAGAACTCAT' },
+        { group_id: 'RLB21', oligo: 'GAGCCTCTCATTGTCCGTTCTCTA' },
+        { group_id: 'RLB22', oligo: 'ACCACTGCCATGTATCAAAGTACG' },
+        { group_id: 'RLB23', oligo: 'CTTACTACCCAGTGAACCTCCTCG' },
+        { group_id: 'RLB24', oligo: 'GCATAGTTCTGCATGATGGGTTAG' }
+      ].each do |tag_attributes|
+        set.tags.find_or_create_by!(tag_attributes)
+      end
+      puts '-> SQK-RPB114.24 tags successfully created'
     end
   end
 

--- a/spec/lib/tasks/create_tags.rake_spec.rb
+++ b/spec/lib/tasks/create_tags.rake_spec.rb
@@ -61,9 +61,12 @@ RSpec.describe 'RakeTasks' do
           -> Creating SQK-PCB114.24 tag set and tags
           -> Tag Set successfully created
           -> SQK-PCB114.24 tags successfully created
+          -> Creating SQK-RPB114.24 tag set and tags
+          -> Tag Set successfully created
+          -> SQK-RPB114.24 tags successfully created
         HEREDOC
       ).to_stdout
-      expect(TagSet.count).to eq(3)
+      expect(TagSet.count).to eq(4)
     end
 
     it 'creates all of the tag sets' do
@@ -113,9 +116,12 @@ RSpec.describe 'RakeTasks' do
           -> Creating SQK-PCB114.24 tag set and tags
           -> Tag Set successfully created
           -> SQK-PCB114.24 tags successfully created
+          -> Creating SQK-RPB114.24 tag set and tags
+          -> Tag Set successfully created
+          -> SQK-RPB114.24 tags successfully created
         HEREDOC
       ).to_stdout
-      expect(TagSet.count).to eq(14)
+      expect(TagSet.count).to eq(15)
     end
   end
 end

--- a/spec/lib/tasks/ont_data.rake_spec.rb
+++ b/spec/lib/tasks/ont_data.rake_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'RakeTasks' do
     let(:expected_tubes) { 2 }
     let(:expected_single_plexed_pools) { 5 }
     let(:expected_multi_plexed_pools) { 10 }
-    let(:expected_tag_sets) { 1 }
+    let(:expected_tag_sets) { 4 }
     let(:expected_wells) { expected_plates * filled_wells_per_plate }
     let(:expected_requests) { expected_tubes + expected_wells }
     let(:expected_runs) { 6 }
@@ -44,6 +44,7 @@ RSpec.describe 'RakeTasks' do
         .and change(Ont::Library, :count)
         .and change(Ont::Instrument, :count)
         .and change(Ont::MinKnowVersion, :count)
+        .and change(TagSet, :count).by(expected_tag_sets)
         .and output(
           "-> Created requests for #{expected_plates} plates and #{expected_tubes} tubes\n" \
           "-> Creating SQK-NBD114.96 tag set and tags\n" \
@@ -55,6 +56,9 @@ RSpec.describe 'RakeTasks' do
           "-> Creating SQK-PCB114.24 tag set and tags\n" \
           "-> Tag Set successfully created\n" \
           "-> SQK-PCB114.24 tags successfully created\n" \
+          "-> Creating SQK-RPB114.24 tag set and tags\n" \
+          "-> Tag Set successfully created\n" \
+          "-> SQK-RPB114.24 tags successfully created\n" \
           "-> Created #{expected_single_plexed_pools} single plexed pools\n" \
           "-> Created #{expected_multi_plexed_pools} multiplexed pools\n" \
           "-> ONT Instruments successfully created\n" \


### PR DESCRIPTION
Closes #https://github.com/sanger/sequencescape/issues/5241

This tag set will also need manual addition in sequencescape.

#### Changes proposed in this pull request

- Adds SQK-RPB tag set


#### Additional context
Tags taken from provided fasta file and https://nanoporetech.com/document/rapid-sequencing-dna-v14-pcr-barcoding-sqk-rpb114-24#:~:text=to%20reagent%20stability.-,Rapid%20Barcode%20Primers,-Component 
