### PR TITLE
Y25584 - fix: change status from unprocessable_entity to unprocessable_content in controllers and specs

### DIFF
--- a/app/controllers/v1/pacbio/requests_controller.rb
+++ b/app/controllers/v1/pacbio/requests_controller.rb
@@ -10,7 +10,7 @@ module V1
         pipeline_request.destroy
         head :no_content
       rescue StandardError => e
-        render json: { data: { errors: e.message } }, status: :unprocessable_entity
+        render json: { data: { errors: e.message } }, status: :unprocessable_content
       end
 
       # Permitted parameters for create and edit actions

--- a/app/controllers/v1/pacbio/runs/plates_controller.rb
+++ b/app/controllers/v1/pacbio/runs/plates_controller.rb
@@ -11,7 +11,7 @@ module V1
             render_json(:created)
           else
             render json: { data: { errors: @plate.errors.messages } },
-                   status: :unprocessable_entity
+                   status: :unprocessable_content
           end
         end
 
@@ -19,14 +19,14 @@ module V1
           plate.update(params_names)
           render_json(:ok)
         rescue StandardError => e
-          render json: { data: { errors: e.message } }, status: :unprocessable_entity
+          render json: { data: { errors: e.message } }, status: :unprocessable_content
         end
 
         def destroy
           plate.destroy
           head :no_content
         rescue StandardError => e
-          render json: { data: { errors: e.message } }, status: :unprocessable_entity
+          render json: { data: { errors: e.message } }, status: :unprocessable_content
         end
 
         private

--- a/app/controllers/v1/pacbio/runs_controller.rb
+++ b/app/controllers/v1/pacbio/runs_controller.rb
@@ -17,7 +17,7 @@ module V1
                     disposition: "attachment; filename=#{run.name}.csv"
         rescue Version::Error => e
           # generate_sample_sheet will raise a Version::Error if the version cannot be found
-          render json: { error: e.message }, status: :unprocessable_entity
+          render json: { error: e.message }, status: :unprocessable_content
         end
       end
     end

--- a/app/controllers/v1/tags_controller.rb
+++ b/app/controllers/v1/tags_controller.rb
@@ -9,7 +9,7 @@ module V1
         head :created
       else
         render json: { data: { errors: @tag.errors.messages } },
-               status: :unprocessable_entity
+               status: :unprocessable_content
       end
     end
 
@@ -17,14 +17,14 @@ module V1
       tag.update(params_names)
       render_json(:ok)
     rescue StandardError => e
-      render json: { data: { errors: e.message } }, status: :unprocessable_entity
+      render json: { data: { errors: e.message } }, status: :unprocessable_content
     end
 
     def destroy
       tag.destroy
       head :no_content
     rescue StandardError => e
-      render json: { data: { errors: e.message } }, status: :unprocessable_entity
+      render json: { data: { errors: e.message } }, status: :unprocessable_content
     end
 
     private

--- a/app/validators/qc_receptions_factory_validator.rb
+++ b/app/validators/qc_receptions_factory_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Failed validations return unprocessable_entity
+# Failed validations return unprocessable_content
 # These are being validated before any entity is created
 class QcReceptionsFactoryValidator < ActiveModel::Validator
   def validate(record)

--- a/app/validators/qc_results_upload_validator.rb
+++ b/app/validators/qc_results_upload_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Failed validations return unprocessable_entity
+# Failed validations return unprocessable_content
 # These are being validated before any QC entity is created
 class QcResultsUploadValidator < ActiveModel::Validator
   def validate(record)

--- a/app/validators/well_validator.rb
+++ b/app/validators/well_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Failed validations return unprocessable_entity
+# Failed validations return unprocessable_content
 class WellValidator < ActiveModel::Validator
   def validate(record)
     return unless record.base_used_aliquots.many?

--- a/spec/requests/v1/data_types_spec.rb
+++ b/spec/requests/v1/data_types_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'DataTypesController' do
 
         it 'can returns unprocessable entity status' do
           post v1_data_types_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a data type' do
@@ -135,7 +135,7 @@ RSpec.describe 'DataTypesController' do
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
-        it 'has a ok unprocessable_entity' do
+        it 'has a ok unprocessable_content' do
           patch v1_data_type_path(123), params: body, headers: json_api_headers
           expect(response).to have_http_status(:not_found)
         end

