### PR TITLE
feat: adds pool_barcode to multi_pool_positions

### DIFF
--- a/app/models/multi_pool_position.rb
+++ b/app/models/multi_pool_position.rb
@@ -17,6 +17,8 @@ class MultiPoolPosition < ApplicationRecord
   validates :position, presence: true
   validate :pool_presence
 
+  delegate :barcode, to: :pool, allow_nil: true, prefix: true
+
   # Validate that at least one pool is associated
   # We can't validate pool relationship presence because it's polymorphic
   # and may be nil during nested creation within multi_pool_positions

--- a/app/resources/v1/multi_pool_position_resource.rb
+++ b/app/resources/v1/multi_pool_position_resource.rb
@@ -24,6 +24,9 @@ module V1
     # @!attribute [rw] created_at
     #   @return [String] the creation date of the multi_pool_position in US format
     attributes :position, :pool_id, :pool_type, :created_at
+    # @!attribute [r] pool_barcode
+    # @return [String] the barcode of the pool associated with this position
+    attribute :pool_barcode, readonly: true
 
     # @!attribute [w] pacbio_pool_attributes
     # @return [Hash] attributes for creating/updating nested pacbio_pool

--- a/spec/models/multi_pool_position_spec.rb
+++ b/spec/models/multi_pool_position_spec.rb
@@ -45,4 +45,18 @@ RSpec.describe MultiPoolPosition do
       expect(multi_pool_position.pipeline).to be_nil
     end
   end
+
+  describe '#pool_barcode' do
+    it 'delegates barcode to the associated pool (pacbio)' do
+      pool = create(:pacbio_pool, tube: build(:tube, barcode: 'TESTBARCODE'))
+      multi_pool_position = create(:multi_pool_position, pool:)
+
+      expect(multi_pool_position.pool_barcode).to eq('TESTBARCODE')
+    end
+
+    it 'returns nil if no pool is associated' do
+      multi_pool_position = build(:multi_pool_position, pool: nil)
+      expect(multi_pool_position.pool_barcode).to be_nil
+    end
+  end
 end

--- a/spec/requests/v1/multi_pools_spec.rb
+++ b/spec/requests/v1/multi_pools_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'MultiPoolsController' do
 
           multi_pool_position_resource = find_included_resource(type: 'multi_pool_positions', id: multi_pool_position.id)
           expect(multi_pool_position_resource.dig('attributes', 'position')).to eq(multi_pool_position.position)
+          expect(multi_pool_position_resource.dig('attributes', 'pool_barcode')).to eq(pacbio_pool.barcode)
           expect(multi_pool_position_resource.dig('relationships', 'pacbio_pool', 'data', 'id')).to eq(pacbio_pool.id.to_s)
           expect(multi_pool_position_resource.dig('relationships', 'pacbio_pool', 'data', 'type')).to eq('pools')
 


### PR DESCRIPTION
#### Changes proposed in this pull request

- Adds pool_barcode attribute to multi pool positions. This enables the UI to access the pool barcode without fetching the full pools. 