### PR TITLE
Remove stale feature flags

### DIFF
--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -143,8 +143,6 @@ module Authenticator
                   "request_id=#{request.request_id}"
     Rails.logger.warn(log_message)
 
-    return unless Flipper.enabled?(:y25_662_reject_unauthenticated_requests)
-
     render_unauthorized('Authentication required')
   end
 

--- a/app/controllers/concerns/authenticator.rb
+++ b/app/controllers/concerns/authenticator.rb
@@ -35,8 +35,6 @@ module Authenticator
   #
   # @return [void]
   def authenticate_request!
-    return unless Flipper.enabled?(:y25_662_enable_request_authentication)
-
     if bearer_token_present?
       authenticate_bearer!
     elsif api_key_present?

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,4 +1,3 @@
 # Add feature flags to this file, example:
 # dpl202_enable_angry_cat_feature: When enabled this will add an angry cat to all pages that will try to catch the mouse pointer
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
-y25_662_reject_unauthenticated_requests: When enabled, this will reject any unauthenticated requests

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,5 +1,4 @@
 # Add feature flags to this file, example:
 # dpl202_enable_angry_cat_feature: When enabled this will add an angry cat to all pages that will try to catch the mouse pointer
 # The key should be lowercase and snake case, and prefixes with the issue number to allow easy identification
-y25_662_enable_request_authentication: When enabled, this will activate the new authenticator module
 y25_662_reject_unauthenticated_requests: When enabled, this will reject any unauthenticated requests

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Authenticator', type: :controller do
-  let(:feature_flag) { :y25_662_enable_request_authentication }
   let(:feature_reject_unauthenticated) { :y25_662_reject_unauthenticated_requests }
   let(:api_application) { create(:api_application) }
 
@@ -32,34 +31,15 @@ RSpec.describe 'Authenticator', type: :controller do
   end
 
   context 'GET requests' do
-    it 'allows unauthenticated GET requests regardless of feature flag' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
-
+    it 'allows unauthenticated GET requests' do
       get :index
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq('ok')
     end
   end
 
-  context 'Authenticator feature flag' do
-    it 'skips authentication when Flipper flag is disabled' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(false)
-      post :create
-      expect(response.body).to eq('created')
-      expect(response).to have_http_status(:ok)
-    end
-
-    it 'calls authentication when Flipper flag is enabled' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
-      # No auth headers, so should be unauthorized
-      post :create
-      expect(response).to have_http_status(:unauthorized)
-    end
-  end
-
   context 'API key authentication' do
     it 'authenticates a valid API key for POST requests' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       issued = api_application.rotate_api_key!
 
       request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
@@ -73,8 +53,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'rejects malformed API keys' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
-
       request.headers['X-Traction-Client-Id'] = 'bad-format-key'
       post :create
 
@@ -82,7 +60,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'permits non-GET requests authenticated by API key' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       issued = api_application.rotate_api_key!
 
       request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
@@ -92,7 +69,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'authenticates a grace-period API key and sets a deprecation warning header' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       # Issue a key then rotate so the first key moves to grace_period
       issued = api_application.rotate_api_key!
       api_application.rotate_api_key!
@@ -107,7 +83,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'rejects an expired API key' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       # Two rotations push the original key to expired
       issued = api_application.rotate_api_key!
       api_application.rotate_api_key!
@@ -120,7 +95,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'rejects an active API key when expires_at has passed' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       issued = api_application.rotate_api_key!
       issued[:api_key].update!(expires_at: 1.minute.ago)
 
@@ -131,7 +105,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'permits non-expiring API keys' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       issued = api_application.rotate_api_key!(expires_at: nil)
 
       request.headers['X-Traction-Client-Id'] = issued[:plaintext_key]
@@ -143,7 +116,6 @@ RSpec.describe 'Authenticator', type: :controller do
 
   context 'unauthenticated requests' do
     it 'logs unauthenticated requests' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
 
       expect(Rails.logger).to receive(:warn).with(include('[AUTH] Unauthenticated request'))
@@ -151,7 +123,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'allows unauthenticated requests when reject flag is OFF' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
 
       post :create
@@ -160,7 +131,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'rejects unauthenticated requests when reject flag is ON' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(true)
 
       post :create
@@ -168,7 +138,6 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'includes method, path, ip, and request_id in unauthenticated log' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
 
       expect(Rails.logger).to receive(:warn) do |message|
@@ -197,21 +166,18 @@ RSpec.describe 'Authenticator', type: :controller do
     end
 
     it 'rejects an invalid bearer token' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       request.headers['Authorization'] = 'Bearer '
       post :create
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'rejects a bearer token with invalid credentials' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       request.headers['Authorization'] = 'Bearer invalid-token'
       post :create
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'permits bearer-authenticated non-GET requests with a valid token' do
-      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
       request.headers['Authorization'] = 'Bearer valid-token'
       post :create
       expect(response).to have_http_status(:ok)

--- a/spec/controllers/concerns/authenticator_spec.rb
+++ b/spec/controllers/concerns/authenticator_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Authenticator', type: :controller do
-  let(:feature_reject_unauthenticated) { :y25_662_reject_unauthenticated_requests }
   let(:api_application) { create(:api_application) }
 
   # Dummy controller for testing
@@ -21,8 +20,6 @@ RSpec.describe 'Authenticator', type: :controller do
   end
 
   before do
-    allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(true)
-
     routes.draw do
       # Define routes for the anonymous controller to test requests.
       get 'index' => 'anonymous#index'
@@ -116,30 +113,16 @@ RSpec.describe 'Authenticator', type: :controller do
 
   context 'unauthenticated requests' do
     it 'logs unauthenticated requests' do
-      allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
-
       expect(Rails.logger).to receive(:warn).with(include('[AUTH] Unauthenticated request'))
       post :create
     end
 
-    it 'allows unauthenticated requests when reject flag is OFF' do
-      allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
-
-      post :create
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to eq('created')
-    end
-
-    it 'rejects unauthenticated requests when reject flag is ON' do
-      allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(true)
-
+    it 'rejects unauthenticated requests' do
       post :create
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'includes method, path, ip, and request_id in unauthenticated log' do
-      allow(Flipper).to receive(:enabled?).with(feature_reject_unauthenticated).and_return(false)
-
       expect(Rails.logger).to receive(:warn) do |message|
         expect(message).to include('[AUTH] Unauthenticated request')
         expect(message).to include('method=POST')

--- a/spec/requests/v1/data_types_spec.rb
+++ b/spec/requests/v1/data_types_spec.rb
@@ -39,18 +39,18 @@ RSpec.describe 'DataTypesController' do
       end
 
       it 'has a created status' do
-        post v1_data_types_path, params: body, headers: json_api_headers
+        post v1_data_types_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a data type' do
         expect do
-          post v1_data_types_path, params: body, headers: json_api_headers
+          post v1_data_types_path, params: body, headers: auth_json_api_headers
         end.to change(DataType, :count).by(1)
       end
 
       it 'creates a data type with the correct attributes' do
-        post v1_data_types_path, params: body, headers: json_api_headers
+        post v1_data_types_path, params: body, headers: auth_json_api_headers
         data_type = DataType.last
         expect(data_type).to have_attributes(attributes)
       end
@@ -69,18 +69,18 @@ RSpec.describe 'DataTypesController' do
         end
 
         it 'can returns unprocessable entity status' do
-          post v1_data_types_path, params: body, headers: json_api_headers
+          post v1_data_types_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a data type' do
           expect do
-            post v1_data_types_path, params: body, headers: json_api_headers
+            post v1_data_types_path, params: body, headers: auth_json_api_headers
           end.not_to change(DataType, :count)
         end
 
         it 'has an error message' do
-          post v1_data_types_path, params: body, headers: json_api_headers
+          post v1_data_types_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['errors'][0]).to include('detail' => "pipeline - can't be blank")
         end
@@ -104,18 +104,18 @@ RSpec.describe 'DataTypesController' do
         end
 
         it 'has a ok status' do
-          patch v1_data_type_path(data_type), params: body, headers: json_api_headers
+          patch v1_data_type_path(data_type), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         it 'updates a data type' do
-          patch v1_data_type_path(data_type), params: body, headers: json_api_headers
+          patch v1_data_type_path(data_type), params: body, headers: auth_json_api_headers
           data_type.reload
           expect(data_type.name).to eq 'Test data type update context'
         end
 
         it 'returns the correct attributes' do
-          patch v1_data_type_path(data_type), params: body, headers: json_api_headers
+          patch v1_data_type_path(data_type), params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['data']['id']).to eq data_type.id.to_s
         end
@@ -136,13 +136,13 @@ RSpec.describe 'DataTypesController' do
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
         it 'has a ok unprocessable_content' do
-          patch v1_data_type_path(123), params: body, headers: json_api_headers
+          patch v1_data_type_path(123), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:not_found)
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
         it 'has an error message' do
-          patch v1_data_type_path(123), params: body, headers: json_api_headers
+          patch v1_data_type_path(123), params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['errors'][0]).to include('detail' => 'The record identified by 123 could not be found.')
         end

--- a/spec/requests/v1/library_types_spec.rb
+++ b/spec/requests/v1/library_types_spec.rb
@@ -41,18 +41,18 @@ RSpec.describe 'LibraryTypesController' do
       end
 
       it 'has a created status' do
-        post v1_library_types_path, params: body, headers: json_api_headers
+        post v1_library_types_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a library type' do
         expect do
-          post v1_library_types_path, params: body, headers: json_api_headers
+          post v1_library_types_path, params: body, headers: auth_json_api_headers
         end.to change(LibraryType, :count).by(1)
       end
 
       it 'creates a library type with the correct attributes' do
-        post v1_library_types_path, params: body, headers: json_api_headers
+        post v1_library_types_path, params: body, headers: auth_json_api_headers
         library_type = LibraryType.last
         expect(library_type).to have_attributes(attributes)
       end
@@ -71,18 +71,18 @@ RSpec.describe 'LibraryTypesController' do
         end
 
         it 'can returns unprocessable entity status' do
-          post v1_library_types_path, params: body, headers: json_api_headers
+          post v1_library_types_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a library type' do
           expect do
-            post v1_library_types_path, params: body, headers: json_api_headers
+            post v1_library_types_path, params: body, headers: auth_json_api_headers
           end.not_to change(LibraryType, :count)
         end
 
         it 'has an error message' do