--- a/spec/requests/v1/library_types_spec.rb
+++ b/spec/requests/v1/library_types_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'LibraryTypesController' do
 
         it 'can returns unprocessable entity status' do
           post v1_library_types_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a library type' do
@@ -137,7 +137,7 @@ RSpec.describe 'LibraryTypesController' do
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
-        it 'has a ok unprocessable_entity' do
+        it 'has a ok unprocessable_content' do
           patch v1_library_type_path(123), params: body, headers: json_api_headers
           expect(response).to have_http_status(:not_found)
         end

--- a/spec/requests/v1/ont/pools_spec.rb
+++ b/spec/requests/v1/ont/pools_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'PoolsController', :ont do
 
         it 'returns unprocessable entity status' do
           post v1_ont_pools_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a pool' do
@@ -242,7 +242,7 @@ RSpec.describe 'PoolsController', :ont do
 
         it 'returns unprocessable entity' do
           post v1_ont_pools_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a pool' do
@@ -368,7 +368,7 @@ RSpec.describe 'PoolsController', :ont do
         end
 
         it 'returns unprocessable entity status' do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not update a pool' do

--- a/spec/requests/v1/ont/requests_spec.rb
+++ b/spec/requests/v1/ont/requests_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe 'Ont::RequestsController', :ont do
 
     it 'returns unprocessable entity status' do
       patch v1_ont_request_path(request), params: body, headers: json_api_headers
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it 'does not publish the message' do

--- a/spec/requests/v1/ont/runs_spec.rb
+++ b/spec/requests/v1/ont/runs_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'RunsController' do
       end
 
       it 'returns an error response' do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'returns failure response' do
@@ -162,7 +162,7 @@ RSpec.describe 'RunsController' do
       it 'does not publish the message' do
         expect(Messages).not_to receive(:publish).with(instance_of(Ont::Run), having_attributes(pipeline: 'ont'))
         post v1_ont_runs_path, params: body, headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity), response.body
+        expect(response).to have_http_status(:unprocessable_content), response.body
       end
     end
   end
@@ -298,7 +298,7 @@ RSpec.describe 'RunsController' do
       end
 
       it 'returns an error response' do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'does not create a run' do
@@ -332,7 +332,7 @@ RSpec.describe 'RunsController' do
         it 'does not be published' do
           expect(Messages).not_to receive(:publish).with(instance_of(Ont::Run), having_attributes(pipeline: 'ont'))
           patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity), response.body
+          expect(response).to have_http_status(:unprocessable_content), response.body
         end
       end
     end
@@ -363,7 +363,7 @@ RSpec.describe 'RunsController' do
       it 'returns errors' do
         post v1_ont_runs_path, params: body, headers: json_api_headers
 
-        expect(response).to have_http_status(:unprocessable_entity), response.body
+        expect(response).to have_http_status(:unprocessable_content), response.body
 
         titles = json['errors'].pluck('title')
         expect(titles).to include("position x#{attr2[:position]} is duplicated in the same run")
@@ -397,7 +397,7 @@ RSpec.describe 'RunsController' do
       it 'returns errors' do
         patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: json_api_headers
 
-        expect(response).to have_http_status(:unprocessable_entity), response.body
+        expect(response).to have_http_status(:unprocessable_content), response.body
 
         titles = json['errors'].pluck('title')
         expect(titles).to include("flowcell_id #{attr3[:flowcell_id]} at position x#{attr3[:position]} is duplicated in the same run")

--- a/spec/requests/v1/pacbio/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/libraries_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe 'LibrariesController', :pacbio do
 
         it 'returns unprocessable entity status' do
           post v1_pacbio_libraries_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a library' do
@@ -435,7 +435,7 @@ RSpec.describe 'LibrariesController', :pacbio do
 
         it 'returns unprocessable entity status' do
           post v1_pacbio_libraries_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a library' do
@@ -567,7 +567,7 @@ RSpec.describe 'LibrariesController', :pacbio do
       end
 
       it 'returns unprocessable entity status' do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'does not update the library' do
@@ -613,7 +613,7 @@ RSpec.describe 'LibrariesController', :pacbio do
       end
 
       it 'returns unprocessable entity status' do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'does not update the library' do

