### PR TITLE
Y26-046 - Keep pacbio library requests and used_aliquot sources in sync

### DIFF
--- a/app/models/pacbio/library.rb
+++ b/app/models/pacbio/library.rb
@@ -80,7 +80,10 @@ module Pacbio
           concentration: primary_aliquot.concentration,
           template_prep_kit_box_barcode: primary_aliquot.template_prep_kit_box_barcode,
           insert_size: primary_aliquot.insert_size,
-          tag: primary_aliquot.tag
+          tag: primary_aliquot.tag,
+          # If we change the request (e.g. sample swap) we also need to update the source of the
+          # used aliquot to ensure the data is consistent
+          source: request
         )
       end
     end

--- a/lib/tasks/support_tasks.rake
+++ b/lib/tasks/support_tasks.rake
@@ -20,14 +20,10 @@ namespace :support_tasks do
       request1 = library1.request
       request2 = library2.request
 
-      # Annoyingly request is linked to the library through request_id and used/derived_aliquots so we need to update both
       library1.request = request2
-      # We make the assumption here that there is only one used aliquot per library
-      library1.used_aliquots.first.update!(source_id: request2.id)
       library1.save!
 
       library2.request = request1
-      library2.used_aliquots.first.update!(source_id: request1.id)
       library2.save!
 
       # Update the updated_at attribute for all primary and derived aliquots of both libraries

--- a/spec/lib/tasks/support_tasks.rake_spec.rb
+++ b/spec/lib/tasks/support_tasks.rake_spec.rb
@@ -51,9 +51,7 @@ RSpec.describe 'RakeTasks' do
       library2.reload
 
       expect(library1.request).to eq(request2)
-      expect(library1.used_aliquots.first.source_id).to eq(request2.id)
       expect(library2.request).to eq(request1)
-      expect(library2.used_aliquots.first.source_id).to eq(request1.id)
 
       # Check that the primary aliquot updated_at attribute has been updated to ensure the warehouse processes the update
       expect(library1.primary_aliquot.updated_at).to be > old_updated_at
@@ -97,9 +95,7 @@ RSpec.describe 'RakeTasks' do
       library2.reload
 
       expect(library1.request).to eq(request2)
-      expect(library1.used_aliquots.first.source_id).to eq(request2.id)
       expect(library2.request).to eq(request1)
-      expect(library2.used_aliquots.first.source_id).to eq(request1.id)
 
       # Check the derived aliquots are updated
       [library1, library2].flat_map(&:derived_aliquots).each do |aliquot|
@@ -154,9 +150,7 @@ RSpec.describe 'RakeTasks' do
       library2.reload
 
       expect(library1.request).to eq(request2)
-      expect(library1.used_aliquots.first.source_id).to eq(request2.id)
       expect(library2.request).to eq(request1)
-      expect(library2.used_aliquots.first.source_id).to eq(request1.id)
     end
   end
 end

--- a/spec/models/pacbio/library_spec.rb
+++ b/spec/models/pacbio/library_spec.rb
@@ -324,13 +324,15 @@ RSpec.describe Pacbio::Library, :pacbio do
   context 'after_update' do
     it 'updates used_aliquots' do
       library = create(:pacbio_library)
+      request = create(:pacbio_request)
       tag = create(:tag)
-      library.update(primary_aliquot_attributes: { tag_id: tag.id, volume: 1000, concentration: 1000, insert_size: 1000, template_prep_kit_box_barcode: 'LK456' })
+      library.update(primary_aliquot_attributes: { tag_id: tag.id, volume: 1000, concentration: 1000, insert_size: 1000, template_prep_kit_box_barcode: 'LK456' }, request: request)
       expect(library.used_aliquots.first.tag).to eq(tag)
       expect(library.used_aliquots.first.volume).to eq(1000)
       expect(library.used_aliquots.first.concentration).to eq(1000)
       expect(library.used_aliquots.first.insert_size).to eq(1000)
       expect(library.used_aliquots.first.template_prep_kit_box_barcode).to eq('LK456')
+      expect(library.used_aliquots.first.source).to eq(request)
     end
   end
 end


### PR DESCRIPTION
Closes #1788 

#### Changes proposed in this pull request

- Sets source in pacbio library used_aliquots during after_update hook.

#### Instructions for Reviewers

This is the PR for the research story associated above. A brief explanation is available as a comment there.