-          post v1_library_types_path, params: body, headers: json_api_headers
+          post v1_library_types_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['errors'][0]).to include('detail' => "pipeline - can't be blank")
         end
@@ -106,18 +106,18 @@ RSpec.describe 'LibraryTypesController' do
         end
 
         it 'has a ok status' do
-          patch v1_library_type_path(library_type), params: body, headers: json_api_headers
+          patch v1_library_type_path(library_type), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         it 'updates a library type' do
-          patch v1_library_type_path(library_type), params: body, headers: json_api_headers
+          patch v1_library_type_path(library_type), params: body, headers: auth_json_api_headers
           library_type.reload
           expect(library_type.name).to eq 'Test library type update context'
         end
 
         it 'returns the correct attributes' do
-          patch v1_library_type_path(library_type), params: body, headers: json_api_headers
+          patch v1_library_type_path(library_type), params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['data']['id']).to eq library_type.id.to_s
         end
@@ -138,13 +138,13 @@ RSpec.describe 'LibraryTypesController' do
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
         it 'has a ok unprocessable_content' do
-          patch v1_library_type_path(123), params: body, headers: json_api_headers
+          patch v1_library_type_path(123), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:not_found)
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
         it 'has an error message' do
-          patch v1_library_type_path(123), params: body, headers: json_api_headers
+          patch v1_library_type_path(123), params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['errors'][0]).to include('detail' => 'The record identified by 123 could not be found.')
         end

--- a/spec/requests/v1/multi_pools_spec.rb
+++ b/spec/requests/v1/multi_pools_spec.rb
@@ -279,22 +279,22 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'has a created status' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created), response.body
         end
 
         it 'creates a multi pool and associated data' do
-          expect { post v1_multi_pools_path, params: body, headers: json_api_headers }.to change(MultiPool, :count).by(1).and change(MultiPoolPosition, :count).by(2).and change(Pacbio::Pool, :count).by(2)
+          expect { post v1_multi_pools_path, params: body, headers: auth_json_api_headers }.to change(MultiPool, :count).by(1).and change(MultiPoolPosition, :count).by(2).and change(Pacbio::Pool, :count).by(2)
         end
 
         it 'returns the id' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           expect(json.dig('data', 'id').to_i).to eq(MultiPool.first.id)
         end
 
         it 'publish message with pipeline: pacbio and volume_tracking' do
           expect(Emq::Publisher).to receive(:publish).twice.with(anything, having_attributes(pipeline: 'pacbio'), 'volume_tracking')
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
         end
       end
     end
@@ -314,16 +314,16 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'has a bad_request status' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:bad_request), response.body
         end
 
         it 'does not create a multi pool or associated data' do
-          expect { post v1_multi_pools_path, params: body, headers: json_api_headers }.not_to change(MultiPool, :count)
+          expect { post v1_multi_pools_path, params: body, headers: auth_json_api_headers }.not_to change(MultiPool, :count)
         end
 
         it 'returns the correct error messages' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'InvalidMethod is not a valid value for pool_method.'
@@ -347,16 +347,16 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'has a bad_request status' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
         end
 
         it 'does not create a multi pool or associated data' do
-          expect { post v1_multi_pools_path, params: body, headers: json_api_headers }.not_to change(MultiPool, :count)
+          expect { post v1_multi_pools_path, params: body, headers: auth_json_api_headers }.not_to change(MultiPool, :count)
         end
 
         it 'returns the correct error messages' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'multi_pool_positions.pool - must have either a pacbio_pool or ont_pool associated'
@@ -433,16 +433,16 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
         end
 
         it 'does not create a multi pool or associated data' do
-          expect { post v1_multi_pools_path, params: body, headers: json_api_headers }.not_to change(MultiPool, :count)
+          expect { post v1_multi_pools_path, params: body, headers: auth_json_api_headers }.not_to change(MultiPool, :count)
         end
 
         it 'returns the correct error messages' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'multi_pool_positions - 1 positions are duplicated'
@@ -502,16 +502,16 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
         end
 
         it 'does not create a multi pool or associated data' do
-          expect { post v1_multi_pools_path, params: body, headers: json_api_headers }.not_to change(MultiPool, :count)
+          expect { post v1_multi_pools_path, params: body, headers: auth_json_api_headers }.not_to change(MultiPool, :count)
         end
 
         it 'returns the correct error messages' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'multi_pool_positions.pacbio_pool.tags - contain duplicates'
@@ -588,16 +588,16 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
         end
 
         it 'does not create a multi pool or associated data' do
-          expect { post v1_multi_pools_path, params: body, headers: json_api_headers }.not_to change(MultiPool, :count)
+          expect { post v1_multi_pools_path, params: body, headers: auth_json_api_headers }.not_to change(MultiPool, :count)
         end
 
         it 'returns the correct error messages' do
-          post v1_multi_pools_path, params: body, headers: json_api_headers
+          post v1_multi_pools_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to include("#{library.barcode} does not have sufficient available volume")
@@ -687,13 +687,13 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'returns created status' do
-          patch v1_multi_pool_path(mp), params: body, headers: json_api_headers
+          patch v1_multi_pool_path(mp), params: body, headers: auth_json_api_headers
 
           expect(response).to have_http_status(:success), response.body
         end
 
         it 'updates the multi_pool' do
-          patch v1_multi_pool_path(mp), params: body, headers: json_api_headers
+          patch v1_multi_pool_path(mp), params: body, headers: auth_json_api_headers
 
           mp.reload
           expect(mp.pool_method).to eq('TubeRack')
@@ -701,7 +701,7 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'updates the existing pool' do
-          patch v1_multi_pool_path(mp), params: body, headers: json_api_headers
+          patch v1_multi_pool_path(mp), params: body, headers: auth_json_api_headers
 
           existing_pool.reload
           expect(existing_pool.volume).to eq(new_pool_volume)
@@ -709,7 +709,7 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         it 'creates a new pool' do
-          patch v1_multi_pool_path(mp), params: body, headers: json_api_headers
+          patch v1_multi_pool_path(mp), params: body, headers: auth_json_api_headers
 
           # Check the existing pool is unchanged
           expect(existing_pool).to eq(mp.multi_pool_positions.find_by(position: 1).pacbio_pool)
@@ -732,7 +732,7 @@ RSpec.describe 'MultiPoolsController' do
           # Empty sequencing runs for new pool
           expect(Messages).to receive(:publish).with([], having_attributes(pipeline: 'pacbio'))
 
-          patch v1_multi_pool_path(mp), params: body, headers: json_api_headers
+          patch v1_multi_pool_path(mp), params: body, headers: auth_json_api_headers
         end
       end
 
@@ -797,7 +797,7 @@ RSpec.describe 'MultiPoolsController' do
         end
 
         before do
-          patch v1_multi_pool_path(mp), params: body, headers: json_api_headers
+          patch v1_multi_pool_path(mp), params: body, headers: auth_json_api_headers
         end
 
         it 'returns created status' do
@@ -827,7 +827,7 @@ RSpec.describe 'MultiPoolsController' do
       let!(:existing_pool) { mp.multi_pool_positions.first.pacbio_pool }
 
       before do
-        patch v1_multi_pool_path(mp), params: body, headers: json_api_headers
+        patch v1_multi_pool_path(mp), params: body, headers: auth_json_api_headers
       end
 
       context 'when updating a multi pool (invalid multi_pool data)' do

--- a/spec/requests/v1/ont/libraries_spec.rb
+++ b/spec/requests/v1/ont/libraries_spec.rb
@@ -143,31 +143,31 @@ RSpec.describe 'LibrariesController', :ont do
       let!(:library) { create(:ont_library) }
 
       it 'returns the correct status' do
-        delete "/v1/ont/libraries/#{library.id}", headers: json_api_headers
+        delete "/v1/ont/libraries/#{library.id}", headers: auth_json_api_headers
         expect(response).to have_http_status(:no_content)
       end
 
       it 'destroys the library' do
         expect do
-          delete "/v1/ont/libraries/#{library.id}", headers: json_api_headers
+          delete "/v1/ont/libraries/#{library.id}", headers: auth_json_api_headers
         end.to change(Ont::Library, :count).by(-1)
       end
 
       it 'does not destroy the requests' do
         expect do
-          delete "/v1/ont/libraries/#{library.id}", headers: json_api_headers
+          delete "/v1/ont/libraries/#{library.id}", headers: auth_json_api_headers
         end.not_to change(Ont::Request, :count)
       end
     end
 
     context 'on failure' do
       it 'does not delete the library' do
-        delete '/v1/ont/libraries/dodgyid', headers: json_api_headers
+        delete '/v1/ont/libraries/dodgyid', headers: auth_json_api_headers
         expect(response).to have_http_status(:bad_request)
       end
 
       it 'has an error message' do
-        delete '/v1/ont/libraries/dodgyid', headers: json_api_headers
+        delete '/v1/ont/libraries/dodgyid', headers: auth_json_api_headers
         expect(json['errors']).to be_present
       end
     end

--- a/spec/requests/v1/ont/pools_spec.rb
+++ b/spec/requests/v1/ont/pools_spec.rb
@@ -115,21 +115,21 @@ RSpec.describe 'PoolsController', :ont do
         end
 
         it 'has a created status' do
-          post v1_ont_pools_path, params: body, headers: json_api_headers
+          post v1_ont_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created), response.body
         end
 
         it 'creates a pool' do
-          expect { post v1_ont_pools_path, params: body, headers: json_api_headers }.to change(Ont::Pool, :count).by(1)
+          expect { post v1_ont_pools_path, params: body, headers: auth_json_api_headers }.to change(Ont::Pool, :count).by(1)
         end
 
         it 'returns the id' do
-          post v1_ont_pools_path, params: body, headers: json_api_headers
+          post v1_ont_pools_path, params: body, headers: auth_json_api_headers
           expect(json.dig('data', 'id').to_i).to eq(Ont::Pool.first.id)
         end
 
         it 'includes the tube' do
-          post "#{v1_ont_pools_path}?include=tube", params: body, headers: json_api_headers
+          post "#{v1_ont_pools_path}?include=tube", params: body, headers: auth_json_api_headers
           tube = find_included_resource(id: Ont::Pool.first.tube_id, type: 'tubes')
           expect(tube.dig('attributes', 'barcode')).to be_present
         end
@@ -157,12 +157,12 @@ RSpec.describe 'PoolsController', :ont do
         end
 
         it 'returns unprocessable entity status' do
