### PR TITLE
deps: bump uri gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uri (1.0.3)
+    uri (1.0.4)
     useragent (0.16.11)
     webmock (3.25.1)
       addressable (>= 2.8.0)


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Fixes puma warning:` You have already activated uri 1.0.4, but your Gemfile requires uri 1.0.3. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem.`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
