### PR TITLE
Y26-150 - Add tol-lab-share api key

### DIFF
--- a/app/models/api_application.rb
+++ b/app/models/api_application.rb
@@ -5,7 +5,7 @@ class ApiApplication < ApplicationRecord
   has_many :api_keys, dependent: :destroy
 
   validates :name, presence: true
-  validates :contact_email, presence: true
+  validates :contact_name, presence: true
 
   # Rotates keys following the lifecycle:
   #   grace_period -> expired  (no longer valid)

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -14,8 +14,9 @@ class ApiKey < ApplicationRecord
   # only its SHA-256 hex digest is persisted.
   # @param api_application [ApiApplication] the application to associate the new key with
   # @param expires_at [Time, nil] optional explicit expiry timestamp for the key
-  def self.issue!(api_application:, expires_at: nil)
-    plaintext_key = SecureRandom.hex(32) # 64-char hex, 256 bits of entropy
+  # @param plaintext_key [String, nil] optional plaintext key (should only be used for testing)
+  def self.issue!(api_application:, expires_at: nil, plaintext_key: nil)
+    plaintext_key ||= SecureRandom.hex(32) # 64-char hex, 256 bits of entropy
 
     api_key = create!(
       api_application: api_application,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,3 +12,5 @@ Rake::Task['smrt_link_versions:create'].invoke
 Rake::Task['ont_instruments:create'].invoke
 Rake::Task['min_know_versions:create'].invoke
 Rake::Task['tol_tubes_report_view:create'].invoke
+# We don't want to expose these keys in non-development environments, so we only seed them for development
+Rake::Task['local_api_key:create'].invoke if Rails.env.development?

--- a/lib/tasks/create_local_api_key.rake
+++ b/lib/tasks/create_local_api_key.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This Rake task creates a local API key for testing purposes.
+namespace :local_api_key do
+  desc 'Create local API keys for testing'
+  task create: :environment do
+    # Initially created for local development with tol-lab-share, but can be used for any local testing requiring API key authentication.
+    default_app = ApiApplication.create(name: 'Default application', contact_name: 'default-application')
+    ApiKey.issue!(api_application: default_app, plaintext_key: 'traction-development')
+
+    puts '-> Local api key created'
+  end
+end

--- a/lib/tasks/pacbio_data.rake
+++ b/lib/tasks/pacbio_data.rake
@@ -83,16 +83,17 @@ namespace :pacbio_data do
       # 96 is the number of possible pools for pooling_method Plate,
       # which is the only pooling method currently used
       position_range = (1..96).to_a
+      positions = position_range.sample(2)
       MultiPool.create!(
         pool_method: :Plate,
         pipeline: :pacbio,
         multi_pool_positions: [
           MultiPoolPosition.new(
-            position: position_range.sample,
+            position: positions[0],
             pool: untagged_pool
           ),
           MultiPoolPosition.new(
-            position: position_range.sample,
+            position: positions[1],
             pool: tagged_pool
           )
         ]

--- a/spec/models/api_application_spec.rb
+++ b/spec/models/api_application_spec.rb
@@ -3,36 +3,52 @@
 require 'rails_helper'
 
 RSpec.describe ApiApplication do
-  it 'issues API keys through rotation when no prior keys exist' do
-    api_application = create(:api_application)
+  describe 'validations' do
+    it 'is valid with factory defaults' do
+      expect(build(:api_application)).to be_valid
+    end
 
-    result = api_application.rotate_api_key!
+    it 'is invalid without a name' do
+      expect(build(:api_application, name: nil)).not_to be_valid
+    end
 
-    expect(result[:api_key]).to be_persisted
-    expect(result[:api_key].api_application).to eq(api_application)
-    expect(result[:plaintext_key]).to be_a(String)
-    expect(result[:plaintext_key].length).to eq(64) # 32-byte hex = 64 chars
+    it 'is invalid without a contact_name' do
+      expect(build(:api_application, contact_name: nil)).not_to be_valid
+    end
   end
 
-  it 'rotates API keys: active key moves to grace_period and a new active key is issued' do
-    api_application = create(:api_application)
-    current = api_application.rotate_api_key![:api_key]
+  describe '.rotate_api_key!' do
+    it 'issues API keys through rotation when no prior keys exist' do
+      api_application = create(:api_application)
 
-    rotated = api_application.rotate_api_key!
+      result = api_application.rotate_api_key!
 
-    expect(current.reload).to be_grace_period
-    expect(rotated[:api_key]).to be_active
-    expect(rotated[:api_key].id).not_to eq(current.id)
-  end
+      expect(result[:api_key]).to be_persisted
+      expect(result[:api_key].api_application).to eq(api_application)
+      expect(result[:plaintext_key]).to be_a(String)
+      expect(result[:plaintext_key].length).to eq(64) # 32-byte hex = 64 chars
+    end
 
-  it 'rotates API keys a second time: previous grace_period key moves to expired' do
-    api_application = create(:api_application)
-    original = api_application.rotate_api_key![:api_key]
+    it 'rotates API keys: active key moves to grace_period and a new active key is issued' do
+      api_application = create(:api_application)
+      current = api_application.rotate_api_key![:api_key]
 
-    first_rotation = api_application.rotate_api_key![:api_key]
-    api_application.rotate_api_key!
+      rotated = api_application.rotate_api_key!
 
-    expect(original.reload).to be_expired
-    expect(first_rotation.reload).to be_grace_period
+      expect(current.reload).to be_grace_period
+      expect(rotated[:api_key]).to be_active
+      expect(rotated[:api_key].id).not_to eq(current.id)
+    end
+
+    it 'rotates API keys a second time: previous grace_period key moves to expired' do
+      api_application = create(:api_application)
+      original = api_application.rotate_api_key![:api_key]
+
+      first_rotation = api_application.rotate_api_key![:api_key]
+      api_application.rotate_api_key!
+
+      expect(original.reload).to be_expired
+      expect(first_rotation.reload).to be_grace_period
+    end
   end
 end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ApiKey do
 
     it 'allows issuing keys with explicit expiration' do
       api_application = create(:api_application)
-      expires_at = 1.week.from_now
+      expires_at = 1.week.from_now.beginning_of_day
 
       result = described_class.issue!(api_application: api_application, expires_at: expires_at)
 

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -7,22 +7,43 @@ RSpec.describe ApiKey do
     expect(build(:api_key)).to be_valid
   end
 
-  it 'issues a key and stores only a SHA-256 digest, not the plaintext' do
-    api_application = create(:api_application)
+  describe '.issue!' do
+    it 'issues a key and stores only a SHA-256 digest, not the plaintext' do
+      api_application = create(:api_application)
 
-    result = described_class.issue!(api_application: api_application)
-    plaintext = result[:plaintext_key]
+      result = described_class.issue!(api_application: api_application)
+      plaintext = result[:plaintext_key]
 
-    expect(result[:api_key]).to be_persisted
-    expect(result[:api_key].key_digest).to eq(Digest::SHA256.hexdigest(plaintext))
-    expect(result[:api_key].key_digest).not_to eq(plaintext)
-  end
+      expect(result[:api_key]).to be_persisted
+      expect(result[:api_key].key_digest).to eq(Digest::SHA256.hexdigest(plaintext))
+      expect(result[:api_key].key_digest).not_to eq(plaintext)
+    end
 
-  it 'issues non-expiring keys by default' do
-    api_application = create(:api_application)
+    it 'issues non-expiring keys by default' do
+      api_application = create(:api_application)
 
-    result = described_class.issue!(api_application: api_application)
+      result = described_class.issue!(api_application: api_application)
 
-    expect(result[:api_key].expires_at).to be_nil
+      expect(result[:api_key].expires_at).to be_nil
+    end
+
+    it 'allows issuing keys with explicit expiration' do
+      api_application = create(:api_application)
+      expires_at = 1.week.from_now
+
+      result = described_class.issue!(api_application: api_application, expires_at: expires_at)
+
+      expect(result[:api_key].expires_at).to eq(expires_at)
+    end
+
+    it 'allows issuing keys with explicit plaintext' do
+      api_application = create(:api_application)
+      plaintext_key = 'my-explicit-test-key'
+
+      result = described_class.issue!(api_application: api_application, plaintext_key: plaintext_key)
+
+      expect(result[:plaintext_key]).to eq(plaintext_key)
+      expect(result[:api_key].key_digest).to eq(Digest::SHA256.hexdigest(plaintext_key))
+    end
   end
 end


### PR DESCRIPTION
Relates to https://github.com/sanger/tol-lab-share/issues/311

#### Changes proposed in this pull request

- Corrects ApiApplication contact presence check.
- Adds default api key rake task for local development. 

- Unrelated: fixes flakey pacbio_data test.