-          post v1_ont_pools_path, params: body, headers: json_api_headers
+          post v1_ont_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a pool' do
-          expect { post v1_ont_pools_path, params: body, headers: json_api_headers }.not_to(
+          expect { post v1_ont_pools_path, params: body, headers: auth_json_api_headers }.not_to(
             change(Ont::Pool, :count)
           )
         end
@@ -200,12 +200,12 @@ RSpec.describe 'PoolsController', :ont do
         end
 
         it 'returns created status' do
-          post v1_ont_pools_path, params: body, headers: json_api_headers
+          post v1_ont_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created)
         end
 
         it 'creates a pool' do
-          expect { post v1_ont_pools_path, params: body, headers: json_api_headers }.to(
+          expect { post v1_ont_pools_path, params: body, headers: auth_json_api_headers }.to(
             change(Ont::Pool, :count).by(1)
           )
         end
@@ -241,12 +241,12 @@ RSpec.describe 'PoolsController', :ont do
         end
 
         it 'returns unprocessable entity' do
-          post v1_ont_pools_path, params: body, headers: json_api_headers
+          post v1_ont_pools_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a pool' do
-          expect { post v1_ont_pools_path, params: body, headers: json_api_headers }.not_to(
+          expect { post v1_ont_pools_path, params: body, headers: auth_json_api_headers }.not_to(
             change(Ont::Pool, :count)
           )
         end
@@ -262,7 +262,7 @@ RSpec.describe 'PoolsController', :ont do
       let(:added_request) { create(:ont_request) }
 
       before do
-        patch v1_ont_pool_path(pool), params: body, headers: json_api_headers
+        patch v1_ont_pool_path(pool), params: body, headers: auth_json_api_headers
       end
 
       context 'on success' do

--- a/spec/requests/v1/ont/requests_spec.rb
+++ b/spec/requests/v1/ont/requests_spec.rb
@@ -192,12 +192,12 @@ RSpec.describe 'Ont::RequestsController', :ont do
     end
 
     it 'returns success status' do
-      patch v1_ont_request_path(request), params: body, headers: json_api_headers
+      patch v1_ont_request_path(request), params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:success), response.body
     end
 
     it 'updates the request' do
-      patch v1_ont_request_path(request), params: body, headers: json_api_headers
+      patch v1_ont_request_path(request), params: body, headers: auth_json_api_headers
       request.reload
       expect(request.cost_code).to eq('fraud')
     end
@@ -217,13 +217,13 @@ RSpec.describe 'Ont::RequestsController', :ont do
     end
 
     it 'returns unprocessable entity status' do
-      patch v1_ont_request_path(request), params: body, headers: json_api_headers
+      patch v1_ont_request_path(request), params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:unprocessable_content)
     end
 
     it 'does not publish the message' do
       expect(Messages).not_to receive(:publish)
-      patch v1_ont_request_path(request), params: body, headers: json_api_headers
+      patch v1_ont_request_path(request), params: body, headers: auth_json_api_headers
     end
   end
 end

--- a/spec/requests/v1/ont/runs_spec.rb
+++ b/spec/requests/v1/ont/runs_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'RunsController' do
       end
 
       it 'creates a run' do
-        post v1_ont_runs_path, params: body, headers: json_api_headers
+        post v1_ont_runs_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
 
         expect(Ont::Run.count).to eq(1)
@@ -122,7 +122,7 @@ RSpec.describe 'RunsController' do
 
       it 'publishes the message' do
         expect(Messages).to receive(:publish).with(instance_of(Ont::Run), having_attributes(pipeline: 'ont'))
-        post v1_ont_runs_path, params: body, headers: json_api_headers
+        post v1_ont_runs_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:success), response.body
       end
     end
@@ -147,7 +147,7 @@ RSpec.describe 'RunsController' do
       end
 
       before do
-        post v1_ont_runs_path, params: body, headers: json_api_headers
+        post v1_ont_runs_path, params: body, headers: auth_json_api_headers
       end
 
       it 'returns an error response' do
@@ -161,7 +161,7 @@ RSpec.describe 'RunsController' do
 
       it 'does not publish the message' do
         expect(Messages).not_to receive(:publish).with(instance_of(Ont::Run), having_attributes(pipeline: 'ont'))
-        post v1_ont_runs_path, params: body, headers: json_api_headers
+        post v1_ont_runs_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content), response.body
       end
     end
@@ -206,7 +206,7 @@ RSpec.describe 'RunsController' do
       end
 
       before do
-        patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: json_api_headers
+        patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: auth_json_api_headers
       end
 
       it 'returns success response' do
@@ -266,7 +266,7 @@ RSpec.describe 'RunsController' do
 
         it 'is published' do
           expect(Messages).to receive(:publish).with(instance_of(Ont::Run), having_attributes(pipeline: 'ont'))
-          patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: json_api_headers
+          patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:success), response.body
         end
       end
@@ -294,7 +294,7 @@ RSpec.describe 'RunsController' do
       end
 
       before do
-        patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: json_api_headers
+        patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: auth_json_api_headers
       end
 
       it 'returns an error response' do
@@ -303,7 +303,7 @@ RSpec.describe 'RunsController' do
 
       it 'does not create a run' do
         expect do
-          patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: json_api_headers
+          patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: auth_json_api_headers
         end.not_to change(Ont::Run, :count)
       end
 
@@ -331,7 +331,7 @@ RSpec.describe 'RunsController' do
 
         it 'does not be published' do
           expect(Messages).not_to receive(:publish).with(instance_of(Ont::Run), having_attributes(pipeline: 'ont'))
-          patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: json_api_headers
+          patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
         end
       end
@@ -361,7 +361,7 @@ RSpec.describe 'RunsController' do
       end
 
       it 'returns errors' do
-        post v1_ont_runs_path, params: body, headers: json_api_headers
+        post v1_ont_runs_path, params: body, headers: auth_json_api_headers
 
         expect(response).to have_http_status(:unprocessable_content), response.body
 
@@ -395,7 +395,7 @@ RSpec.describe 'RunsController' do
       end
 
       it 'returns errors' do
-        patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: json_api_headers
+        patch "#{v1_ont_runs_path}/#{run.id}", params: body, headers: auth_json_api_headers
 
         expect(response).to have_http_status(:unprocessable_content), response.body
 

--- a/spec/requests/v1/pacbio/libraries_spec.rb
+++ b/spec/requests/v1/pacbio/libraries_spec.rb
@@ -344,29 +344,29 @@ RSpec.describe 'LibrariesController', :pacbio do
         end
 
         it 'has a created status' do
-          post v1_pacbio_libraries_path, params: body, headers: json_api_headers
+          post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created), response.body
         end
 
         it 'publishes volume tracking message for the aliquot' do
           expect(Emq::Publisher).to receive(:publish)
-          post v1_pacbio_libraries_path, params: body, headers: json_api_headers
+          post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:success), response.body
         end
 
         it 'creates a library and aliquots' do
-          expect { post v1_pacbio_libraries_path, params: body, headers: json_api_headers }
+          expect { post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers }
             .to change(Pacbio::Library, :count).by(1)
             .and change(Aliquot, :count).by(2) # We create a primary aliquot and a used_by aliquot
         end
 
         it 'returns the id' do
-          post v1_pacbio_libraries_path, params: body, headers: json_api_headers
+          post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers
           expect(json.dig('data', 'id').to_i).to eq(Pacbio::Library.first.id)
         end
 
         it 'includes the tube' do
-          post "#{v1_pacbio_libraries_path}?include=tube", params: body, headers: json_api_headers
+          post "#{v1_pacbio_libraries_path}?include=tube", params: body, headers: auth_json_api_headers
           tube = find_included_resource(id: Pacbio::Library.first.tube_id, type: 'tubes')
           expect(tube.dig('attributes', 'barcode')).to be_present
         end
@@ -398,12 +398,12 @@ RSpec.describe 'LibrariesController', :pacbio do
         end
 
         it 'returns unprocessable entity status' do
-          post v1_pacbio_libraries_path, params: body, headers: json_api_headers
+          post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a library' do
-          expect { post v1_pacbio_libraries_path, params: body, headers: json_api_headers }.not_to(
+          expect { post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers }.not_to(
             change(Pacbio::Library, :count) &&
             change(Aliquot, :count)
           )
@@ -434,12 +434,12 @@ RSpec.describe 'LibrariesController', :pacbio do
         end
 
         it 'returns unprocessable entity status' do
-          post v1_pacbio_libraries_path, params: body, headers: json_api_headers
+          post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a library' do
-          expect { post v1_pacbio_libraries_path, params: body, headers: json_api_headers }.not_to(
+          expect { post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers }.not_to(
             change(Pacbio::Library, :count) &&
             change(Aliquot, :count)
           )
@@ -471,13 +471,13 @@ RSpec.describe 'LibrariesController', :pacbio do
         end
 
         it 'returns unprocessable entity status' do
-          post v1_pacbio_libraries_path, params: body, headers: json_api_headers
+          post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:bad_request)
           expect(response.body).to include('barcode is not allowed')
         end
 
         it 'cannot create a library' do
-          expect { post v1_pacbio_libraries_path, params: body, headers: json_api_headers }.not_to(
+          expect { post v1_pacbio_libraries_path, params: body, headers: auth_json_api_headers }.not_to(
             change(Pacbio::Library, :count) &&
             change(Aliquot, :count)
           )
@@ -492,7 +492,7 @@ RSpec.describe 'LibrariesController', :pacbio do
     let!(:primary_aliquot) { library.primary_aliquot }
 
     before do
-      patch v1_pacbio_library_path(library), params: body, headers: json_api_headers
+      patch v1_pacbio_library_path(library), params: body, headers: auth_json_api_headers
     end
 
     context 'on success' do
@@ -667,7 +667,7 @@ RSpec.describe 'LibrariesController', :pacbio do
       it 'publishes a message' do
         expect(Messages).to receive(:publish).with(library.sequencing_runs, having_attributes(pipeline: 'pacbio'))
         expect(Emq::Publisher).to receive(:publish)
-        patch v1_pacbio_library_path(library), params: body, headers: json_api_headers
+        patch v1_pacbio_library_path(library), params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:success), response.body
       end
     end
@@ -678,27 +678,27 @@ RSpec.describe 'LibrariesController', :pacbio do
       let!(:library) { create(:pacbio_library) }
 
       it 'returns the correct status' do
-        delete "/v1/pacbio/libraries/#{library.id}", headers: json_api_headers
+        delete "/v1/pacbio/libraries/#{library.id}", headers: auth_json_api_headers
         expect(response).to have_http_status(:no_content)
       end
 
       it 'destroys the library' do
         expect do
-          delete "/v1/pacbio/libraries/#{library.id}", headers: json_api_headers
+          delete "/v1/pacbio/libraries/#{library.id}", headers: auth_json_api_headers
         end.to change(Pacbio::Library, :count).by(-1)
                                               .and change(Aliquot, :count).by(-2) # We destroy the primary and used_by aliquots
       end
 
       it 'does not destroy the requests' do
         expect do
-          delete "/v1/pacbio/libraries/#{library.id}", headers: json_api_headers
+          delete "/v1/pacbio/libraries/#{library.id}", headers: auth_json_api_headers
         end.not_to change(Pacbio::Request, :count)
       end
 
       it 'does not destroy the library if it has associated wells' do
         create(:pacbio_well, libraries: [library])
         expect do
-          delete "/v1/pacbio/libraries/#{library.id}", headers: json_api_headers
+          delete "/v1/pacbio/libraries/#{library.id}", headers: auth_json_api_headers
         end.not_to change(Pacbio::Library, :count)
         expect(json['errors'][0]['title']).to eq('Cannot delete a library that is used in a pool or run')
       end
@@ -706,12 +706,12 @@ RSpec.describe 'LibrariesController', :pacbio do
 
     context 'on failure' do
       it 'does not delete the library' do
-        delete '/v1/pacbio/libraries/dodgyid', headers: json_api_headers
+        delete '/v1/pacbio/libraries/dodgyid', headers: auth_json_api_headers
         expect(response).to have_http_status(:bad_request)
       end
 
       it 'has an error message' do
-        delete '/v1/pacbio/libraries/dodgyid', headers: json_api_headers
+        delete '/v1/pacbio/libraries/dodgyid', headers: auth_json_api_headers
         expect(json['errors']).to be_present
       end
     end

--- a/spec/requests/v1/pacbio/library_batches_spec.rb
+++ b/spec/requests/v1/pacbio/library_batches_spec.rb
@@ -52,28 +52,28 @@ RSpec.describe 'LibraryBatchesController', :pacbio do
         end
 
         it 'has a created status' do
-          post v1_pacbio_library_batches_path, params: body, headers: json_api_headers
+          post v1_pacbio_library_batches_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created), response.body
         end
 
         it 'creates a library and aliquots' do
