### PR TITLE
Add ostruct gem for Ruby 4.x compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'bunny'
 gem 'csv'
 gem 'exception_notification'
 gem 'mysql2'
+gem "ostruct" # No longer part of the default gems in Ruby 4.x
 gem 'puma' # Use Puma as the app server
 gem 'rack-cors' # Use Rack CORS for handling CORS, making cross-origin AJAX possible
 gem 'rack-session' # Use Rack Session for session management. Needed for flipper

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'bunny'
 gem 'csv'
 gem 'exception_notification'
 gem 'mysql2'
-gem "ostruct" # No longer part of the default gems in Ruby 4.x
+gem 'ostruct' # No longer part of the default gems in Ruby 4.x
 gem 'puma' # Use Puma as the app server
 gem 'rack-cors' # Use Rack CORS for handling CORS, making cross-origin AJAX possible
 gem 'rack-session' # Use Rack Session for session management. Needed for flipper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,7 @@ GEM
     nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
@@ -369,6 +370,7 @@ DEPENDENCIES
   flipper-ui
   listen
   mysql2
+  ostruct
   pry-rails
   puma
   rack-cors


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Add `ostruct` gem back for Ruby 4.x compatibility.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
