### PR TITLE
Y26-204 - Remove MySQL 8.0 references

### DIFF
--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql-version: ["8.0", "8.4"]
+        mysql-version: ["8.4"]
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql


### PR DESCRIPTION
Relates to https://github.com/sanger/General-Backlog-Items/issues/738

#### Changes proposed in this pull request

- Removes mysql 8.0 from CI matrices 
