### PR TITLE
Y25-662 - [PR] As a developer (Ben) I would like to add API keys to enable programmatic access to traction-service

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 # ApplicationController
 class ApplicationController < ActionController::Base
   include JSONAPI::ActsAsResourceController
+  include Authenticator
 
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -129,7 +129,7 @@ module Authenticator
 
     return if request.get?
 
-    render_forbidden('API keys are read-only')
+    render_forbidden('API keys are for read-only access')
   end
 
   # Handles requests with no valid credentials.
@@ -178,7 +178,6 @@ module Authenticator
     key.expires_at.present? && key.expires_at.past?
   end
 
-  # Response helpers
   # Renders a 401 Unauthorized response.
   #
   # @param message [String] error message to include in response

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -6,7 +6,6 @@
 # 1. Bearer tokens (JWT/OAuth2, for future Identity Provider integration)
 # 2. API keys (via X-Traction-Client-Id header, for programmatic access)
 #
-# Enforces API key permissions: keys are read-only (GET requests only).
 # Key usage is logged, and grace-period keys trigger deprecation warnings.
 #
 # @example Include in a controller
@@ -41,7 +40,6 @@ module Authenticator
       authenticate_bearer!
     elsif api_key_present?
       authenticate_api_key!
-      enforce_api_key_permissions!
     else
       handle_unauthenticated!
     end
@@ -121,17 +119,6 @@ module Authenticator
     @current_api_client = key.api_application
   end
 
-  # Enforces that API key-authenticated requests are GET-only (read-only).
-  #
-  # @return [void]
-  def enforce_api_key_permissions!
-    return unless @current_auth == :api_key
-
-    return if request.get?
-
-    render_forbidden('API keys are for read-only access')
-  end
-
   # Handles requests with no valid credentials.
   #
   # @return [void]
@@ -193,13 +180,5 @@ module Authenticator
   # @return [void]
   def render_unauthorized(message)
     render json: { error: message }, status: :unauthorized
-  end
-
-  # Renders a 403 Forbidden response.
-  #
-  # @param message [String] error message to include in response
-  # @return [void]
-  def render_forbidden(message)
-    render json: { error: message }, status: :forbidden
   end
 end

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -9,7 +9,8 @@
 module Authenticator
   extend ActiveSupport::Concern
 
-  API_KEY_HEADER = 'X-Traction-Client-Id' # Using headers instead of env, HTTP_X_TRACTION_CLIENT_ID in Rails.
+  # Using headers instead of env, HTTP_X_TRACTION_CLIENT_ID in Rails.
+  API_KEY_HEADER = 'X-Traction-Client-Id'
 
   included do
     before_action :authenticate_request! # preceed all controller actions

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -20,6 +20,8 @@ module Authenticator
 
   # Main authentication entry point
   def authenticate_request!
+    return unless Flipper.enabled?(:y25_662_enable_request_authentication)
+
     if bearer_token_present? # identity provider check
       authenticate_bearer!
     elsif api_key_present? # api key check
@@ -104,7 +106,7 @@ module Authenticator
   # transitional
   def handle_unauthenticated!
     # Y25-661: allow GET temporarily
-    return if request.get?
+    # return if request.get?
 
     render_unauthorized('Authentication required')
   end

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
-# Plug this to authenticate requests using either Bearer tokens
-# (e.g. Identity Provider) or API keys.
-# TODO: handle paths v1 and flipper
-# TODO: UI needs to start with token flow and possibly check before each request
-# TODO: put behind flipper feature flag
-# TODO: migrations and models for api apps and api keys tables
+# Plug this to authenticate requests using either Bearer tokens or API keys.
+#
+# Supports two authentication methods:
+# 1. Bearer tokens (JWT/OAuth2, for future Identity Provider integration)
+# 2. API keys (via X-Traction-Client-Id header, for programmatic access)
+#
+# Enforces API key permissions: keys are read-only (GET requests only).
+# Key usage is logged, and grace-period keys trigger deprecation warnings.
+#
+# @example Include in a controller
+#   class ApiController < ApplicationController
+#     include Authenticator
+#   end
+#
 module Authenticator
   extend ActiveSupport::Concern
 
@@ -13,93 +21,109 @@ module Authenticator
   API_KEY_HEADER = 'X-Traction-Client-Id'
 
   included do
-    before_action :authenticate_request! # preceed all controller actions
+    before_action :authenticate_request!
   end
 
-  private # not controller public actions
+  private
 
-  # Main authentication entry point
+  # Main authentication entry point for all controller actions.
+  #
+  # Routes requests through appropriate authentication strategy:
+  # 1. Bearer token (if Authorization header present)
+  # 2. API key (if X-Traction-Client-Id header present)
+  # 3. Denied (if neither present)
+  #
+  # @return [void]
   def authenticate_request!
     return unless Flipper.enabled?(:y25_662_enable_request_authentication)
 
-    if bearer_token_present? # Identity provider check
+    if bearer_token_present?
       authenticate_bearer!
-    elsif api_key_present? # API Key check
+    elsif api_key_present?
       authenticate_api_key!
-      enforce_api_key_permissions! # story requires API keys to be for GET.
+      enforce_api_key_permissions!
     else
-      # XXX: Should allow for now, or make a flipper flag
-      handle_unauthenticated! # return 401
+      handle_unauthenticated!
     end
   end
 
-  # Checks if the Authorization header contains a Bearer token (OAuth2/JWT style)
+  # Checks if the Authorization header contains a Bearer token (JWT/OAuth2 style).
+  #
   # @return [Boolean] true if Bearer token is present, false otherwise
   def bearer_token_present?
     request.headers['Authorization']&.start_with?('Bearer ')
   end
 
   # Authenticates a request using a Bearer token from the Authorization header.
