### PR TITLE
ci: remove fail-fast from rubocop command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
         uses: sanger/.github/.github/actions/setup/ruby@master
 
       - name: Run rubocop
-        run: bundle exec rubocop -c .rubocop.yml --fail-fast 
+        run: bundle exec rubocop -c .rubocop.yml

--- a/app/controllers/v1/ont/runs_controller.rb
+++ b/app/controllers/v1/ont/runs_controller.rb
@@ -8,7 +8,7 @@ module V1
     class RunsController < ApplicationController
       # endpoint generating a sample sheet for a Ont::Run
       def sample_sheet
-        run = ::Ont::Run.find(params[:run_id])
+        run = ::Ont::Run.find(params.expect(:run_id))
         csv = run.generate_sample_sheet
 
         send_data csv,

--- a/app/controllers/v1/pacbio/runs/plates_controller.rb
+++ b/app/controllers/v1/pacbio/runs/plates_controller.rb
@@ -36,7 +36,7 @@ module V1
         end
 
         def plate
-          @plate ||= ::Pacbio::Plate.find(params[:id])
+          @plate ||= ::Pacbio::Plate.find(params.expect(:id))
         end
 
         def render_json(status)

--- a/app/controllers/v1/pacbio/runs_controller.rb
+++ b/app/controllers/v1/pacbio/runs_controller.rb
@@ -8,7 +8,7 @@ module V1
     class RunsController < ApplicationController
       # endpoint generating a sample sheet for a Pacbio::Run
       def sample_sheet
-        run = ::Pacbio::Run.find(params[:run_id])
+        run = ::Pacbio::Run.find(params.expect(:run_id))
 
         begin
           csv = run.generate_sample_sheet

--- a/app/controllers/v1/tags_controller.rb
+++ b/app/controllers/v1/tags_controller.rb
@@ -34,7 +34,7 @@ module V1
     end
 
     def tag
-      @tag ||= Tag.find(params[:id])
+      @tag ||= Tag.find(params.expect(:id))
     end
 
     def render_json(status)

--- a/app/resources/v1/multi_pool_resource.rb
+++ b/app/resources/v1/multi_pool_resource.rb
@@ -134,9 +134,9 @@ module V1
 
     filter :pool_barcode, apply: lambda { |records, value, _options|
       pacbio_pools = records.joins(multi_pool_positions: { pacbio_pool: :tube })
-                     .where(tubes: { barcode: value })
+                            .where(tubes: { barcode: value })
       ont_pools = records.joins(multi_pool_positions: { ont_pool: :tube })
-                  .where(tubes: { barcode: value })
+                         .where(tubes: { barcode: value })
       records.where(id: pacbio_pools.select(:id)).or(records.where(id: ont_pools.select(:id)))
     }
 


### PR DESCRIPTION
#### Changes proposed in this pull request

- Remove fail fast as it was hiding errors.