--- a/spec/requests/v1/pacbio/library_batches_spec.rb
+++ b/spec/requests/v1/pacbio/library_batches_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'LibraryBatchesController', :pacbio do
 
         it 'returns unprocessable entity status' do
           post v1_pacbio_library_batches_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('libraries.insert_size - is not a number')
         end
 

--- a/spec/requests/v1/pacbio/pools_spec.rb
+++ b/spec/requests/v1/pacbio/pools_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe 'PoolsController', :pacbio do
 
       it 'returns unprocessable entity status' do
         post v1_pacbio_pools_path, params: body, headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'cannot create a pool' do
@@ -357,7 +357,7 @@ RSpec.describe 'PoolsController', :pacbio do
 
       it 'returns unprocessable entity status' do
         post v1_pacbio_pools_path, params: body, headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("primary_aliquot.volume - can't be blank")
       end
 
@@ -502,7 +502,7 @@ RSpec.describe 'PoolsController', :pacbio do
 
       it 'returns unprocessable entity status' do
         post v1_pacbio_pools_path, params: body, headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'cannot create a pool' do
@@ -694,7 +694,7 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'returns unprocessable entity status' do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'does not update a pool' do

--- a/spec/requests/v1/pacbio/requests_spec.rb
+++ b/spec/requests/v1/pacbio/requests_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe 'RequestsController', :pacbio do
     context 'on failure' do
       it 'does not delete the request' do
         delete "#{v1_pacbio_requests_path}/fakerequest", headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'has an error message' do
@@ -359,7 +359,7 @@ RSpec.describe 'RequestsController', :pacbio do
 
     it 'returns unprocessable entity status' do
       patch v1_pacbio_request_path(request), params: body, headers: json_api_headers
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it 'does not publish the message' do

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -469,9 +469,9 @@ RSpec.describe 'RunsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
@@ -569,9 +569,9 @@ RSpec.describe 'RunsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
@@ -623,9 +623,9 @@ RSpec.describe 'RunsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
@@ -696,9 +696,9 @@ RSpec.describe 'RunsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
@@ -838,9 +838,9 @@ RSpec.describe 'RunsController' do
           pool2.used_aliquots[0].update(tag_id: pool1.used_aliquots[0].tag_id)
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
@@ -913,9 +913,9 @@ RSpec.describe 'RunsController' do
           library2.used_aliquots[0].update(tag_id: library1.used_aliquots[0].tag_id)
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
@@ -1064,10 +1064,10 @@ RSpec.describe 'RunsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_pacbio_runs_path, params: body, headers: json_api_headers
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
@@ -1705,7 +1705,7 @@ RSpec.describe 'RunsController' do
     it 'returns an error message if the smrt_link_version is not supported' do
       run.update(smrt_link_version: version10)
       get v1_pacbio_run_sample_sheet_path(run).to_s, headers: json_api_headers
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include 'SMRTLink sample sheet (v10) is not supported or invalid'
     end
   end

--- a/spec/requests/v1/pacbio/tag_sets_spec.rb
+++ b/spec/requests/v1/pacbio/tag_sets_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Pacbio::TagSetsController' do
 
         it 'can returns unprocessable entity status' do
           post v1_pacbio_tag_sets_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a tag set' do
@@ -147,7 +147,7 @@ RSpec.describe 'Pacbio::TagSetsController' do
 
         # the failure responses are slightly different to in tags_spec because we are using the
         # default controller
-        it 'has a ok unprocessable_entity' do
+        it 'has a ok unprocessable_content' do
           patch v1_tag_set_path(123), params: body, headers: json_api_headers
           expect(response).to have_http_status(:not_found)
         end

--- a/spec/requests/v1/qc_reception_spec.rb
+++ b/spec/requests/v1/qc_reception_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe '/qc_receptions' do
 
         it 'renders a JSON response with errors for the new qc_receptions' do
           post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "qc_results_list - can't be blank"
         end
@@ -158,7 +158,7 @@ RSpec.describe '/qc_receptions' do
 
         it 'renders a JSON response with errors for the new qc_receptions' do
           post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "qc_results_list - can't be blank"
         end