-  # @return [void] Sets @current_auth to :bearer on success.
+  #
+  # TODO(Y25-660): Identity provider integration
+  #
+  # @return [void]
   def authenticate_bearer!
     token = bearer_token
-
-    # TODO(Y25-660): Identity provider integration
     return render_unauthorized('Invalid Bearer token') unless valid_bearer_token?(token)
 
     @current_auth = :bearer
   end
 
-  # Extracts the token value from the Authorization header in the format "Bearer <token>"
-  # @return [String, nil] Returns the token string if present, or nil otherwise
+  # Extracts the token value from the Authorization header in the format "Bearer <token>".
+  #
+  # @return [String, nil] the token string if present, nil otherwise
   def bearer_token
     request.headers['Authorization']&.split&.last
   end
 
+  # Validates a Bearer token.
+  #
+  # TODO(Y25-660): Identity provider integration
+  #
+  # @param token [String] the token to validate
+  # @return [Boolean] true if token is valid
   def valid_bearer_token?(token)
-    # TODO: plug real Bearer validation here, i.e. Identity Provider, JWT, etc.
     token.present?
   end
 
-  # API key authentication
+  # Checks if an API key is present in the X-Traction-Client-Id header.
+  #
+  # @return [Boolean] true if header is present, false otherwise
   def api_key_present?
     request.headers[API_KEY_HEADER].present?
   end
 
+  # Authenticates a request using an API key from the X-Traction-Client-Id header.
+  #
+  # Validates that the key:
+  # - Exists in the database (via SHA-256 digest lookup)
+  # - Is in active or grace_period status
+  # - Has not passed expires_at (when expires_at is present)
+  #
+  # Updates last_used_at timestamp and logs grace-period usage.
+  # If in grace period, sets deprecation warning header.
+  # Renders 401 Unauthorized if key is invalid.
+  #
+  # @return [void]
   def authenticate_api_key!
     raw_key = request.headers[API_KEY_HEADER]
 
-    # XXX: prefix or not? Maybe helpful for rotation, and possible key types.
-    prefix, secret = parse_api_key(raw_key)
-    return render_unauthorized('Invalid API key format') unless prefix
-
-    key = ApiKey.find_by(prefix: prefix)
+    key = ApiKey.find_by(key_digest: Digest::SHA256.hexdigest(raw_key))
     return render_unauthorized('API key not found') unless key
 
-    return render_unauthorized('API key revoked') unless key.active?
-
-    return render_unauthorized('Invalid API key') unless valid_secret?(secret, key.key_hash)
+    # active and grace_period keys are both valid; expired is rejected
+    return render_unauthorized('API key not valid') unless key.active? || key.grace_period?
+    return render_unauthorized('API key expired') if api_key_expired?(key)
 
     log_key_usage(key)
+
+    # Warn the caller if their key is in the grace period so they know to rotate
+    add_grace_period_warning_header(key)
 
     @current_auth = :api_key
     @current_api_client = key.api_application
   end
 
-  def parse_api_key(raw_key)
-    # assumes format "prefix.secret", where prefix is stored in DB and secret is hashed
-    parts = raw_key.split('.', 2)
-    return [nil, nil] unless parts.size == 2
-
-    parts
-  end
-
-  def valid_secret?(secret, key_hash)
-    # TODO: salt
-    BCrypt::Password.new(key_hash) == secret
-  end
-
-  # story says API keys should be read-only
+  # Enforces that API key-authenticated requests are GET-only (read-only).
+  #
+  # @return [void]
   def enforce_api_key_permissions!
     return unless @current_auth == :api_key
 
@@ -108,30 +132,65 @@ module Authenticator
     render_forbidden('API keys are read-only')
   end
 
-  # transitional
+  # Handles requests with no valid credentials.
+  #
+  # @return [void]
   def handle_unauthenticated!
-    # Y25-661: allow GET temporarily
-    # return if request.get?
-
     render_unauthorized('Authentication required')
   end
 
-  # logging
+  # Logs API key usage and warns if key is in grace period.
+  #
+  # Updates the key's last_used_at timestamp and logs a warning message if the
+  # key is in grace_period status.
+  #
+  # @param key [ApiKey] the API key that was used
+  # @return [void]
   def log_key_usage(key)
-    key.update(:last_used_at, Time.current)
+    key.update(last_used_at: Time.current)
 
-    # Soft "grace period" from rotation design from Y25-575
-    # XXX: checking against a magic number
-    return unless key.created_at < 3.months.ago
+    # Log a warning when a grace-period key is used.
+    return unless key.grace_period?
 
-    Rails.logger.warn("[API KEY] Old key used: #{key.id}")
+    log_message = '[API KEY] Grace-period key used ' \
+                  "(id=#{key.id}, expires_at=#{key.expires_at})"
+    Rails.logger.warn(log_message)
   end
 
-  # responses
+  # Sets a response header warning when a grace-period API key is used.
+  #
+  # @param key [ApiKey] the API key used for authentication
+  # @return [void]
+  def add_grace_period_warning_header(key)
+    return unless key.grace_period?
+
+    expires_str = key.expires_at&.strftime('%Y-%m-%d') || 'soon'
+    warning_message =
+      "The API key used is deprecated and will be deactivated on #{expires_str}"
+    response.set_header('X-Traction-Client-Id-Warning', warning_message)
+  end
+
+  # Returns true when key has an expires_at timestamp in the past.
+  #
+  # @param key [ApiKey]
+  # @return [Boolean]
+  def api_key_expired?(key)
+    key.expires_at.present? && key.expires_at.past?
+  end
+
+  # Response helpers
+  # Renders a 401 Unauthorized response.
+  #
+  # @param message [String] error message to include in response
+  # @return [void]
   def render_unauthorized(message)
     render json: { error: message }, status: :unauthorized
   end
 