-          expect { post v1_pacbio_library_batches_path, params: body, headers: json_api_headers }
+          expect { post v1_pacbio_library_batches_path, params: body, headers: auth_json_api_headers }
             .to change(Pacbio::Library, :count).by(2)
             .and change(Aliquot, :count).by(4) # We create a primary aliquot and a used_by aliquot for each library
         end
 
         it 'publish volume tracking messages for all libraries' do
           expect(Emq::Publisher).to receive(:publish).twice
-          post v1_pacbio_library_batches_path, params: body, headers: json_api_headers
+          post v1_pacbio_library_batches_path, params: body, headers: auth_json_api_headers
         end
 
         it 'returns the id' do
-          post v1_pacbio_library_batches_path, params: body, headers: json_api_headers
+          post v1_pacbio_library_batches_path, params: body, headers: auth_json_api_headers
           expect(json.dig('data', 'id').to_i).to eq(Pacbio::LibraryBatch.first.id)
         end
 
         it 'includes the libraries and their tubes' do
-          post "#{v1_pacbio_library_batches_path}?include=libraries.tube", params: body, headers: json_api_headers
+          post "#{v1_pacbio_library_batches_path}?include=libraries.tube", params: body, headers: auth_json_api_headers
           expect(json['included'].length).to eq(4)
           expect(json['included'].filter { |record| record['type'] == 'tubes' }.length).to eq(2)
           expect(json['included'].filter { |record| record['type'] == 'libraries' }.length).to eq(2)
@@ -124,13 +124,13 @@ RSpec.describe 'LibraryBatchesController', :pacbio do
         end
 
         it 'returns unprocessable entity status' do
-          post v1_pacbio_library_batches_path, params: body, headers: json_api_headers
+          post v1_pacbio_library_batches_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('libraries.insert_size - is not a number')
         end
 
         it 'cannot create a library' do
-          expect { post v1_pacbio_library_batches_path, params: body, headers: json_api_headers }.not_to(
+          expect { post v1_pacbio_library_batches_path, params: body, headers: auth_json_api_headers }.not_to(
             change(Pacbio::Library, :count) &&
             change(Aliquot, :count)
           )

--- a/spec/requests/v1/pacbio/pools_spec.rb
+++ b/spec/requests/v1/pacbio/pools_spec.rb
@@ -268,21 +268,21 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'has a created status' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
       end
 
       it 'creates a pool' do
-        expect { post v1_pacbio_pools_path, params: body, headers: json_api_headers }.to change(Pacbio::Pool, :count).by(1)
+        expect { post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Pool, :count).by(1)
       end
 
       it 'returns the id' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(json.dig('data', 'id').to_i).to eq(Pacbio::Pool.first.id)
       end
 
       it 'includes the tube' do
-        post "#{v1_pacbio_pools_path}?include=tube", params: body, headers: json_api_headers
+        post "#{v1_pacbio_pools_path}?include=tube", params: body, headers: auth_json_api_headers
         tube = find_included_resource(id: Pacbio::Pool.first.tube_id, type: 'tubes')
         expect(tube.dig('attributes', 'barcode')).to be_present
       end
@@ -317,12 +317,12 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'returns unprocessable entity status' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'cannot create a pool' do
-        expect { post v1_pacbio_pools_path, params: body, headers: json_api_headers }.not_to(
+        expect { post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers }.not_to(
           change(Pacbio::Pool, :count)
         )
       end
@@ -356,13 +356,13 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'returns unprocessable entity status' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("primary_aliquot.volume - can't be blank")
       end
 
       it 'cannot create a pool' do
-        expect { post v1_pacbio_pools_path, params: body, headers: json_api_headers }.not_to(
+        expect { post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers }.not_to(
           change(Pacbio::Pool, :count)
         )
       end
@@ -398,13 +398,13 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'returns unprocessable entity status' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:bad_request)
         expect(response.body).to include('barcode is not allowed')
       end
 
       it 'cannot create a pool' do
-        expect { post v1_pacbio_pools_path, params: body, headers: json_api_headers }.not_to(
+        expect { post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers }.not_to(
           change(Pacbio::Pool, :count)
         )
       end
@@ -440,18 +440,18 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'returns unprocessable entity status' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'cannot create a pool' do
-        expect { post v1_pacbio_pools_path, params: body, headers: json_api_headers }.not_to(
+        expect { post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers }.not_to(
           change(Pacbio::Pool, :count)
         )
       end
 
       it 'returns the correct error messages' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         errors = json['errors']
         expect(errors[1]['detail']).to include("Insufficient volume available for #{library.barcode}")
@@ -498,12 +498,12 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'returns created status' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a pool' do
-        expect { post v1_pacbio_pools_path, params: body, headers: json_api_headers }.to(
+        expect { post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers }.to(
           change(Pacbio::Pool, :count).by(1).and(
             change(Aliquot, :count).by(3)
           )
@@ -549,12 +549,12 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'returns unprocessable entity status' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'cannot create a pool' do
-        expect { post v1_pacbio_pools_path, params: body, headers: json_api_headers }.not_to(
+        expect { post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers }.not_to(
           change(Pacbio::Pool, :count)
         )
       end
@@ -600,13 +600,13 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'returns internal_server_error status' do
-        post v1_pacbio_pools_path, params: body, headers: json_api_headers
+        post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:internal_server_error)
         expect(response.body).to include('Aliquot is not part of the pool')
       end
 
       it 'cannot create a pool' do
-        expect { post v1_pacbio_pools_path, params: body, headers: json_api_headers }.not_to(
+        expect { post v1_pacbio_pools_path, params: body, headers: auth_json_api_headers }.not_to(
           change(Pacbio::Pool, :count)
         )
       end
@@ -622,7 +622,7 @@ RSpec.describe 'PoolsController', :pacbio do
     let(:added_request) { create(:pacbio_request) }
 
     before do
-      patch v1_pacbio_pool_path(pool), params: body, headers: json_api_headers
+      patch v1_pacbio_pool_path(pool), params: body, headers: auth_json_api_headers
     end
 
     context 'on success' do
@@ -806,7 +806,7 @@ RSpec.describe 'PoolsController', :pacbio do
 
     it 'publishes a message' do
       expect(Messages).to receive(:publish).with(pool.sequencing_runs, having_attributes(pipeline: 'pacbio'))
-      patch v1_pacbio_pool_path(pool), params: body, headers: json_api_headers
+      patch v1_pacbio_pool_path(pool), params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:success), response.body
     end
   end
@@ -846,7 +846,7 @@ RSpec.describe 'PoolsController', :pacbio do
       end
 
       it 'creates a pool' do
-        post "#{v1_pacbio_pools_path}?include=tube", params: body, headers: json_api_headers
+        post "#{v1_pacbio_pools_path}?include=tube", params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:success)
         change(Pacbio::Pool, :count).by(1).and(
           change(Aliquot, :count).by(3)
@@ -855,7 +855,7 @@ RSpec.describe 'PoolsController', :pacbio do
 
       it 'publish message with pipeline: pacbio and volume_tracking' do
         expect(Emq::Publisher).to receive(:publish).with(anything, having_attributes(pipeline: 'pacbio'), 'volume_tracking')
-        post "#{v1_pacbio_pools_path}?include=tube", params: body, headers: json_api_headers
+        post "#{v1_pacbio_pools_path}?include=tube", params: body, headers: auth_json_api_headers
       end
     end
   end

--- a/spec/requests/v1/pacbio/requests_spec.rb
+++ b/spec/requests/v1/pacbio/requests_spec.rb
@@ -285,25 +285,25 @@ RSpec.describe 'RequestsController', :pacbio do
 
     context 'on success' do
       it 'returns the correct status' do
-        delete "#{v1_pacbio_requests_path}/#{request.id}", headers: json_api_headers
+        delete "#{v1_pacbio_requests_path}/#{request.id}", headers: auth_json_api_headers
         expect(response).to have_http_status(:no_content)
       end
 
       it 'destroys the request' do
         expect do
-          delete "#{v1_pacbio_requests_path}/#{request.id}", headers: json_api_headers
+          delete "#{v1_pacbio_requests_path}/#{request.id}", headers: auth_json_api_headers
         end.to change(Pacbio::Request, :count).by(-1)
       end
     end
 
     context 'on failure' do
       it 'does not delete the request' do
-        delete "#{v1_pacbio_requests_path}/fakerequest", headers: json_api_headers
+        delete "#{v1_pacbio_requests_path}/fakerequest", headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'has an error message' do
-        delete "#{v1_pacbio_requests_path}/fakerequest", headers: json_api_headers
+        delete "#{v1_pacbio_requests_path}/fakerequest", headers: auth_json_api_headers
         data = response.parsed_body['data']
         expect(data['errors']).to be_present
       end
@@ -326,12 +326,12 @@ RSpec.describe 'RequestsController', :pacbio do
     end
 
     it 'returns success status' do
-      patch v1_pacbio_request_path(request), params: body, headers: json_api_headers
+      patch v1_pacbio_request_path(request), params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:success), response.body
     end
 
     it 'updates the request' do
-      patch v1_pacbio_request_path(request), params: body, headers: json_api_headers
+      patch v1_pacbio_request_path(request), params: body, headers: auth_json_api_headers
       request.reload
       expect(request.cost_code).to eq('fraud')
     end
@@ -339,7 +339,7 @@ RSpec.describe 'RequestsController', :pacbio do
     it 'publishes a message' do
       expect(Messages).to receive(:publish).with(request.sequencing_runs,
                                                  having_attributes(pipeline: 'pacbio'))
-      patch v1_pacbio_request_path(request), params: body, headers: json_api_headers
+      patch v1_pacbio_request_path(request), params: body, headers: auth_json_api_headers
     end
   end
 
@@ -358,13 +358,13 @@ RSpec.describe 'RequestsController', :pacbio do
     end
 
     it 'returns unprocessable entity status' do
-      patch v1_pacbio_request_path(request), params: body, headers: json_api_headers
+      patch v1_pacbio_request_path(request), params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:unprocessable_content)
     end
 
     it 'does not publish the message' do
       expect(Messages).not_to receive(:publish)
-      patch v1_pacbio_request_path(request), params: body, headers: json_api_headers
+      patch v1_pacbio_request_path(request), params: body, headers: auth_json_api_headers
     end
   end
 end

--- a/spec/requests/v1/pacbio/runs_spec.rb
+++ b/spec/requests/v1/pacbio/runs_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe 'RunsController' do
   shared_examples 'publish_messages_on_create' do
     it 'publishes a message' do
       expect(Messages).to receive(:publish).with(instance_of(Pacbio::Run), having_attributes(pipeline: 'pacbio'))
-      post v1_pacbio_runs_path, params: body, headers: json_api_headers
+      post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:success), response.body
     end
 
     it 'publishes volume tracking message for each used aliquot' do
       expect(Emq::Publisher).to receive(:publish)
-      post v1_pacbio_runs_path, params: body, headers: json_api_headers
+      post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:success), response.body
     end
   end
@@ -27,13 +27,13 @@ RSpec.describe 'RunsController' do
   shared_examples 'publish_messages_on_update' do
     it 'publishes a message' do
       expect(Messages).to receive(:publish).with(run, having_attributes(pipeline: 'pacbio'))
-      patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+      patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:success), response.body
     end
 
     it 'publishes volume tracking message for each used aliquot' do
       expect(Emq::Publisher).to receive(:publish)
-      patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+      patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
       expect(response).to have_http_status(:success), response.parsed_body
     end
   end
@@ -295,24 +295,24 @@ RSpec.describe 'RunsController' do
       end
 
       it 'has a created status' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a run' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Run, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Run, :count).by(1)
       end
 
       it 'creates a plate' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Plate, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Plate, :count).by(1)
       end
 
       it 'creates a well' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Well, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Well, :count).by(1)
       end
 
       it 'creates an annotation' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         run = Pacbio::Run.first
         expect(run.annotations.count).to eq(1)
         expect(run.wells.first.annotations.count).to eq(1)
