### PR TITLE
feat(support-tasks): adds pacbio_library_sample_swap support task

### DIFF
--- a/lib/tasks/support_tasks.rake
+++ b/lib/tasks/support_tasks.rake
@@ -29,6 +29,16 @@ namespace :support_tasks do
       library2.request = request1
       library2.used_aliquots.first.update!(source_id: request1.id)
       library2.save!
+
+      # Update the updated_at attribute for all primary and derived aliquots of both libraries
+      # This ensures that any messages published to the warehouse for these aliquots will have the updated timestamp
+      # so are correctly processed.
+      # If we don't do this the warehouse will ignore the updates as the aliquot sample_name attribute change does not occur
+      # directly on the aliquot so the updated_at timestamp does not change and the warehouse assumes there is no change to process.
+      #
+      # .aliquots is all aliquots where the library is the source, so includes both primary and derived aliquots
+      library1.aliquots.each(&:touch)
+      library2.aliquots.each(&:touch)
     end
 
     puts "-> Swapped samples of libraries #{library1_id} and #{library2_id}"

--- a/lib/tasks/support_tasks.rake
+++ b/lib/tasks/support_tasks.rake
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+namespace :support_tasks do
+  # Example usage 'bundle exec rails "support_tasks:pacbio_library_sample_swap[5,4]"'
+  desc 'Swap the samples of two libraries and push all related data to the warehouse'
+  task :pacbio_library_sample_swap, %i[library1_id library2_id] => :environment do |_t, args|
+    library1_id = args[:library1_id]
+    library2_id = args[:library2_id]
+
+    library1 = Pacbio::Library.find_by(id: library1_id)
+    library2 = Pacbio::Library.find_by(id: library2_id)
+
+    unless library1 && library2
+      puts "Warning: Could not find library with id #{library1_id}" unless library1
+      puts "Warning: Could not find library with id #{library2_id}" unless library2
+      exit 0
+    end
+
+    ActiveRecord::Base.transaction do
+      request1 = library1.request
+      request2 = library2.request
+
+      # Annoyingly request is linked to the library through request_id and used/derived_aliquots so we need to update both
+      library1.request = request2
+      # We make the assumption here that there is only one used aliquot per library
+      library1.used_aliquots.first.update!(source_id: request2.id)
+      library1.save!
+
+      library2.request = request1
+      library2.used_aliquots.first.update!(source_id: request1.id)
+      library2.save!
+    end
+
+    puts "-> Swapped samples of libraries #{library1_id} and #{library2_id}"
+
+    sequencing_runs = []
+    # Ensure all related data is published to the warehouse
+    [library1, library2].each do |library|
+      # We need to publish the primary aliquot and all used aliquots for the library as the sample name and source has changed
+      Emq::Publisher.publish([library.primary_aliquot, *library.used_aliquots],
+                             Pipelines.pacbio, 'volume_tracking')
+
+      # We also need to republish the messages for any runs that the library is in as the sample has changed
+      sequencing_runs += library.sequencing_runs
+
+      # We also need to republish the messages for any pools that the library is in as the sample has changed
+      library.derived_aliquots.each do |aliquot|
+        next unless aliquot.used_by_type == 'Pacbio::Pool'
+
+        pool = aliquot.used_by
+        sequencing_runs += pool.sequencing_runs
+      end
+    end
+
+    # Publish sequencing runs together at the end to ensure they are only published once
+    sequencing_runs.uniq.each do |run|
+      puts "-> Republishing run data and volume tracking messages for run #{run.name}"
+      Messages.publish(run, Pipelines.pacbio.message)
+      Emq::Publisher.publish(run.aliquots_to_publish_on_run, Pipelines.pacbio, 'volume_tracking')
+    end
+  end
+end