@@ -186,7 +186,7 @@ RSpec.describe '/qc_receptions' do
         it 'renders a JSON response with errors for the qc_results_list' do
           error_message = error_config['attributes']['qc_results_list']['empty_array']
           post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['title']).to eq error_message
         end
@@ -212,7 +212,7 @@ RSpec.describe '/qc_receptions' do
 
         it 'renders a JSON response with errors for the new qc_receptions' do
           post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "source - can't be blank"
         end
@@ -239,7 +239,7 @@ RSpec.describe '/qc_receptions' do
 
         it 'renders a JSON response with errors for the new qc_results_list' do
           post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "source - can't be blank"
         end

--- a/spec/requests/v1/qc_results_uploads_spec.rb
+++ b/spec/requests/v1/qc_results_uploads_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
           post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "csv_data - can't be blank"
         end
@@ -121,7 +121,7 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
           post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "csv_data - can't be blank"
         end
@@ -150,7 +150,7 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
           post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "used_by - can't be blank"
         end
@@ -177,7 +177,7 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
           post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "used_by - can't be blank"
         end
@@ -227,7 +227,7 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
           post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq 'csv_data - Missing header row'
         end
@@ -261,7 +261,7 @@ RSpec.describe '/qc_results_uploads' do
         # There should always be a LR Decision, throw a 500 if not
         it 'renders a JSON response with errors for the new qc_results_upload' do
           post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['title']).to eq 'Missing required headers: Tissue Tube ID'
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq 'csv_data - Missing required headers: Tissue Tube ID'
@@ -294,7 +294,7 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
           post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq 'csv_data - Missing data rows'
         end

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe 'ReceptionsController' do
         expect(response).to have_http_status(:created), response.body
 
         post v1_receptions_path, params: changed_body, headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity), response.body
+        expect(response).to have_http_status(:unprocessable_content), response.body
       end
     end
 
@@ -493,9 +493,9 @@ RSpec.describe 'ReceptionsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('pool/concentration - must be greater than or equal to 0')
         end
       end
@@ -530,9 +530,9 @@ RSpec.describe 'ReceptionsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('pool/libraries - can\'t be blank')
         end
       end
@@ -591,9 +591,9 @@ RSpec.describe 'ReceptionsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('pool/tags - must be present on all libraries')
         end
       end
@@ -652,9 +652,9 @@ RSpec.describe 'ReceptionsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('requests/1/library_type - is not a recognised library type')
         end
       end
@@ -684,9 +684,9 @@ RSpec.describe 'ReceptionsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'generates a valid json-api error response' do
@@ -719,9 +719,9 @@ RSpec.describe 'ReceptionsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'generates a valid json-api error response' do
@@ -754,9 +754,9 @@ RSpec.describe 'ReceptionsController' do
           }.to_json
         end
 
-        it 'has a unprocessable_entity status' do
+        it 'has a unprocessable_content status' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'generates a valid json-api error response' do
@@ -819,7 +819,7 @@ RSpec.describe 'ReceptionsController' do
         it 'has a bad_request status and correct errors' do
           create(:plate_with_wells_and_requests, barcode: 'NT1', pipeline: 'pacbio')
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(json['errors'][0]['detail']).to eq('requests - there are no new samples to import')
         end
       end
@@ -978,11 +978,11 @@ RSpec.describe 'ReceptionsController' do
         }.to_json
       end
 
-      it 'has a unprocessable_entity status' do
+      it 'has a unprocessable_content status' do
         # This errors because of a type mismatch when attempting to create the pool as its trying to
         # put PacBio libraries into an ONT pool
         post v1_receptions_path, params: body, headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json['errors'][0]['detail']).to eq('pool/libraries - can\'t be blank')
       end
     end
@@ -1077,7 +1077,7 @@ RSpec.describe 'ReceptionsController' do
 
         it 'responds with correct result' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity), response.body
+          expect(response).to have_http_status(:unprocessable_content), response.body
           expect(response.body).to include('requests/0/requestable - is invalid')
         end
       end
@@ -1087,7 +1087,7 @@ RSpec.describe 'ReceptionsController' do
 
         it 'responds with correct result' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity), response.body
+          expect(response).to have_http_status(:unprocessable_content), response.body
           expect(response.body).to include('requests/0/requestable - is invalid')
         end
       end
@@ -1097,7 +1097,7 @@ RSpec.describe 'ReceptionsController' do
 
         it 'responds with correct result' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity), response.body