@@ -321,11 +321,11 @@ RSpec.describe 'RunsController' do
       it 'creates a used_aliquot' do
         # Preloaded so its aliquots are built and don't affect the test below
         pool1.reload
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Aliquot, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Aliquot, :count).by(1)
       end
 
       it 'creates a run with the correct attributes' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         run = Pacbio::Run.first
 
@@ -380,20 +380,20 @@ RSpec.describe 'RunsController' do
       end
 
       it 'has a created status' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a run' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Run, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Run, :count).by(1)
       end
 
       it 'creates a plate' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Plate, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Plate, :count).by(1)
       end
 
       it 'creates a well' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Well, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Well, :count).by(1)
       end
 
       it 'creates 2 used_aliquots' do
@@ -401,11 +401,11 @@ RSpec.describe 'RunsController' do
         pool1.reload
         library1.reload
         # One aliquot for the library and one for the pool
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Aliquot, :count).by(2)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Aliquot, :count).by(2)
       end
 
       it 'creates a run with the correct attributes' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         run = Pacbio::Run.first
 
@@ -459,30 +459,30 @@ RSpec.describe 'RunsController' do
       end
 
       it 'has a created status' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a run' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Run, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Run, :count).by(1)
       end
 
       it 'creates a plate' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Plate, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Plate, :count).by(1)
       end
 
       it 'creates a well' do
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Well, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Well, :count).by(1)
       end
 
       it 'creates a used_aliquot' do
         # Preloaded so its aliquots are built and don't affect the test below
         pool1.reload
-        expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Aliquot, :count).by(1)
+        expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Aliquot, :count).by(1)
       end
 
       it 'creates a run with the correct attributes' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         run = Pacbio::Run.first
 
@@ -535,12 +535,12 @@ RSpec.describe 'RunsController' do
       end
 
       it 'has a created status' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a run with the correct attributes' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         run = Pacbio::Run.last
 
@@ -566,19 +566,19 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'plates - must have at least 1 plate'
@@ -598,19 +598,19 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a bad_request status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:bad_request)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'invalid is not a valid value for system_name.'
@@ -631,19 +631,19 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a bad_request status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:bad_request)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'adaptive_loading is not allowed.'
@@ -666,26 +666,26 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'does not create a well' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors.pluck('detail')).to include 'plates - plate  wells must have at least 1 well'
@@ -720,21 +720,21 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'does not create a a well' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
@@ -745,12 +745,12 @@ RSpec.describe 'RunsController' do
 
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq "plates.wells.column - can't be blank"
@@ -793,33 +793,33 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'does not create a a well' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
         it 'does not create any used_aliquots' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq("plates.wells.used_aliquots - can't be blank")
@@ -860,33 +860,33 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a internal_server_error status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:internal_server_error)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'does not create a a well' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
         it 'does not create any used_aliquots' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'Internal Server Error'
@@ -935,33 +935,33 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'does not create a a well' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
         it 'does not create any used_aliquots' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'plates.wells.tags - are not unique within the libraries for well A1'
@@ -1010,33 +1010,33 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'does not create a a well' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
         it 'does not create any used_aliquots' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'plates.wells.tags - are not unique within the libraries for well A1'
@@ -1093,28 +1093,28 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a created status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created)
         end
 
         it 'creates a run' do
-          expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Run, :count).by(1)
+          expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Run, :count).by(1)
         end
 
         it 'creates a plate' do
-          expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Plate, :count).by(1)
+          expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Plate, :count).by(1)
         end
 
         it 'creates a well' do
-          expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Pacbio::Well, :count).by(2)
+          expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Pacbio::Well, :count).by(2)
         end
 
         it 'creates 2 used_aliquots' do
-          expect { post v1_pacbio_runs_path, params: body, headers: json_api_headers }.to change(Aliquot, :count).by(2)
+          expect { post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers }.to change(Aliquot, :count).by(2)
         end
 
         it 'creates a run with the correct attributes' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           run = Pacbio::Run.first
 
@@ -1161,7 +1161,7 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
 
           expect(response).to have_http_status(:unprocessable_content)
         end
@@ -1169,14 +1169,14 @@ RSpec.describe 'RunsController' do
         it 'does not create a run' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'does not create a well' do
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
@@ -1187,12 +1187,12 @@ RSpec.describe 'RunsController' do
 
           expect do
             post v1_pacbio_runs_path, params: body,
-                                      headers: json_api_headers
+                                      headers: auth_json_api_headers
           end.not_to change(Aliquot, :count)
         end
 
         it 'has the correct error messages' do
-          post v1_pacbio_runs_path, params: body, headers: json_api_headers
+          post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           errors = json['errors']
           expect(errors[0]['detail']).to eq 'plates.wells.tags - are missing from the libraries'
@@ -1240,7 +1240,7 @@ RSpec.describe 'RunsController' do
 
     context 'on success' do
       it 'creates a run with the correct attributes' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         run = Pacbio::Run.first
         version = Pacbio::SmrtLinkVersion.find_by(default: true)
@@ -1293,7 +1293,7 @@ RSpec.describe 'RunsController' do
 
     context 'on success' do
       it 'creates a run with the correct attributes' do
-        post v1_pacbio_runs_path, params: body, headers: json_api_headers
+        post v1_pacbio_runs_path, params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         run = Pacbio::Run.first
         version = Pacbio::SmrtLinkVersion.find_by(name: 'v10')
@@ -1326,18 +1326,18 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a ok status' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         it 'updates a run' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           run.reload
           expect(run.state).to eq 'started'
         end
 
         it 'returns the correct attributes' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['data']['id']).to eq run.id.to_s
         end
@@ -1345,7 +1345,7 @@ RSpec.describe 'RunsController' do
         it 'retains the existing plate, wells, pools etc' do
           existing_wells = run.plates.first.wells
           existing_pools = existing_wells.map(&:pools)
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           run.reload
           expect(run.plates.first.wells).to eq existing_wells
           expect(run.plates.first.wells.map(&:pools)).to eq existing_pools
@@ -1370,18 +1370,18 @@ RSpec.describe 'RunsController' do
         let!(:run) { create(:pacbio_revio_run) }
 
         it 'has a ok status' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         it 'does not create a run' do
           expect do
-            patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+            patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           end.not_to change(Pacbio::Run, :count)
         end
 
         it 'updates a run' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           run.reload
           expect(run.dna_control_complex_box_barcode).to eq 'Lxxxxx101717600123191_updated'
           expect(run.system_name).to eq 'Sequel I'