--- a/spec/lib/tasks/support_tasks.rake_spec.rb
+++ b/spec/lib/tasks/support_tasks.rake_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+# only load Rake tasks if they haven't been loaded already
+Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+RSpec.describe 'RakeTasks' do
+  before do
+    Pacbio::SmrtLinkVersion.find_by(name: 'v13_revio') || create(:pacbio_smrt_link_version, name: 'v13_revio', default: true)
+  end
+
+  describe 'pacbio_library_sample_swap' do
+    before do
+      create(:library_type, :pacbio)
+    end
+
+    it 'outputs a warning and does if one or both library ids are invalid' do
+      Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
+
+      expect { Rake::Task['support_tasks:pacbio_library_sample_swap'].invoke('nonId', 'nonId2') }.to output(
+        <<~HEREDOC
+          Warning: Could not find library with id nonId
+          Warning: Could not find library with id nonId2
+        HEREDOC
+      ).to_stdout
+    end
+
+    it 'correctly swaps the libraries samples and rebraoadcasts the correct messages (no runs, no pools)' do
+      Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
+
+      library1 = create(:pacbio_library)
+      library2 = create(:pacbio_library)
+      request1 = library1.request
+      request2 = library2.request
+
+      # Published twice, onces for each library
+      expect(Emq::Publisher).to receive(:publish).twice.with(anything, having_attributes(pipeline: 'pacbio'), 'volume_tracking')
+
+      expect { Rake::Task['support_tasks:pacbio_library_sample_swap'].invoke(library1.id, library2.id) }.to output(
+        <<~HEREDOC
+          -> Swapped samples of libraries #{library1.id} and #{library2.id}
+        HEREDOC
+      ).to_stdout
+
+      library1.reload
+      library2.reload
+
+      expect(library1.request).to eq(request2)
+      expect(library1.used_aliquots.first.source_id).to eq(request2.id)
+      expect(library2.request).to eq(request1)
+      expect(library2.used_aliquots.first.source_id).to eq(request1.id)
+    end
+
+    it 'correctly swaps the libraries samples and rebraoadcasts the correct messages (runs, no pools)' do
+      Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
+
+      library1 = create(:pacbio_library)
+      library2 = create(:pacbio_library)
+      request1 = library1.request
+      request2 = library2.request
+      # Creates runs using the library
+      run1 = create(:pacbio_revio_run)
+      run2 = create(:pacbio_revio_run)
+      create(:pacbio_well, libraries: [library1], plate: run1.plates.first)
+      create(:pacbio_well, libraries: [library2], plate: run2.plates.first)
+
+      # Published 4 times
+      # once for each library
+      # once for each run
+      expect(Emq::Publisher).to receive(:publish).exactly(4).times.with(anything, having_attributes(pipeline: 'pacbio'), 'volume_tracking')
+      # Runs that the library is in as the sample has changed
+      expect(Messages).to receive(:publish).with(run1, having_attributes(pipeline: 'pacbio'))
+      expect(Messages).to receive(:publish).with(run2, having_attributes(pipeline: 'pacbio'))
+
+      expect { Rake::Task['support_tasks:pacbio_library_sample_swap'].invoke(library1.id, library2.id) }.to output(
+        <<~HEREDOC
+          -> Republishing run data and volume tracking messages for run #{run1.name}
+          -> Republishing run data and volume tracking messages for run #{run2.name}
+          -> Swapped samples of libraries #{library1.id} and #{library2.id}
+        HEREDOC
+      ).to_stdout
+
+      library1.reload
+      library2.reload
+
+      expect(library1.request).to eq(request2)
+      expect(library1.used_aliquots.first.source_id).to eq(request2.id)
+      expect(library2.request).to eq(request1)
+      expect(library2.used_aliquots.first.source_id).to eq(request1.id)
+    end
+
+    it 'correctly swaps the libraries samples and rebraoadcasts the correct messages (runs, pools)' do
+      Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
+
+      # Create pools and libraries
+      pool1 = create(:pacbio_pool, :tagged, library_count: 1)
+      library1 = pool1.libraries.first
+      pool2 = create(:pacbio_pool, :tagged, library_count: 1)
+      library2 = pool2.libraries.first
+      request1 = library1.request
+      request2 = library2.request
+
+      # Creates runs using the library
+      run1 = create(:pacbio_revio_run)
+      run2 = create(:pacbio_revio_run)
+      create(:pacbio_well, libraries: [library1], plate: run1.plates.first)
+      create(:pacbio_well, libraries: [library2], plate: run2.plates.first)
+      # Create runs using the pools
+      run3 = create(:pacbio_revio_run)
+      run4 = create(:pacbio_revio_run)
+      create(:pacbio_well, pools: [pool1], plate: run3.plates.first)
+      create(:pacbio_well, pools: [pool2], plate: run4.plates.first)
+
+      # Published 6 times
+      # once for each library
+      # once for each run
+      expect(Emq::Publisher).to receive(:publish).exactly(6).times.with(anything, having_attributes(pipeline: 'pacbio'), 'volume_tracking')
+      # Runs that the library is in as the sample has changed
+      expect(Messages).to receive(:publish).with(run1, having_attributes(pipeline: 'pacbio'))
+      expect(Messages).to receive(:publish).with(run2, having_attributes(pipeline: 'pacbio'))
+      expect(Messages).to receive(:publish).with(run3, having_attributes(pipeline: 'pacbio'))
+      expect(Messages).to receive(:publish).with(run4, having_attributes(pipeline: 'pacbio'))
+
+      # Note run order is because it goes library and library pools runs before moving onto the next library
+      expect { Rake::Task['support_tasks:pacbio_library_sample_swap'].invoke(library1.id, library2.id) }.to output(
+        <<~HEREDOC
+          -> Republishing run data and volume tracking messages for run #{run1.name}
+          -> Republishing run data and volume tracking messages for run #{run3.name}
+          -> Republishing run data and volume tracking messages for run #{run2.name}
+          -> Republishing run data and volume tracking messages for run #{run4.name}
+          -> Swapped samples of libraries #{library1.id} and #{library2.id}
+        HEREDOC
+      ).to_stdout
+
+      library1.reload
+      library2.reload
+
+      expect(library1.request).to eq(request2)
+      expect(library1.used_aliquots.first.source_id).to eq(request2.id)
+      expect(library2.request).to eq(request1)
+      expect(library2.used_aliquots.first.source_id).to eq(request1.id)
+    end
+  end
+end