+  # Renders a 403 Forbidden response.
+  #
+  # @param message [String] error message to include in response
+  # @return [void]
   def render_forbidden(message)
     render json: { error: message }, status: :forbidden
   end

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -137,20 +137,23 @@ module Authenticator
 
   # Logs API key usage and warns if key is in grace period.
   #
-  # Updates the key's last_used_at timestamp and logs a warning message if the
-  # key is in grace_period status.
+  # Updates the key's last_used_at timestamp and logs, logs an info message
+  # for the active key or a warning message if the key is in grace_period status.
   #
   # @param key [ApiKey] the API key that was used
   # @return [void]
   def log_key_usage(key)
     key.update(last_used_at: Time.current)
 
-    # Log a warning when a grace-period key is used.
-    return unless key.grace_period?
-
-    log_message = '[API KEY] Grace-period key used ' \
-                  "(id=#{key.id}, expires_at=#{key.expires_at})"
-    Rails.logger.warn(log_message)
+    if key.grace_period?
+      log_message = '[API KEY] Grace-period key used ' \
+                    "(id=#{key.id}, status=#{key.status}, expires_at=#{key.expires_at})"
+      Rails.logger.warn(log_message)
+    else
+      log_message = '[API KEY] Key used ' \
+                    "(id=#{key.id}, status=#{key.status}, expires_at=#{key.expires_at})"
+      Rails.logger.info(log_message)
+    end
   end
 
   # Sets a response header warning when a grace-period API key is used.

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -136,6 +136,15 @@ module Authenticator
   #
   # @return [void]
   def handle_unauthenticated!
+    log_message = '[AUTH] Unauthenticated request ' \
+                  "method=#{request.request_method} " \
+                  "path=#{request.fullpath} " \
+                  "ip=#{request.remote_ip} " \
+                  "request_id=#{request.request_id}"
+    Rails.logger.warn(log_message)
+
+    return unless Flipper.enabled?(:y25_662_reject_unauthenticated_requests)
+
     render_unauthorized('Authentication required')
   end
 

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -22,9 +22,9 @@ module Authenticator
   def authenticate_request!
     return unless Flipper.enabled?(:y25_662_enable_request_authentication)
 
-    if bearer_token_present? # identity provider check
+    if bearer_token_present? # Identity provider check
       authenticate_bearer!
-    elsif api_key_present? # api key check
+    elsif api_key_present? # API Key check
       authenticate_api_key!
       enforce_api_key_permissions! # story requires API keys to be for GET.
     else
@@ -33,21 +33,26 @@ module Authenticator
     end
   end
 
-  # Identity provider authentication
+  # Checks if the Authorization header contains a Bearer token (OAuth2/JWT style)
+  # @return [Boolean] true if Bearer token is present, false otherwise
   def bearer_token_present?
     request.headers['Authorization']&.start_with?('Bearer ')
   end
 
+  # Authenticates a request using a Bearer token from the Authorization header.
+  # @return [void] Sets @current_auth to :bearer on success.
   def authenticate_bearer!
     token = bearer_token
 
+    # TODO(Y25-660): Identity provider integration
     return render_unauthorized('Invalid Bearer token') unless valid_bearer_token?(token)
 
     @current_auth = :bearer
   end
 
+  # Extracts the token value from the Authorization header in the format "Bearer <token>"
+  # @return [String, nil] Returns the token string if present, or nil otherwise
   def bearer_token