@@ -1425,18 +1425,18 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a ok status' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         it 'does not create a well' do
           expect do
-            patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+            patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
         it 'updates a well' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           well.reload
           expect(well.row).to eq 'D'
           expect(well.column).to eq '7'
@@ -1496,7 +1496,7 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a ok status' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           # byebug
           expect(response).to have_http_status(:ok)
         end
@@ -1504,7 +1504,7 @@ RSpec.describe 'RunsController' do
         # Creates a well and deletes a well = +1-1 = 0
         it 'does not create a well' do
           expect do
-            patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+            patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
@@ -1514,12 +1514,12 @@ RSpec.describe 'RunsController' do
           pool1.reload
           well1.pools[0].reload
           expect do
-            patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+            patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           end.to change(Aliquot, :count).from(65).to(61)
         end
 
         it 'updates a well' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           run.reload
           expect(run.wells.length).to eq 2
           expect(run.wells[0].row).to eq 'D'
@@ -1573,25 +1573,25 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a ok status' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         # Creates a well and deletes a well = +1-1 = 0
         it 'does not create a well' do
           expect do
-            patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+            patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           end.not_to change(Pacbio::Well, :count)
         end
 
         it 'creates the correct number of used_aliquots' do
           expect do
-            patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+            patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           end.not_to change(Aliquot, :count)
         end
 
         it 'updates a well' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           run.reload
           updated_plate = run.plates.find_by(id: plate.id)
           expect(updated_plate.wells.length).to eq 2
@@ -1641,12 +1641,12 @@ RSpec.describe 'RunsController' do
         end
 
         it 'has a ok status' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         it 'updates a well with new values' do
-          patch v1_pacbio_run_path(run), params: body, headers: json_api_headers
+          patch v1_pacbio_run_path(run), params: body, headers: auth_json_api_headers
           run.reload
           updated_plate = run.plates.find_by(id: plate.id)
           expect(updated_plate.wells.length).to eq 1
@@ -1679,18 +1679,18 @@ RSpec.describe 'RunsController' do
       end
 
       it 'has a bad_request' do
-        patch v1_pacbio_run_path(run.id), params: body, headers: json_api_headers
+        patch v1_pacbio_run_path(run.id), params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:bad_request)
       end
 
       it 'has an error message' do
-        patch v1_pacbio_run_path(run.id), params: body, headers: json_api_headers
+        patch v1_pacbio_run_path(run.id), params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         expect(json['errors'][0]['detail']).to eq 'unknown is not a valid value for state.'
       end
 
       it 'does not update a run' do
-        patch v1_pacbio_run_path(run.id), params: body, headers: json_api_headers
+        patch v1_pacbio_run_path(run.id), params: body, headers: auth_json_api_headers
         run.reload
         expect(run).to be_pending
       end
@@ -1748,27 +1748,27 @@ RSpec.describe 'RunsController' do
 
     context 'on success' do
       it 'returns the correct status' do
-        delete v1_pacbio_run_path(run), headers: json_api_headers
+        delete v1_pacbio_run_path(run), headers: auth_json_api_headers
         expect(response).to have_http_status(:no_content)
       end
 
       it 'deletes the run' do
-        expect { delete v1_pacbio_run_path(run), headers: json_api_headers }.to change(Pacbio::Run, :count).by(-1)
+        expect { delete v1_pacbio_run_path(run), headers: auth_json_api_headers }.to change(Pacbio::Run, :count).by(-1)
       end
 
       it 'deletes the plate' do
-        expect { delete v1_pacbio_run_path(run), headers: json_api_headers }.to change(Pacbio::Plate, :count).by(-1)
+        expect { delete v1_pacbio_run_path(run), headers: auth_json_api_headers }.to change(Pacbio::Plate, :count).by(-1)
       end
     end
 
     context 'on failure' do
       it 'does not delete the run' do
-        delete '/v1/pacbio/runs/123', headers: json_api_headers
+        delete '/v1/pacbio/runs/123', headers: auth_json_api_headers
         expect(response).to have_http_status(:not_found)
       end
 
       it 'has an error message' do
-        delete '/v1/pacbio/runs/123', headers: json_api_headers
+        delete '/v1/pacbio/runs/123', headers: auth_json_api_headers
         body = response.parsed_body
         expect(body['errors']).to be_present
       end

--- a/spec/requests/v1/pacbio/tag_sets_spec.rb
+++ b/spec/requests/v1/pacbio/tag_sets_spec.rb
@@ -49,18 +49,18 @@ RSpec.describe 'Pacbio::TagSetsController' do
       end
 
       it 'has a created status' do
-        post v1_pacbio_tag_sets_path, params: body, headers: json_api_headers
+        post v1_pacbio_tag_sets_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
       end
 
       it 'creates a tag set' do
-        expect { post v1_pacbio_tag_sets_path, params: body, headers: json_api_headers }.to(
+        expect { post v1_pacbio_tag_sets_path, params: body, headers: auth_json_api_headers }.to(
           change(TagSet, :count).by(1)
         )
       end
 
       it 'creates a tag set with the correct attributes' do
-        post v1_pacbio_tag_sets_path, params: body, headers: json_api_headers
+        post v1_pacbio_tag_sets_path, params: body, headers: auth_json_api_headers
         tag_set = TagSet.first
         expect(tag_set.uuid).to be_present
       end
@@ -78,21 +78,21 @@ RSpec.describe 'Pacbio::TagSetsController' do
         end
 
         it 'can returns unprocessable entity status' do
-          post v1_pacbio_tag_sets_path, params: body, headers: json_api_headers
+          post v1_pacbio_tag_sets_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a tag set' do
           expect do
             post v1_pacbio_tag_sets_path, params: body,
-                                          headers: json_api_headers
+                                          headers: auth_json_api_headers
           end.not_to change(TagSet, :count)
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the
         # default controller
         it 'has an error message' do
-          post v1_pacbio_tag_sets_path, params: body, headers: json_api_headers
+          post v1_pacbio_tag_sets_path, params: body, headers: auth_json_api_headers
           expect(json['errors'][0]).to include('detail' => "name - can't be blank")
         end
       end
@@ -115,18 +115,18 @@ RSpec.describe 'Pacbio::TagSetsController' do
         end
 
         it 'has a ok status' do
-          patch v1_tag_set_path(tag_set), params: body, headers: json_api_headers
+          patch v1_tag_set_path(tag_set), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         it 'updates a tag set' do
-          patch v1_tag_set_path(tag_set), params: body, headers: json_api_headers
+          patch v1_tag_set_path(tag_set), params: body, headers: auth_json_api_headers
           tag_set.reload
           expect(tag_set.name).to eq 'Test Tag Set update context'
         end
 
         it 'returns the correct attributes' do
-          patch v1_tag_set_path(tag_set), params: body, headers: json_api_headers
+          patch v1_tag_set_path(tag_set), params: body, headers: auth_json_api_headers
 
           expect(json['data']['id']).to eq tag_set.id.to_s
         end
@@ -148,14 +148,14 @@ RSpec.describe 'Pacbio::TagSetsController' do
         # the failure responses are slightly different to in tags_spec because we are using the
         # default controller
         it 'has a ok unprocessable_content' do
-          patch v1_tag_set_path(123), params: body, headers: json_api_headers
+          patch v1_tag_set_path(123), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:not_found)
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the
         # default controller
         it 'has an error message' do
-          patch v1_tag_set_path(123), params: body, headers: json_api_headers
+          patch v1_tag_set_path(123), params: body, headers: auth_json_api_headers
           expect(json['errors'][0]).to include(
             'detail' => 'The record identified by 123 could not be found.'
           )

--- a/spec/requests/v1/qc_reception_spec.rb
+++ b/spec/requests/v1/qc_reception_spec.rb
@@ -46,18 +46,18 @@ RSpec.describe '/qc_receptions' do
       end
 
       it 'returns a created status' do
-        post v1_qc_receptions_url, params: body, headers: json_api_headers
+        post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a new QcReception' do
         expect do
-          post v1_qc_receptions_url, params: body, headers: json_api_headers
+          post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
         end.to change(QcReception, :count).by(1)
       end
 
       it 'creates a new QcReception with the given source' do
-        post v1_qc_receptions_url, params: body, headers: json_api_headers
+        post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
         expect(QcReception.last.source).to eq source
       end
 
@@ -65,14 +65,14 @@ RSpec.describe '/qc_receptions' do
         create(:qc_assay_type, key: 'post_spri_concentration', label: 'Post SPRI Concentration (ng/ul)', used_by: 1, units: 'ng/ul')
         create(:qc_assay_type, key: 'post_spri_volume', label: 'Post SPRI Volume (ul)', used_by: 1, units: 'ul')
         expect do
-          post v1_qc_receptions_url, params: body, headers: json_api_headers
+          post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
         end.to change(QcResult, :count).by(3)
       end
 
       it 'creates the relevant QcResult data' do
         qc_results = qc_results_list[0]
         assay_type_id = QcAssayType.find_by(key: 'sheared_femto_fragment_size').id
-        post v1_qc_receptions_url, params: body, headers: json_api_headers
+        post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
         expect(QcResult.last.labware_barcode).to eq qc_results[:labware_barcode]
         expect(QcResult.last.sample_external_id).to eq qc_results[:sample_external_id]
         expect(QcResult.last.qc_assay_type_id).to eq assay_type_id
@@ -82,11 +82,11 @@ RSpec.describe '/qc_receptions' do
       it 'sends the messages' do
         # 1 as there is 1 QcResult created
         expect(Broker::Handle).to receive(:publish).once
-        post v1_qc_receptions_url, params: body, headers: json_api_headers
+        post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
       end
 
       it 'renders a JSON response with the new qc_receptions' do
-        post v1_qc_receptions_url, params: body, headers: json_api_headers
+        post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
         expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
       end
 
@@ -97,13 +97,13 @@ RSpec.describe '/qc_receptions' do
 
         it 'does not create a new QcReception' do
           expect do
-            post v1_qc_receptions_url, params: body, headers: json_api_headers
+            post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
           end.not_to change(QcReception, :count)
         end
 
         it 'does not create any QcResults' do
           expect do
-            post v1_qc_receptions_url, params: body, headers: json_api_headers
+            post v1_qc_receptions_url, params: body, headers: auth_json_api_headers
           end.not_to change(QcResult, :count)
         end
       end