+          expect(response).to have_http_status(:unprocessable_content), response.body
           expect(response.body).to include('requests/0/requestable - is invalid')
         end
       end
@@ -1107,7 +1107,7 @@ RSpec.describe 'ReceptionsController' do
 
         it 'responds with correct result' do
           post v1_receptions_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity), response.body
+          expect(response).to have_http_status(:unprocessable_content), response.body
           expect(response.body).to include('requests/0/requestable - is invalid')
         end
       end

--- a/spec/requests/v1/tag_sets_spec.rb
+++ b/spec/requests/v1/tag_sets_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'TagSetsController' do
 
         it 'can returns unprocessable entity status' do
           post v1_tag_sets_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a tag set' do
@@ -133,7 +133,7 @@ RSpec.describe 'TagSetsController' do
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
-        it 'has a ok unprocessable_entity' do
+        it 'has a ok unprocessable_content' do
           patch v1_tag_set_path(123), params: body, headers: json_api_headers
           expect(response).to have_http_status(:not_found)
         end

--- a/spec/requests/v1/tags_spec.rb
+++ b/spec/requests/v1/tags_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'TagsController' do
 
         it 'can returns unprocessable entity status' do
           post v1_tags_path, params: body, headers: json_api_headers
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a tag' do
@@ -135,9 +135,9 @@ RSpec.describe 'TagsController' do
         }.to_json
       end
 
-      it 'has a ok unprocessable_entity' do
+      it 'has a ok unprocessable_content' do
         patch v1_tag_path(123), params: body, headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'has an error message' do
@@ -166,7 +166,7 @@ RSpec.describe 'TagsController' do
     context 'on failure' do
       it 'returns the correct status' do
         delete '/v1/tags/123', headers: json_api_headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'has an error message' do


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

This pull request standardizes the HTTP status code used for validation and processing errors across the application. Specifically, it replaces all uses of the non-standard `:unprocessable_entity` status with the correct `:unprocessable_content` status in controllers, validators, and request specs. This ensures consistency in error handling and improves clarity for both developers and API consumers.

NB - we should not need to have unprocessable content in controllers as JSON API resources can handle this automatically.

**Controller and Validator Updates:**