-    # extract token from "Bearer <token>" format
     request.headers['Authorization']&.split&.last
   end
 

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Plug this to authenticate requests using either Bearer tokens
+# (e.g. Identity Provider) or API keys.
+# TODO: handle paths v1 and flipper
+# TODO: UI needs to start with token flow and possibly check before each request
+# TODO: put behind flipper feature flag
+# TODO: migrations and models for api apps and api keys tables
+module Authenticator
+  extend ActiveSupport::Concern
+
+  API_KEY_HEADER = 'X-Traction-Client-Id' # Using headers instead of env, HTTP_X_TRACTION_CLIENT_ID in Rails.
+
+  included do
+    before_action :authenticate_request! # preceed all controller actions
+  end
+
+  private # not controller public actions
+
+  # Main authentication entry point
+  def authenticate_request!
+    if bearer_token_present? # identity provider check
+      authenticate_bearer!
+    elsif api_key_present? # api key check
+      authenticate_api_key!
+      enforce_api_key_permissions! # story requires API keys to be for GET.
+    else
+      # XXX: Should allow for now, or make a flipper flag
+      handle_unauthenticated! # return 401
+    end
+  end
+
+  # Identity provider authentication
+  def bearer_token_present?
+    request.headers['Authorization']&.start_with?('Bearer ')
+  end
+
+  def authenticate_bearer!
+    token = bearer_token
+
+    return render_unauthorized('Invalid Bearer token') unless valid_bearer_token?(token)
+
+    @current_auth = :bearer
+  end
+
+  def bearer_token
+    # extract token from "Bearer <token>" format
+    request.headers['Authorization']&.split&.last
+  end
+
+  def valid_bearer_token?(token)
+    # TODO: plug real Bearer validation here, i.e. Identity Provider, JWT, etc.
+    token.present?
+  end
+
+  # API key authentication
+  def api_key_present?
+    request.headers[API_KEY_HEADER].present?
+  end
+
+  def authenticate_api_key!
+    raw_key = request.headers[API_KEY_HEADER]
+
+    # XXX: prefix or not? Maybe helpful for rotation, and possible key types.
+    prefix, secret = parse_api_key(raw_key)
+    return render_unauthorized('Invalid API key format') unless prefix
+
+    key = ApiKey.find_by(prefix: prefix)
+    return render_unauthorized('API key not found') unless key
+
+    return render_unauthorized('API key revoked') unless key.active?
+
+    return render_unauthorized('Invalid API key') unless valid_secret?(secret, key.key_hash)
+
+    log_key_usage(key)
+
+    @current_auth = :api_key
+    @current_api_client = key.api_application
+  end
+
+  def parse_api_key(raw_key)
+    # assumes format "prefix.secret", where prefix is stored in DB and secret is hashed
+    parts = raw_key.split('.', 2)
+    return [nil, nil] unless parts.size == 2
+
+    parts
+  end
+
+  def valid_secret?(secret, key_hash)
+    # TODO: salt
+    BCrypt::Password.new(key_hash) == secret
+  end
+
+  # story says API keys should be read-only
+  def enforce_api_key_permissions!
+    return unless @current_auth == :api_key
+
+    return if request.get?
+
+    render_forbidden('API keys are read-only')
+  end
+
+  # transitional
+  def handle_unauthenticated!
+    # Y25-661: allow GET temporarily
+    return if request.get?
+
+    render_unauthorized('Authentication required')
+  end
+
+  # logging
+  def log_key_usage(key)
+    key.update(:last_used_at, Time.current)
+
+    # Soft "grace period" from rotation design from Y25-575
+    # XXX: checking against a magic number
+    return unless key.created_at < 3.months.ago
+
+    Rails.logger.warn("[API KEY] Old key used: #{key.id}")
+  end
+
+  # responses
+  def render_unauthorized(message)
+    render json: { error: message }, status: :unauthorized
+  end
+
+  def render_forbidden(message)
+    render json: { error: message }, status: :forbidden
+  end
+end

--- a/app/models/api_application.rb
+++ b/app/models/api_application.rb
@@ -4,8 +4,31 @@
 class ApiApplication < ApplicationRecord
   has_many :api_keys, dependent: :destroy
 
-  enum :privilege, { full: 0, read_only: 1 }
-
   validates :name, presence: true
   validates :contact_email, presence: true
+
+  # Rotates keys following the lifecycle:
+  #   grace_period -> expired  (no longer valid)
+  #   active       -> grace_period  (still valid, but caller is warned)
+  #   new key      -> active
+  # @param expires_at [Time, nil] the optional expiration time for the new key
+  # @return [Hash] a hash containing the new API key and its plaintext representation
+  def rotate_api_key!(expires_at: nil)
+    transaction do
+      now = Time.current
+      api_keys.grace_period.find_each { |key| key.update!(status: :expired, updated_at: now) }
+      api_keys.active.find_each { |key| key.update!(status: :grace_period, updated_at: now) }
+      issue_api_key!(expires_at: expires_at)
+    end
+  end
+
+  private
+
+  # Issues a new API key for this application.
+  #
+  # @param expires_at [Time, nil] Optional explicit expiry timestamp for the key.
+  # @return [Hash] Result from {ApiKey.issue!} containing :api_key and :plaintext_key.
+  def issue_api_key!(expires_at: nil)
+    ApiKey.issue!(api_application: self, expires_at: expires_at)
+  end
 end

--- a/app/models/api_application.rb
+++ b/app/models/api_application.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Represents an application that can access the API using API keys.
+class ApiApplication < ApplicationRecord
+  has_many :api_keys, dependent: :destroy
+
+  enum :privilege, { full: 0, read_only: 1 }
+
+  validates :name, presence: true
+  validates :contact_email, presence: true
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Represents an API key that can be used to authenticate API requests.
+class ApiKey < ApplicationRecord
+  belongs_to :api_application
+
+  enum :status, { active: 0, grace_period: 1, expired: 2, revoked: 3 }
+
+  validates :key, presence: true, uniqueness: true
+  validates :status, presence: true
+  validates :expires_at, presence: true
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -4,9 +4,26 @@
 class ApiKey < ApplicationRecord
   belongs_to :api_application
 
-  enum :status, { active: 0, grace_period: 1, expired: 2, revoked: 3 }
+  enum :status, { active: 0, grace_period: 1, expired: 2 }
 
-  validates :key, presence: true, uniqueness: true
+  validates :key_digest, presence: true, uniqueness: true
   validates :status, presence: true
-  validates :expires_at, presence: true
+
+  # Issues a new active key with a 6-month lifetime.
+  # The plaintext key is a 256-bit random token returned once and never stored;
+  # only its SHA-256 hex digest is persisted.
+  # @param api_application [ApiApplication] the application to associate the new key with
+  # @param expires_at [Time, nil] optional explicit expiry timestamp for the key (
+  def self.issue!(api_application:, expires_at: 6.months.from_now)
+    plaintext_key = SecureRandom.hex(32) # 64-char hex, 256 bits of entropy
+
+    api_key = create!(
+      api_application: api_application,
+      key_digest: Digest::SHA256.hexdigest(plaintext_key),
+      status: :active,
+      expires_at: expires_at
+    )
+
+    { api_key: api_key, plaintext_key: plaintext_key }
+  end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -9,12 +9,12 @@ class ApiKey < ApplicationRecord
   validates :key_digest, presence: true, uniqueness: true
   validates :status, presence: true
 