@@ -125,12 +125,12 @@ RSpec.describe '/qc_receptions' do
 
         it 'does not create a new QcReception' do
           expect do
-            post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcReception, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_receptions' do
-          post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "qc_results_list - can't be blank"
@@ -152,12 +152,12 @@ RSpec.describe '/qc_receptions' do
 
         it 'does not create a new QcReception' do
           expect do
-            post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcReception, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_receptions' do
-          post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "qc_results_list - can't be blank"
@@ -179,13 +179,13 @@ RSpec.describe '/qc_receptions' do
 
         it 'does not create a new QcReception' do
           expect do
-            post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcReception, :count)
         end
 
         it 'renders a JSON response with errors for the qc_results_list' do
           error_message = error_config['attributes']['qc_results_list']['empty_array']
-          post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['title']).to eq error_message
@@ -206,12 +206,12 @@ RSpec.describe '/qc_receptions' do
 
         it 'does not create a new QcReception' do
           expect do
-            post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcReception, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_receptions' do
-          post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "source - can't be blank"
@@ -233,12 +233,12 @@ RSpec.describe '/qc_receptions' do
 
         it 'does not create a new QcReception' do
           expect do
-            post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcReception, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_results_list' do
-          post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "source - can't be blank"
@@ -252,12 +252,12 @@ RSpec.describe '/qc_receptions' do
 
         it 'does not create a new QcReception' do
           expect do
-            post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcReception, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_receptions' do
-          post v1_qc_receptions_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_receptions_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:bad_request)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq 'The required parameter, data, is missing.'

--- a/spec/requests/v1/qc_results_uploads_spec.rb
+++ b/spec/requests/v1/qc_results_uploads_spec.rb
@@ -33,42 +33,42 @@ RSpec.describe '/qc_results_uploads' do
       end
 
       it 'returns a created status' do
-        post v1_qc_results_uploads_url, params: body, headers: json_api_headers
+        post v1_qc_results_uploads_url, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a new QcResultsUpload' do
         expect do
-          post v1_qc_results_uploads_url, params: body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: body, headers: auth_json_api_headers
         end.to change(QcResultsUpload, :count).by(1)
       end
 
       it 'creates a new QcResultsUpload with the given csv_data' do
-        post v1_qc_results_uploads_url, params: body, headers: json_api_headers
+        post v1_qc_results_uploads_url, params: body, headers: auth_json_api_headers
         expect(QcResultsUpload.last.csv_data).to eq csv
       end
 
       it 'creates the relevant QC entities' do
         expect do
-          post v1_qc_results_uploads_url, params: body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: body, headers: auth_json_api_headers
         end.to change(QcDecision, :count).by(2)
 
         expect do
-          post v1_qc_results_uploads_url, params: body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: body, headers: auth_json_api_headers
         end.to change(QcResult, :count).by(20)
 
         expect do
-          post v1_qc_results_uploads_url, params: body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: body, headers: auth_json_api_headers
         end.to change(QcDecisionResult, :count).by(18)
       end
 
       it 'sends the messages' do
         expect(Broker::Handle).to receive(:publish).exactly(18).times
-        post v1_qc_results_uploads_url, params: body, headers: json_api_headers
+        post v1_qc_results_uploads_url, params: body, headers: auth_json_api_headers
       end
 
       it 'renders a JSON response with the new qc_results_upload' do
-        post v1_qc_results_uploads_url, params: body, headers: json_api_headers
+        post v1_qc_results_uploads_url, params: body, headers: auth_json_api_headers
         expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
       end
     end
@@ -88,12 +88,12 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does not create a new QcResultsUpload' do
           expect do
-            post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcResultsUpload, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "csv_data - can't be blank"
@@ -115,12 +115,12 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does not create a new QcResultsUpload' do
           expect do
-            post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcResultsUpload, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "csv_data - can't be blank"
@@ -144,12 +144,12 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does not create a new QcResultsUpload' do
           expect do
-            post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcResultsUpload, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "used_by - can't be blank"
@@ -171,12 +171,12 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does not create a new QcResultsUpload' do
           expect do
-            post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcResultsUpload, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq "used_by - can't be blank"
@@ -190,12 +190,12 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does not create a new QcResultsUpload' do
           expect do
-            post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcResultsUpload, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:bad_request)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq 'The required parameter, data, is missing.'
@@ -221,12 +221,12 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does not create a new QcResultsUpload' do
           expect do
-            post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcResultsUpload, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq 'csv_data - Missing header row'
@@ -254,13 +254,13 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does create a new QcResultsUpload' do
           expect do
-            post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcResultsUpload, :count)
         end
 
         # There should always be a LR Decision, throw a 500 if not
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['title']).to eq 'Missing required headers: Tissue Tube ID'
@@ -288,12 +288,12 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does not create a new QcResultsUpload' do
           expect do
-            post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           end.not_to change(QcResultsUpload, :count)
         end
 
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: invalid_body, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: invalid_body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.content_type).to match(a_string_including('application/vnd.api+json'))
           expect(JSON.parse(response.parsed_body)['errors'][0]['detail']).to eq 'csv_data - Missing data rows'
@@ -321,25 +321,25 @@ RSpec.describe '/qc_results_uploads' do
 
         it 'does creates a new QcResultsUpload, but ignores the missing row' do
           expect do
-            post v1_qc_results_uploads_url, params: missing_row, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: missing_row, headers: auth_json_api_headers
           end.to change(QcResultsUpload, :count).by(1)
 
           expect do
-            post v1_qc_results_uploads_url, params: missing_row, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: missing_row, headers: auth_json_api_headers
           end.not_to change(QcDecision, :count)
 
           expect do
-            post v1_qc_results_uploads_url, params: missing_row, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: missing_row, headers: auth_json_api_headers
           end.not_to change(QcResult, :count)
 
           expect do
-            post v1_qc_results_uploads_url, params: missing_row, headers: json_api_headers
+            post v1_qc_results_uploads_url, params: missing_row, headers: auth_json_api_headers
           end.not_to change(QcDecisionResult, :count)
         end
 
         # There should always be a LR Decision, throw a 500 if not
         it 'renders a JSON response with errors for the new qc_results_upload' do
-          post v1_qc_results_uploads_url, params: missing_row, headers: json_api_headers
+          post v1_qc_results_uploads_url, params: missing_row, headers: auth_json_api_headers
           expect(response).to have_http_status(:created)
         end
       end

--- a/spec/requests/v1/reception_spec.rb
+++ b/spec/requests/v1/reception_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe 'ReceptionsController' do
       end
 
       it 'has a created status' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
       end
 
       it 'publishes a message' do
         allow(Messages).to receive(:publish).and_call_original
         expect(Messages).to receive(:publish).twice
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(Broker::Handle.test_received_messages.length).to eq(2)
         expect(Broker::Handle.test_received_messages[0].include?('priority_level')).to be true
         assert match_json?(Broker::Handle.test_received_messages[0],
@@ -127,12 +127,12 @@ RSpec.describe 'ReceptionsController' do
       end
 
       it 'has a created status' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
       end
 
       it 'does not publish a message' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(Broker::Handle.test_received_messages.length).to eq(0)
       end
     end
@@ -189,10 +189,10 @@ RSpec.describe 'ReceptionsController' do
       end
 
       it 'rejects the request' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
 
-        post v1_receptions_path, params: changed_body, headers: json_api_headers
+        post v1_receptions_path, params: changed_body, headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content), response.body
       end
     end
@@ -252,9 +252,9 @@ RSpec.describe 'ReceptionsController' do
       end
 
       it 'can accept an update on labware' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
-        post v1_receptions_path, params: updated_body, headers: json_api_headers
+        post v1_receptions_path, params: updated_body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
       end
     end
@@ -322,9 +322,9 @@ RSpec.describe 'ReceptionsController' do
       end
 
       it 'can accept an update on labware with duplicates' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
-        post v1_receptions_path, params: updated_body, headers: json_api_headers
+        post v1_receptions_path, params: updated_body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
 
         json = ActiveSupport::JSON.decode(response.body)
@@ -410,12 +410,12 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a created status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created), response.body
         end
 
         it 'creates the correct data' do
-          expect { post v1_receptions_path, params: body, headers: json_api_headers }
+          expect { post v1_receptions_path, params: body, headers: auth_json_api_headers }
             .to change(Ont::Pool, :count)
             .from(0)
             .to(1)
@@ -494,7 +494,7 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('pool/concentration - must be greater than or equal to 0')
         end
@@ -531,7 +531,7 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('pool/libraries - can\'t be blank')
         end
@@ -592,7 +592,7 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('pool/tags - must be present on all libraries')
         end
@@ -653,7 +653,7 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include('requests/1/library_type - is not a recognised library type')
         end
@@ -685,12 +685,12 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'generates a valid json-api error response' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           pointer = json.dig('errors', 0, 'source', 'pointer')
           expect(pointer).to eq('/data/attributes/source')
         end
@@ -720,12 +720,12 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'generates a valid json-api error response' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           pointer = json.dig('errors', 0, 'source', 'pointer')
           expect(pointer).to eq('/data/attributes/requests/0/library_type')
         end
@@ -755,12 +755,12 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a unprocessable_content status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'generates a valid json-api error response' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           pointers = json.fetch('errors').map do |error|
             error.dig('source', 'pointer')
           end
@@ -783,7 +783,7 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'has a bad_request status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:bad_request)
         end
       end
@@ -818,7 +818,7 @@ RSpec.describe 'ReceptionsController' do
 
         it 'has a bad_request status and correct errors' do
           create(:plate_with_wells_and_requests, barcode: 'NT1', pipeline: 'pacbio')
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
           expect(json['errors'][0]['detail']).to eq('requests - there are no new samples to import')
         end
@@ -858,14 +858,14 @@ RSpec.describe 'ReceptionsController' do
       end
 
       it 'has a created status' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
       end
 
       it 'publishes a message' do
         allow(Messages).to receive(:publish).and_call_original
         expect(Messages).to receive(:publish).twice
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(Broker::Handle.test_received_messages.length).to eq(2)
         expect(Broker::Handle.test_received_messages[0].include?('priority_level')).to be true
         assert match_json?(Broker::Handle.test_received_messages[0],
@@ -931,12 +931,12 @@ RSpec.describe 'ReceptionsController' do
       end
 
       it 'has a created status' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created), response.body
       end
 
       it 'does not publish a message' do
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(Broker::Handle.test_received_messages.length).to eq(0)
       end
     end