* All controller actions that previously returned `:unprocessable_entity` on validation or processing errors now return `:unprocessable_content` instead. This change affects actions in controllers such as `pacbio/requests_controller.rb`, `pacbio/runs/plates_controller.rb`, `pacbio/runs_controller.rb`, and `tags_controller.rb`. [[1]](diffhunk://#diff-2027535257a675c7dba1cbe6990da39dbbef510b6b93791b8d3a807aea990ac8L13-R13) [[2]](diffhunk://#diff-7ff7ad10464347875376252d46d34eb771463ec892c09ea43a199a9a19b10716L14-R29) [[3]](diffhunk://#diff-dc4175fd7d80967053ff87cb19cc7f165308665652bc55af4068ab4e6e4b978dL20-R20) [[4]](diffhunk://#diff-4b658ecc68eddbb64f616364c13d30e6de89c73019a6ea622a4215f45a5f3c20L12-R27)
* Documentation comments in validators (`qc_receptions_factory_validator.rb`, `qc_results_upload_validator.rb`, `well_validator.rb`) have been updated to reference `:unprocessable_content` instead of `:unprocessable_entity`. [[1]](diffhunk://#diff-5117bbc71201f7bd21e139a6ef36870656daef696e2f64852dbf2d673f6759ebL3-R3) [[2]](diffhunk://#diff-85e0ae219b3c4100b9444409aa928f808a2a6ae5cb23a0946f7b2b119935b8aaL3-R3) [[3]](diffhunk://#diff-37f13023137b69713eceaaab43ccfae1fe1bbdd56cd43daf02b6d80eca8dd63eL3-R3)

**Test Suite Updates:**

* All request specs have been updated to expect the `:unprocessable_content` status code in their error handling tests. This includes specs for data types, library types, ONT pools, ONT requests, ONT runs, PacBio libraries, PacBio library batches, PacBio pools, PacBio requests, and PacBio runs. [[1]](diffhunk://#diff-2ffda0878d5c3cd69d336fbd42be74eb3f3494f539b655da705270f24acc13cdL73-R73) [[2]](diffhunk://#diff-2ffda0878d5c3cd69d336fbd42be74eb3f3494f539b655da705270f24acc13cdL138-R138) [[3]](diffhunk://#diff-f916503559b7df0cf42c1e20bf974272532164c2ffca4458add91e71b8a9a9fbL75-R75) [[4]](diffhunk://#diff-f916503559b7df0cf42c1e20bf974272532164c2ffca4458add91e71b8a9a9fbL140-R140) [[5]](diffhunk://#diff-8e3b3907cfa1bef18521435fb16cab27d57758c4cec299befbc18c79e34db37bL161-R161) [[6]](diffhunk://#diff-8e3b3907cfa1bef18521435fb16cab27d57758c4cec299befbc18c79e34db37bL245-R245) [[7]](diffhunk://#diff-8e3b3907cfa1bef18521435fb16cab27d57758c4cec299befbc18c79e34db37bL371-R371) [[8]](diffhunk://#diff-e1f4f7cf1013095c4d83ea170fa355067f0de9465429c007b1a459bef6cf149bL221-R221) [[9]](diffhunk://#diff-97317a8afea5abb4934d6af262c69f37b5af5ecaac7e6bc93e5a586ef8cc88a3L154-R154) [[10]](diffhunk://#diff-97317a8afea5abb4934d6af262c69f37b5af5ecaac7e6bc93e5a586ef8cc88a3L165-R165) [[11]](diffhunk://#diff-97317a8afea5abb4934d6af262c69f37b5af5ecaac7e6bc93e5a586ef8cc88a3L301-R301) [[12]](diffhunk://#diff-97317a8afea5abb4934d6af262c69f37b5af5ecaac7e6bc93e5a586ef8cc88a3L335-R335) [[13]](diffhunk://#diff-97317a8afea5abb4934d6af262c69f37b5af5ecaac7e6bc93e5a586ef8cc88a3L366-R366) [[14]](diffhunk://#diff-97317a8afea5abb4934d6af262c69f37b5af5ecaac7e6bc93e5a586ef8cc88a3L400-R400) [[15]](diffhunk://#diff-0456dc6b3b68d04c4171da0220e7f7a7f8be644632714500dba09fa37464e67eL402-R402) [[16]](diffhunk://#diff-0456dc6b3b68d04c4171da0220e7f7a7f8be644632714500dba09fa37464e67eL438-R438) [[17]](diffhunk://#diff-0456dc6b3b68d04c4171da0220e7f7a7f8be644632714500dba09fa37464e67eL570-R570) [[18]](diffhunk://#diff-0456dc6b3b68d04c4171da0220e7f7a7f8be644632714500dba09fa37464e67eL616-R616) [[19]](diffhunk://#diff-16509761d85edd0fd2c5986026cc79d70fa07645e4079fedb61b80390f687537L128-R128) [[20]](diffhunk://#diff-428ab9d63c74e934c19a788545d551ec54c9681c53d99fde3f6198dbd6bf4df7L321-R321) [[21]](diffhunk://#diff-428ab9d63c74e934c19a788545d551ec54c9681c53d99fde3f6198dbd6bf4df7L360-R360) [[22]](diffhunk://#diff-428ab9d63c74e934c19a788545d551ec54c9681c53d99fde3f6198dbd6bf4df7L505-R505) [[23]](diffhunk://#diff-428ab9d63c74e934c19a788545d551ec54c9681c53d99fde3f6198dbd6bf4df7L697-R697) [[24]](diffhunk://#diff-803b31d97af6ea8f5faca1cc523c773a736376002d3d45a34b07caeccc2d4686L302-R302) [[25]](diffhunk://#diff-803b31d97af6ea8f5faca1cc523c773a736376002d3d45a34b07caeccc2d4686L362-R362) [[26]](diffhunk://#diff-daedbb993e13166f7c87a4326f903af1daf635f51ced9b69d757e1732753bb75L472-R474) [[27]](diffhunk://#diff-daedbb993e13166f7c87a4326f903af1daf635f51ced9b69d757e1732753bb75L572-R574)

These changes collectively ensure that the application consistently uses the correct HTTP status code for unprocessable content errors, both in API responses and in test expectations.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