-  # Issues a new active key with a 6-month lifetime.
+  # Issues a new active key.
   # The plaintext key is a 256-bit random token returned once and never stored;
   # only its SHA-256 hex digest is persisted.
   # @param api_application [ApiApplication] the application to associate the new key with
-  # @param expires_at [Time, nil] optional explicit expiry timestamp for the key (
-  def self.issue!(api_application:, expires_at: 6.months.from_now)
+  # @param expires_at [Time, nil] optional explicit expiry timestamp for the key
+  def self.issue!(api_application:, expires_at: nil)
     plaintext_key = SecureRandom.hex(32) # 64-char hex, 256 bits of entropy
 
     api_key = create!(

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -2,3 +2,4 @@
 # dpl202_enable_angry_cat_feature: When enabled this will add an angry cat to all pages that will try to catch the mouse pointer
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
 y25_662_enable_request_authentication: When enabled, this will activate the new authenticator module
+y25_662_reject_unauthenticated_requests: When enabled, this will reject any unauthenticated requests

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,4 +1,4 @@
 # Add feature flags to this file, example:
 # dpl202_enable_angry_cat_feature: When enabled this will add an angry cat to all pages that will try to catch the mouse pointer
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
-y25_662_enable_request_authentication: When enabled, this will enable the new authenticator module
+y25_662_enable_request_authentication: When enabled, this will activate the new authenticator module

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,3 +1,4 @@
 # Add feature flags to this file, example:
 # dpl202_enable_angry_cat_feature: When enabled this will add an angry cat to all pages that will try to catch the mouse pointer
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
+y25_662_enable_request_authentication: When enabled, this will enable the new authenticator module

--- a/db/migrate/20260325120000_create_api_applications_and_api_keys.rb
+++ b/db/migrate/20260325120000_create_api_applications_and_api_keys.rb
@@ -1,0 +1,22 @@
+class CreateApiApplicationsAndApiKeys < ActiveRecord::Migration[7.0]
+  def change
+    create_table :api_applications do |t|
+      t.string :name, null: false # application name
+      t.string :contact
+      t.text :description
+      t.integer :privileges, default: 0, null: false # enum: 0=full, 1=read_only
+      t.timestamps
+    end
+
+    create_table :api_keys do |t|
+      t.references :api_application, null: false, foreign_key: true
+      t.string :key, null: false
+      t.integer :status, null: false, default: 0 # enum: 0=active, 1=grace_period, 2=expired, 3=revoked
+      t.datetime :expires_at
+      t.timestamps
+    end
+
+    add_index :api_keys, [:api_application_id, :status]
+    add_index :api_keys, :key, unique: true
+  end
+end

--- a/db/migrate/20260325120000_create_api_applications_and_api_keys.rb
+++ b/db/migrate/20260325120000_create_api_applications_and_api_keys.rb
@@ -2,7 +2,7 @@ class CreateApiApplicationsAndApiKeys < ActiveRecord::Migration[7.0]
   def change
     create_table :api_applications do |t|
       t.string :name, null: false # application name
-      t.string :contact_name
+      t.string :contact_name, null: false
       t.string :contact_email
       t.text :description
       t.integer :privileges, default: 0, null: false # enum: 0=full, 1=read_only

--- a/db/migrate/20260325120000_create_api_applications_and_api_keys.rb
+++ b/db/migrate/20260325120000_create_api_applications_and_api_keys.rb
@@ -2,7 +2,8 @@ class CreateApiApplicationsAndApiKeys < ActiveRecord::Migration[7.0]
   def change
     create_table :api_applications do |t|
       t.string :name, null: false # application name
-      t.string :contact
+      t.string :contact_name
+      t.string :contact_email
       t.text :description
       t.integer :privileges, default: 0, null: false # enum: 0=full, 1=read_only
       t.timestamps

--- a/db/migrate/20260325120000_create_api_applications_and_api_keys.rb
+++ b/db/migrate/20260325120000_create_api_applications_and_api_keys.rb
@@ -5,19 +5,19 @@ class CreateApiApplicationsAndApiKeys < ActiveRecord::Migration[7.0]
       t.string :contact_name, null: false
       t.string :contact_email
       t.text :description
-      t.integer :privileges, default: 0, null: false # enum: 0=full, 1=read_only
       t.timestamps
     end
 
     create_table :api_keys do |t|
       t.references :api_application, null: false, foreign_key: true
-      t.string :key, null: false
-      t.integer :status, null: false, default: 0 # enum: 0=active, 1=grace_period, 2=expired, 3=revoked
+      t.string :key_digest, null: false
+      t.integer :status, null: false, default: 0 # enum: 0=active, 1=grace_period, 2=expired
       t.datetime :expires_at
+      t.datetime :last_used_at
       t.timestamps
     end
 
     add_index :api_keys, [:api_application_id, :status]
-    add_index :api_keys, :key, unique: true
+    add_index :api_keys, :key_digest, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,6 +31,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_120000) do
     t.index ["used_by_type", "used_by_id"], name: "index_aliquots_on_used_by"
   end
 
+  create_table "api_applications", charset: "utf8mb3", force: :cascade do |t|
+    t.string "contact_email"
+    t.string "contact_name", null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "api_keys", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "api_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at"
+    t.string "key_digest", null: false
+    t.datetime "last_used_at"
+    t.integer "status", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_application_id", "status"], name: "index_api_keys_on_api_application_id_and_status"
+    t.index ["api_application_id"], name: "index_api_keys_on_api_application_id"
+    t.index ["key_digest"], name: "index_api_keys_on_key_digest", unique: true
+  end
+
   create_table "annotation_types", charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