--- a/spec/lib/tasks/support_tasks.rake_spec.rb
+++ b/spec/lib/tasks/support_tasks.rake_spec.rb
@@ -30,8 +30,11 @@ RSpec.describe 'RakeTasks' do
     it 'correctly swaps the libraries samples and rebroadcasts the correct messages (no runs, no pools)' do
       Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
 
+      old_updated_at = 1.day.ago
       library1 = create(:pacbio_library)
       library2 = create(:pacbio_library)
+      library1.primary_aliquot.update!(updated_at: old_updated_at)
+      library2.primary_aliquot.update!(updated_at: old_updated_at)
       request1 = library1.request
       request2 = library2.request
 
@@ -51,11 +54,16 @@ RSpec.describe 'RakeTasks' do
       expect(library1.used_aliquots.first.source_id).to eq(request2.id)
       expect(library2.request).to eq(request1)
       expect(library2.used_aliquots.first.source_id).to eq(request1.id)
+
+      # Check that the primary aliquot updated_at attribute has been updated to ensure the warehouse processes the update
+      expect(library1.primary_aliquot.updated_at).to be > old_updated_at
+      expect(library2.primary_aliquot.updated_at).to be > old_updated_at
     end
 
     it 'correctly swaps the libraries samples and rebroadcasts the correct messages (runs, no pools)' do
       Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
 
+      old_updated_at = 1.day.ago
       library1 = create(:pacbio_library)
       library2 = create(:pacbio_library)
       request1 = library1.request
@@ -65,6 +73,9 @@ RSpec.describe 'RakeTasks' do
       run2 = create(:pacbio_revio_run)
       create(:pacbio_well, libraries: [library1], plate: run1.plates.first)
       create(:pacbio_well, libraries: [library2], plate: run2.plates.first)
+      [library1, library2].flat_map(&:derived_aliquots).each do |aliquot|
+        aliquot.update!(updated_at: old_updated_at)
+      end
 
       # Published 4 times
       # once for each library
@@ -89,6 +100,11 @@ RSpec.describe 'RakeTasks' do
       expect(library1.used_aliquots.first.source_id).to eq(request2.id)
       expect(library2.request).to eq(request1)
       expect(library2.used_aliquots.first.source_id).to eq(request1.id)
+
+      # Check the derived aliquots are updated
+      [library1, library2].flat_map(&:derived_aliquots).each do |aliquot|
+        expect(aliquot.updated_at).to be > old_updated_at
+      end
     end
 
     it 'correctly swaps the libraries samples and rebroadcasts the correct messages (runs, pools)' do

--- a/spec/lib/tasks/support_tasks.rake_spec.rb
+++ b/spec/lib/tasks/support_tasks.rake_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'RakeTasks' do
       ).to_stdout
     end
 
-    it 'correctly swaps the libraries samples and rebraoadcasts the correct messages (no runs, no pools)' do
+    it 'correctly swaps the libraries samples and rebroadcasts the correct messages (no runs, no pools)' do
       Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
 
       library1 = create(:pacbio_library)
@@ -53,7 +53,7 @@ RSpec.describe 'RakeTasks' do
       expect(library2.used_aliquots.first.source_id).to eq(request1.id)
     end
 
-    it 'correctly swaps the libraries samples and rebraoadcasts the correct messages (runs, no pools)' do
+    it 'correctly swaps the libraries samples and rebroadcasts the correct messages (runs, no pools)' do
       Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
 
       library1 = create(:pacbio_library)
@@ -91,7 +91,7 @@ RSpec.describe 'RakeTasks' do
       expect(library2.used_aliquots.first.source_id).to eq(request1.id)
     end
 
-    it 'correctly swaps the libraries samples and rebraoadcasts the correct messages (runs, pools)' do
+    it 'correctly swaps the libraries samples and rebroadcasts the correct messages (runs, pools)' do
       Rake::Task['support_tasks:pacbio_library_sample_swap'].reenable
 
       # Create pools and libraries


### PR DESCRIPTION
#### Changes proposed in this pull request

- Adds support tasks script to swap the samples of two pacbio libraries and rebroadcast the relevant data to the warehouse.