@@ -981,7 +981,7 @@ RSpec.describe 'ReceptionsController' do
       it 'has a unprocessable_content status' do
         # This errors because of a type mismatch when attempting to create the pool as its trying to
         # put PacBio libraries into an ONT pool
-        post v1_receptions_path, params: body, headers: json_api_headers
+        post v1_receptions_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content)
         expect(json['errors'][0]['detail']).to eq('pool/libraries - can\'t be blank')
       end
@@ -1018,12 +1018,12 @@ RSpec.describe 'ReceptionsController' do
         let(:library) { { volume: 1, concentration: 2, insert_size: 3, template_prep_kit_box_barcode: 'barcode' } }
 
         it 'has a created status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created), response.body
         end
 
         it 'creates the correct library for the request' do
-          expect { post v1_receptions_path, params: body, headers: json_api_headers }
+          expect { post v1_receptions_path, params: body, headers: auth_json_api_headers }
             .to change(Pacbio::Library, :count)
             .from(0)
             .to(1)
@@ -1036,7 +1036,7 @@ RSpec.describe 'ReceptionsController' do
         end
 
         it 'creates the correct request associated with the library' do
-          expect { post v1_receptions_path, params: body, headers: json_api_headers }
+          expect { post v1_receptions_path, params: body, headers: auth_json_api_headers }
             .to change(Request, :count)
             .from(0)
             .to(1)
@@ -1054,12 +1054,12 @@ RSpec.describe 'ReceptionsController' do
         let(:library) { { volume: 1, concentration: 2, template_prep_kit_box_barcode: 'barcode' } }
 
         it 'has a created status' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:created), response.body
         end
 
         it 'creates the correct library for the request' do
-          expect { post v1_receptions_path, params: body, headers: json_api_headers }
+          expect { post v1_receptions_path, params: body, headers: auth_json_api_headers }
             .to change(Pacbio::Library, :count)
             .from(0)
             .to(1)
@@ -1076,7 +1076,7 @@ RSpec.describe 'ReceptionsController' do
         let(:library) { { concentration: 2, template_prep_kit_box_barcode: 'barcode' } }
 
         it 'responds with correct result' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
           expect(response.body).to include('requests/0/requestable - is invalid')
         end
@@ -1086,7 +1086,7 @@ RSpec.describe 'ReceptionsController' do
         let(:library) { { volume: 1, template_prep_kit_box_barcode: 'barcode' } }
 
         it 'responds with correct result' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
           expect(response.body).to include('requests/0/requestable - is invalid')
         end
@@ -1096,7 +1096,7 @@ RSpec.describe 'ReceptionsController' do
         let(:library) { { volume: 1, concentration: 2 } }
 
         it 'responds with correct result' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
           expect(response.body).to include('requests/0/requestable - is invalid')
         end
@@ -1106,7 +1106,7 @@ RSpec.describe 'ReceptionsController' do
         let(:library) { {} }
 
         it 'responds with correct result' do
-          post v1_receptions_path, params: body, headers: json_api_headers
+          post v1_receptions_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content), response.body
           expect(response.body).to include('requests/0/requestable - is invalid')
         end

--- a/spec/requests/v1/tag_sets_spec.rb
+++ b/spec/requests/v1/tag_sets_spec.rb
@@ -58,18 +58,18 @@ RSpec.describe 'TagSetsController' do
       end
 
       it 'has a created status' do
-        post v1_tag_sets_path, params: body, headers: json_api_headers
+        post v1_tag_sets_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a tag set' do
         expect do
-          post v1_tag_sets_path, params: body, headers: json_api_headers
+          post v1_tag_sets_path, params: body, headers: auth_json_api_headers
         end.to change(TagSet, :count).by(1)
       end
 
       it 'creates a tag set with the correct attributes' do
-        post v1_tag_sets_path, params: body, headers: json_api_headers
+        post v1_tag_sets_path, params: body, headers: auth_json_api_headers
         tag_set = TagSet.first
         expect(tag_set.uuid).to be_present
       end
@@ -87,19 +87,19 @@ RSpec.describe 'TagSetsController' do
         end
 
         it 'can returns unprocessable entity status' do
-          post v1_tag_sets_path, params: body, headers: json_api_headers
+          post v1_tag_sets_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a tag set' do
           expect do
-            post v1_tag_sets_path, params: body, headers: json_api_headers
+            post v1_tag_sets_path, params: body, headers: auth_json_api_headers
           end.not_to change(TagSet, :count)
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
         it 'has an error message' do
-          post v1_tag_sets_path, params: body, headers: json_api_headers
+          post v1_tag_sets_path, params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['errors'][0]).to include('detail' => "name - can't be blank")
         end
@@ -123,18 +123,18 @@ RSpec.describe 'TagSetsController' do
         end
 
         it 'has a ok status' do
-          patch v1_tag_set_path(tag_set), params: body, headers: json_api_headers
+          patch v1_tag_set_path(tag_set), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:ok)
         end
 
         it 'updates a tag set' do
-          patch v1_tag_set_path(tag_set), params: body, headers: json_api_headers
+          patch v1_tag_set_path(tag_set), params: body, headers: auth_json_api_headers
           tag_set.reload
           expect(tag_set.name).to eq 'Test Tag Set update context'
         end
 
         it 'returns the correct attributes' do
-          patch v1_tag_set_path(tag_set), params: body, headers: json_api_headers
+          patch v1_tag_set_path(tag_set), params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['data']['id']).to eq tag_set.id.to_s
         end
@@ -155,13 +155,13 @@ RSpec.describe 'TagSetsController' do
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
         it 'has a ok unprocessable_content' do
-          patch v1_tag_set_path(123), params: body, headers: json_api_headers
+          patch v1_tag_set_path(123), params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:not_found)
         end
 
         # the failure responses are slightly different to in tags_spec because we are using the default controller
         it 'has an error message' do
-          patch v1_tag_set_path(123), params: body, headers: json_api_headers
+          patch v1_tag_set_path(123), params: body, headers: auth_json_api_headers
           json = ActiveSupport::JSON.decode(response.body)
           expect(json['errors'][0]['detail']).to eq('The record identified by 123 could not be found.')
         end

--- a/spec/requests/v1/tags_spec.rb
+++ b/spec/requests/v1/tags_spec.rb
@@ -39,18 +39,18 @@ RSpec.describe 'TagsController' do
       end
 
       it 'has a created status' do
-        post v1_tags_path, params: body, headers: json_api_headers
+        post v1_tags_path, params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:created)
       end
 
       it 'creates a tag' do
         expect do
-          post v1_tags_path, params: body, headers: json_api_headers
+          post v1_tags_path, params: body, headers: auth_json_api_headers
         end.to change(Tag, :count).by(1)
       end
 
       it 'creates a tag with the correct attributes' do
-        post v1_tags_path, params: body, headers: json_api_headers
+        post v1_tags_path, params: body, headers: auth_json_api_headers
         tag = Tag.first
         expect(tag.oligo).to be_present
       end
@@ -68,18 +68,18 @@ RSpec.describe 'TagsController' do
         end
 
         it 'can returns unprocessable entity status' do
-          post v1_tags_path, params: body, headers: json_api_headers
+          post v1_tags_path, params: body, headers: auth_json_api_headers
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'cannot create a tag' do
           expect do
-            post v1_tags_path, params: body, headers: json_api_headers
+            post v1_tags_path, params: body, headers: auth_json_api_headers
           end.not_to change(Tag, :count)
         end
 
         it 'has an error message' do
-          post v1_tags_path, params: body, headers: json_api_headers
+          post v1_tags_path, params: body, headers: auth_json_api_headers
           expect(response.parsed_body['data']).to include('errors' => {
                                                             'group_id' => ["can't be blank"], 'oligo' => ["can't be blank"], 'tag_set' => ['must exist']
                                                           })
@@ -105,18 +105,18 @@ RSpec.describe 'TagsController' do
       end
 
       it 'has a ok status' do
-        patch v1_tag_path(tag), params: body, headers: json_api_headers
+        patch v1_tag_path(tag), params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:ok)
       end
 
       it 'updates a tag' do
-        patch v1_tag_path(tag), params: body, headers: json_api_headers
+        patch v1_tag_path(tag), params: body, headers: auth_json_api_headers
         tag.reload
         expect(tag.oligo).to eq 'ACDC'
       end
 
       it 'returns the correct attributes' do
-        patch v1_tag_path(tag), params: body, headers: json_api_headers
+        patch v1_tag_path(tag), params: body, headers: auth_json_api_headers
         json = ActiveSupport::JSON.decode(response.body)
         expect(json['data']['id']).to eq tag.id.to_s
       end
@@ -136,12 +136,12 @@ RSpec.describe 'TagsController' do
       end
 
       it 'has a ok unprocessable_content' do
-        patch v1_tag_path(123), params: body, headers: json_api_headers
+        patch v1_tag_path(123), params: body, headers: auth_json_api_headers
         expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'has an error message' do
-        patch v1_tag_path(123), params: body, headers: json_api_headers
+        patch v1_tag_path(123), params: body, headers: auth_json_api_headers
         expect(response.parsed_body['data']).to include('errors' => %(Couldn't find Tag with 'id'="123"))
       end
     end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -8,6 +8,17 @@ module RequestHelpers
     }
   end
 
+  def auth_headers(api_application = create(:api_application))
+    issued = api_application.rotate_api_key!
+    {
+      'X-Traction-Client-Id' => issued[:plaintext_key]
+    }
+  end
+
+  def auth_json_api_headers(api_application = create(:api_application))
+    json_api_headers.merge(auth_headers(api_application))
+  end
+
   #
   # Returns a hash representing the decoded json response
   #


### PR DESCRIPTION
Removes stale feature flags from the code base

#### Changes proposed in this pull request

- y25_662_enable_request_authentication [1ba6439](https://github.com/sanger/traction-service/pull/1870/commits/1ba64392387809c69c6d7fcc627b0cdb1e01d88a)
- y25_662_reject_unauthenticated_requests [85cd964](https://github.com/sanger/traction-service/pull/1870/commits/85cd964a40bcbd93d86df04981285f56d8f18bab)
    - This was slightly tricker as it means now that all of our non-GET specs require an API key to get past auth hence the mass changes from json_api_headers to -> auth_json_api_headers. This felt like a better solution that stubbing the auth module. 