@@ -48,28 +70,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_120000) do
     t.string "user", limit: 10, null: false
     t.index ["annotatable_type", "annotatable_id"], name: "index_annotations_on_annotatable"
     t.index ["annotation_type_id"], name: "index_annotations_on_annotation_type_id"
-  end
-
-  create_table "api_applications", charset: "utf8mb3", force: :cascade do |t|
-    t.string "contact_email"
-    t.string "contact_name", null: false
-    t.datetime "created_at", null: false
-    t.text "description"
-    t.string "name", null: false
-    t.integer "privileges", default: 0, null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "api_keys", charset: "utf8mb3", force: :cascade do |t|
-    t.bigint "api_application_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "expires_at"
-    t.string "key", null: false
-    t.integer "status", default: 0, null: false
-    t.datetime "updated_at", null: false
-    t.index ["api_application_id", "status"], name: "index_api_keys_on_api_application_id_and_status"
-    t.index ["api_application_id"], name: "index_api_keys_on_api_application_id"
-    t.index ["key"], name: "index_api_keys_on_key", unique: true
   end
 
   create_table "container_materials", charset: "utf8mb3", force: :cascade do |t|
@@ -524,7 +524,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_120000) do
   end
 
   add_foreign_key "annotations", "annotation_types"
-  add_foreign_key "api_keys", "api_applications"
   add_foreign_key "ont_flowcells", "ont_pools"
   add_foreign_key "ont_flowcells", "ont_runs"
   add_foreign_key "ont_requests", "data_types"
@@ -544,4 +543,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_120000) do
   add_foreign_key "qc_results", "qc_receptions"
   add_foreign_key "requests", "receptions"
   add_foreign_key "workflow_steps", "workflows"
+  add_foreign_key "api_keys", "api_applications"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_13_150155) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_120000) do
   create_table "aliquots", charset: "utf8mb3", force: :cascade do |t|
     t.integer "aliquot_type", default: 0, null: false
     t.float "concentration"
@@ -48,6 +48,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_150155) do
     t.string "user", limit: 10, null: false
     t.index ["annotatable_type", "annotatable_id"], name: "index_annotations_on_annotatable"
     t.index ["annotation_type_id"], name: "index_annotations_on_annotation_type_id"
+  end
+
+  create_table "api_applications", charset: "utf8mb3", force: :cascade do |t|
+    t.string "contact_email"
+    t.string "contact_name"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.integer "privileges", default: 0, null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "api_keys", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "api_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at"
+    t.string "key", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_application_id", "status"], name: "index_api_keys_on_api_application_id_and_status"
+    t.index ["api_application_id"], name: "index_api_keys_on_api_application_id"
+    t.index ["key"], name: "index_api_keys_on_key", unique: true
   end
 
   create_table "container_materials", charset: "utf8mb3", force: :cascade do |t|
@@ -502,6 +524,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_150155) do
   end
 
   add_foreign_key "annotations", "annotation_types"
+  add_foreign_key "api_keys", "api_applications"
   add_foreign_key "ont_flowcells", "ont_pools"
   add_foreign_key "ont_flowcells", "ont_runs"
   add_foreign_key "ont_requests", "data_types"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,7 +52,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_120000) do
 
   create_table "api_applications", charset: "utf8mb3", force: :cascade do |t|
     t.string "contact_email"
-    t.string "contact_name"
+    t.string "contact_name", null: false
     t.datetime "created_at", null: false
     t.text "description"
     t.string "name", null: false

--- a/lib/tasks/api_keys.rake
+++ b/lib/tasks/api_keys.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+namespace :api_keys do
+  desc 'Rotate API key for a single app: rake "api_keys:rotate[api_application_name,expires_at]"'
+  task :rotate, %i[api_application_name expires_at] => :environment do |_task, args|
+    api_application_name = args[:api_application_name]
+    raise ArgumentError, 'api_application_name is required' if api_application_name.blank?
+
+    api_application = ApiApplication.find_by(name: api_application_name)
+    unless api_application
+      raise ActiveRecord::RecordNotFound, "ApiApplication '#{api_application_name}' not found"
+    end
+
+    expires_at = nil
+    if args[:expires_at].present?
+      expires_at = Time.zone.parse(args[:expires_at])
+      if expires_at.nil?
+        raise ArgumentError, "Invalid expires_at '#{args[:expires_at]}'. Use an ISO-like datetime."
+      end
+    end
+
+    result = api_application.rotate_api_key!(expires_at: expires_at)
+
+    puts "Rotated API key for app #{api_application.id} (#{api_application.name})"
+    puts "  New key: #{result[:plaintext_key]}"
+    puts "  Expires: #{result[:api_key].expires_at || 'default policy'}"
+    puts 'Rotation complete.'
+  end
+end

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -50,6 +50,9 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
     issued = api_application.rotate_api_key!
 
     request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
+
+    allow(Rails.logger).to receive(:info)
+    expect(Rails.logger).to receive(:info).with(match(/\[API KEY\] Key used/))
     get :index
 
     expect(response).to have_http_status(:ok)
@@ -82,6 +85,8 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
     api_application.rotate_api_key!
 
     request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
+
+    expect(Rails.logger).to receive(:warn).with(match(/\[API KEY\] Grace-period key used/))
     get :index
 
     expect(response).to have_http_status(:ok)

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -115,4 +115,14 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
 
     expect(response).to have_http_status(:ok)
   end
+
+  it 'permits non-expiring API keys' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+    issued = api_application.rotate_api_key!(expires_at: nil)
+
+    request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
+    get :index
+
+    expect(response).to have_http_status(:ok)
+  end
 end

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
+  let(:feature) { :y25_662_enable_request_authentication }
+
+  # Dummy controller for testing
+  controller(ApplicationController) do
+    include Authenticator
+
+    def index
+      render plain: 'ok'
+    end
+  end
+
+  before do
+    routes.draw { get 'index' => 'anonymous#index' }
+  end
+
+  it 'skips authentication when Flipper flag is disabled' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(false)
+    get :index
+    expect(response.body).to eq('ok')
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'calls authentication when Flipper flag is enabled' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+    # No auth headers, so should be unauthorized
+    get :index
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
     expect(response).to have_http_status(:unauthorized)
   end
 
-  it 'forbids non-GET requests authenticated by API key' do
+  it 'permits non-GET requests authenticated by API key' do
     allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
     issued = api_application.rotate_api_key!
 
     request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
     post :create
 
-    expect(response).to have_http_status(:forbidden)
+    expect(response).to have_http_status(:ok)
   end
 
   it 'authenticates a grace-period API key and sets a deprecation warning header' do

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
   let(:feature) { :y25_662_enable_request_authentication }
+  let(:feature_reject_unauthenticated) { :y25_662_reject_unauthenticated_requests }
   let(:api_application) { create(:api_application) }
 
   # Dummy controller for testing
@@ -20,6 +21,8 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
   end
 
   before do
+    allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(true)
+
     routes.draw do
       get 'index' => 'anonymous#index'
       post 'create' => 'anonymous#create'
@@ -124,5 +127,46 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
     get :index
 
     expect(response).to have_http_status(:ok)
+  end
+
+  context 'unauthenticated request behavior' do
+    it 'logs unauthenticated requests' do
+      allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+      allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
+
+      expect(Rails.logger).to receive(:warn).with(match(/\[AUTH\] Unauthenticated request/))
+      get :index
+    end
+
+    it 'allows unauthenticated requests when reject flag is OFF' do
+      allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+      allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
+
+      get :index
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq('ok')
+    end
+
+    it 'rejects unauthenticated requests when reject flag is ON' do
+      allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+      allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(true)
+
+      get :index
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'includes method, path, ip, and request_id in unauthenticated log' do
+      allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+      allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
+
+      expect(Rails.logger).to receive(:warn) do |message|
+        expect(message).to include('[AUTH] Unauthenticated request')
+        expect(message).to include('method=GET')
+        expect(message).to include('path=/index')
+        expect(message).to include('ip=')
+        expect(message).to include('request_id=')
+      end
+      get :index
+    end
   end
 end

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
 
   # Dummy controller for testing
   controller(ApplicationController) do
+    # Define methods on a temporary class named AnonymousController.
     include Authenticator
 
     def index
@@ -24,6 +25,7 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
     allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(true)
 
     routes.draw do
+      # Define routes for the anonymous controller to test requests.
       get 'index' => 'anonymous#index'
       post 'create' => 'anonymous#create'
     end

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
   let(:feature) { :y25_662_enable_request_authentication }
+  let(:api_application) { create(:api_application) }
 
   # Dummy controller for testing
   controller(ApplicationController) do
@@ -12,10 +13,17 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
     def index
       render plain: 'ok'
     end
+
+    def create
+      render plain: 'created'
+    end
   end
 
   before do
-    routes.draw { get 'index' => 'anonymous#index' }
+    routes.draw do
+      get 'index' => 'anonymous#index'
+      post 'create' => 'anonymous#create'
+    end
   end
 
   it 'skips authentication when Flipper flag is disabled' do
@@ -30,5 +38,81 @@ RSpec.describe 'Authenticator Flipper feature flagging', type: :controller do
     # No auth headers, so should be unauthorized
     get :index
     expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'authenticates a valid API key for GET requests' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+    issued = api_application.rotate_api_key!
+
+    request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
+    get :index
+
+    expect(response).to have_http_status(:ok)
+    expect(issued[:api_key].reload.last_used_at).not_to be_nil
+  end
+
+  it 'rejects malformed API keys' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+
+    request.headers['X-Traction-Client-Id'] = 'bad-format-key'
+    get :index
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'forbids non-GET requests authenticated by API key' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+    issued = api_application.rotate_api_key!
+
+    request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
+    post :create
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it 'authenticates a grace-period API key and sets a deprecation warning header' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+    # Issue a key then rotate so the first key moves to grace_period
+    issued = api_application.rotate_api_key!
+    api_application.rotate_api_key!
+
+    request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
+    get :index
+
+    expect(response).to have_http_status(:ok)
+    expect(response.headers['X-Traction-Client-Id-Warning']).to match(/deprecated/i)
+  end
+
+  it 'rejects an expired API key' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+    # Two rotations push the original key to expired
+    issued = api_application.rotate_api_key!
+    api_application.rotate_api_key!
+    api_application.rotate_api_key!
+
+    request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
+    get :index
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'rejects an active API key when expires_at has passed' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+    issued = api_application.rotate_api_key!
+    issued[:api_key].update!(expires_at: 1.minute.ago)
+
+    request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
+    get :index
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'permits bearer-authenticated non-GET requests' do
+    allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+
+    request.headers['Authorization'] = 'Bearer valid-token'
+    post :create
+
+    expect(response).to have_http_status(:ok)
   end
 end

--- a/spec/factories/api_applications.rb
+++ b/spec/factories/api_applications.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_application do
+    sequence(:name) { |n| "api-app-#{n}" }
+    sequence(:contact_name) { |n| "Developer #{n}" }
+    sequence(:contact_email) { |n| "developer#{n}@example.com" }
+    description { 'Programmatic integration client' }
+  end
+end

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_key do
+    api_application
+    key_digest { Digest::SHA256.hexdigest(SecureRandom.hex(32)) }
+    status { :active }
+    expires_at { 1.year.from_now }
+  end
+end

--- a/spec/lib/tasks/api_keys.rake_spec.rb
+++ b/spec/lib/tasks/api_keys.rake_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+# only load Rake tasks if they haven't been loaded already
+Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+RSpec.describe 'RakeTasks' do
+  describe 'api_keys:rotate' do
+    before do
+      Rake::Task['api_keys:rotate'].reenable
+    end
+
+    it 'rotates an API key for a single application by name' do
+      api_application = create(:api_application)
+
+      expect { Rake::Task['api_keys:rotate'].invoke(api_application.name) }
+        .to change(ApiKey, :count).by(1)
+        .and output(/Rotation complete\./).to_stdout
+    end
+
+    it 'requires api_application_name argument' do
+      expect { Rake::Task['api_keys:rotate'].invoke }
+        .to raise_error(ArgumentError, 'api_application_name is required')
+    end
+
+    it 'raises when application name does not exist' do
+      expect { Rake::Task['api_keys:rotate'].invoke('missing-app') }
+        .to raise_error(ActiveRecord::RecordNotFound, "ApiApplication 'missing-app' not found")
+    end
+
+    it 'raises for invalid expires_at format' do
+      api_application = create(:api_application)
+
+      expect { Rake::Task['api_keys:rotate'].invoke(api_application.name, 'not-a-date') }
+        .to raise_error(ArgumentError, /Invalid expires_at/)
+    end
+  end
+end

--- a/spec/models/api_application_spec.rb
+++ b/spec/models/api_application_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApiApplication do
+  it 'issues API keys through rotation when no prior keys exist' do
+    api_application = create(:api_application)
+
+    result = api_application.rotate_api_key!
+
+    expect(result[:api_key]).to be_persisted
+    expect(result[:api_key].api_application).to eq(api_application)
+    expect(result[:plaintext_key]).to be_a(String)
+    expect(result[:plaintext_key].length).to eq(64) # 32-byte hex = 64 chars
+  end
+
+  it 'rotates API keys: active key moves to grace_period and a new active key is issued' do
+    api_application = create(:api_application)
+    current = api_application.rotate_api_key![:api_key]
+
+    rotated = api_application.rotate_api_key!
+
+    expect(current.reload).to be_grace_period
+    expect(rotated[:api_key]).to be_active
+    expect(rotated[:api_key].id).not_to eq(current.id)
+  end
+
+  it 'rotates API keys a second time: previous grace_period key moves to expired' do
+    api_application = create(:api_application)
+    original = api_application.rotate_api_key![:api_key]
+
+    first_rotation = api_application.rotate_api_key![:api_key]
+    api_application.rotate_api_key!
+
+    expect(original.reload).to be_expired
+    expect(first_rotation.reload).to be_grace_period
+  end
+end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -17,4 +17,12 @@ RSpec.describe ApiKey do
     expect(result[:api_key].key_digest).to eq(Digest::SHA256.hexdigest(plaintext))
     expect(result[:api_key].key_digest).not_to eq(plaintext)
   end
+
+  it 'issues non-expiring keys by default' do
+    api_application = create(:api_application)
+
+    result = described_class.issue!(api_application: api_application)
+
+    expect(result[:api_key].expires_at).to be_nil
+  end
 end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApiKey do
+  it 'is valid with factory defaults' do
+    expect(build(:api_key)).to be_valid
+  end
+
+  it 'issues a key and stores only a SHA-256 digest, not the plaintext' do
+    api_application = create(:api_application)
+
+    result = described_class.issue!(api_application: api_application)
+    plaintext = result[:plaintext_key]
+
+    expect(result[:api_key]).to be_persisted
+    expect(result[:api_key].key_digest).to eq(Digest::SHA256.hexdigest(plaintext))
+    expect(result[:api_key].key_digest).not_to eq(plaintext)
+  end
+end


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

Adds API key support for programmatic access to Traction service

- Added ApiApplication and ApiKey models.
- Implemented API key issuance using one-time plaintext tokens with persisted SHA-256 key_digest only.
- Implemented lifecycle rotation in ApiApplication#rotate_api_key!:
  - active -> grace_period
  - grace_period -> expired
  - issue new active key

- Added Authenticator concern flow for:
  - Bearer token auth path
  - API key auth via X-Traction-Client-Id
  - GET-only enforcement for API-key-authenticated requests
  - grace-period warning header
  - expires_at enforcement in auth checks [We are allowing non-expiring keys for now]

- Added migration and schema updates for:
  - api_applications
  - api_keys (key_digest, status, expires_at, last_used_at)

- Added rake task:
  - api_keys:rotate[api_application_name,expires_at] for single-app key rotation by name.

- Added factories and full test coverage for models, authenticator flows, and rake task behaviour.

Notes:
- ~API keys are treated as read-only credentials (GET requests only)~ [post using API Key should be allowed]
- A key can be rejected either by lifecycle status (expired) or by expires_at having passed.
- Grace-period keys remain valid but return a deprecation warning header.
- Marked the places for Y25-661 (OKTA) https://github.com/sanger/traction-service/issues/1735

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
